### PR TITLE
Print build metadata during startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,6 +1351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1944,6 +1953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,6 +2096,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2216,6 +2240,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "vergen",
 ]
 
 [[package]]
@@ -2358,9 +2383,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.29.9"
+version = "0.29.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d0e9cc2273cc8d31377bdd638d72e3ac3e5607b18621062b169d02787f1bab"
+checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -2437,6 +2462,8 @@ checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",
@@ -2834,6 +2861,18 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc5ad0d9d26b2c49a5ab7da76c3e79d3ee37e7821799f8223fcb8f2f391a2e7"
+dependencies = [
+ "anyhow",
+ "rustc_version",
+ "rustversion",
+ "time",
+]
 
 [[package]]
 name = "version_check"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "server"
-version = "0.0.3"
+version = "0.0.4"
 edition = "2021"
+build = "src/build.rs"
 
 [dependencies]
 iggy = { path = "../iggy" }
@@ -43,6 +44,15 @@ rustls = { version = "0.21.1", features = ["dangerous_configuration", "quic"] }
 assert_cmd = "2.0.12"
 predicates = "3.0.3"
 libc = "0.2.147"
+
+[build-dependencies]
+vergen = { version = "8.2.4", features = [
+    "build",
+    "cargo",
+    "git",
+    "gitcl",
+    "rustc",
+] }
 
 [[bin]]
 name = "iggy-server"

--- a/server/src/build.rs
+++ b/server/src/build.rs
@@ -1,0 +1,12 @@
+use std::error::{self};
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn error::Error>> {
+    EmitBuilder::builder()
+        .all_build()
+        .all_cargo()
+        .all_git()
+        .all_rustc()
+        .emit()?;
+    Ok(())
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -36,6 +36,14 @@ async fn main() -> Result<(), ServerError> {
     let standard_font = FIGfont::standard().unwrap();
     let figure = standard_font.convert("Iggy Server");
     println!("{}", figure.unwrap());
+    info!(
+        "Version: {}, hash: {}, built at: {} using rust version: {} for target: {}",
+        env!("CARGO_PKG_VERSION"),
+        env!("VERGEN_GIT_DESCRIBE"),
+        env!("VERGEN_BUILD_TIMESTAMP"),
+        env!("VERGEN_RUSTC_SEMVER"),
+        env!("VERGEN_CARGO_TARGET_TRIPLE")
+    );
     let config_provider = config_provider::resolve(&args.config_provider)?;
     let config = ServerConfig::load(config_provider.as_ref()).await?;
     let mut system = System::new(config.system.clone(), None);


### PR DESCRIPTION
Added printing of relevant build metadata during
startup of iggy-server. This should help debug
problems in the future.