### PR TITLE
Fix release via github actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,13 +10,10 @@
 
 name: Rust
 on:
-  push:
-    branches:
-      - master
-      - test_release_branch
   pull_request:
     branches:
       - master
+    types: [opened, synchronize, reopened, closed]
 env:
   CRATE_NAME: iggy
   GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
It seems like github action needs to have
specified pull request workflow. This commit
sets workflow to act on "closed" and all default
actions.