### PR TITLE
Fix cross compilation

### DIFF
--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -35,3 +35,4 @@ tracing = { version = "0.1.37"}
 tracing-subscriber = {version = "0.3.16"}
 quinn = "0.10.0"
 rustls = { version = "0.21.1", features = ["dangerous_configuration", "quic"] }
+openssl = { version = "0.10.*", features = ["vendored"] }


### PR DESCRIPTION
When cross compiling it is required to have openssl MUSL
library to compile against. There are 2 ways of fixing it,
this commit introduces easy one, which is using vendored
openssl. Harder way is to create custom docker image with
libssl-dev.

See https://github.com/cross-rs/cross/wiki/Recipes#openssl

