### PR TITLE
Add topic related commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1157,7 @@ dependencies = [
  "async-trait",
  "clap",
  "comfy-table",
+ "humantime",
  "iggy",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cmd"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -16,6 +16,7 @@ thiserror = "1.0.48"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17" }
 tracing-appender = "0.2.2"
+humantime = "2.1.0"
 
 [[bin]]
 name = "iggy"

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cmd"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/common.rs
+++ b/cmd/src/args/common.rs
@@ -1,0 +1,7 @@
+use clap::ValueEnum;
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub(crate) enum ListMode {
+    Table,
+    List,
+}

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -1,9 +1,9 @@
 pub(crate) mod common;
+pub(crate) mod stream;
 pub(crate) mod topic;
 
-use crate::args::common::ListMode;
-use crate::args::topic::TopicAction;
-use clap::{Args, Parser, Subcommand};
+use crate::args::{stream::StreamAction, topic::TopicAction};
+use clap::{Parser, Subcommand};
 use iggy::args::Args as IggyArgs;
 use std::path::PathBuf;
 
@@ -33,25 +33,4 @@ pub(crate) enum Command {
     /// topic operations
     #[clap(subcommand)]
     Topic(TopicAction),
-}
-
-#[derive(Debug, Subcommand)]
-pub(crate) enum StreamAction {
-    /// Create stream with given ID and name
-    Create { id: u32, name: String },
-    /// Delete stream with given ID
-    Delete { id: u32 },
-    /// Update stream name for given stream ID
-    Update { id: u32, name: String },
-    /// Get details of a single stream with given ID
-    Get { id: u32 },
-    /// List all streams
-    List(StreamListArgs),
-}
-
-#[derive(Debug, Args)]
-pub(crate) struct StreamListArgs {
-    /// List mode (table or list)
-    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
-    pub(crate) list_mode: ListMode,
 }

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -1,8 +1,11 @@
-use std::path::PathBuf;
+pub(crate) mod common;
+pub(crate) mod topic;
 
-use clap::{Args, Parser, Subcommand, ValueEnum};
-
+use crate::args::common::ListMode;
+use crate::args::topic::TopicAction;
+use clap::{Args, Parser, Subcommand};
 use iggy::args::Args as IggyArgs;
+use std::path::PathBuf;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -27,6 +30,9 @@ pub(crate) enum Command {
     /// stream operations
     #[clap(subcommand)]
     Stream(StreamAction),
+    /// topic operations
+    #[clap(subcommand)]
+    Topic(TopicAction),
 }
 
 #[derive(Debug, Subcommand)]
@@ -40,18 +46,12 @@ pub(crate) enum StreamAction {
     /// Get details of a single stream with given ID
     Get { id: u32 },
     /// List all streams
-    List(ListArgs),
+    List(StreamListArgs),
 }
 
 #[derive(Debug, Args)]
-pub(crate) struct ListArgs {
+pub(crate) struct StreamListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
     pub(crate) list_mode: ListMode,
-}
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-pub(crate) enum ListMode {
-    Table,
-    List,
 }

--- a/cmd/src/args/stream.rs
+++ b/cmd/src/args/stream.rs
@@ -1,0 +1,51 @@
+use crate::args::common::ListMode;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum StreamAction {
+    /// Create stream with given ID and name
+    Create(StreamCreateArgs),
+    /// Delete stream with given ID
+    Delete(StreamDeleteArgs),
+    /// Update stream name for given stream ID
+    Update(StreamUpdateArgs),
+    /// Get details of a single stream with given ID
+    Get(StreamGetArgs),
+    /// List all streams
+    List(StreamListArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StreamCreateArgs {
+    /// Stream ID to create topic
+    pub(crate) stream_id: u32,
+    /// Name of the stream
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StreamDeleteArgs {
+    /// Stream ID to delete
+    pub(crate) stream_id: u32,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StreamUpdateArgs {
+    /// Stream ID to update
+    pub(crate) stream_id: u32,
+    /// New name for the stream
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StreamGetArgs {
+    /// Stream ID to get
+    pub(crate) stream_id: u32,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct StreamListArgs {
+    /// List mode (table or list)
+    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
+    pub(crate) list_mode: ListMode,
+}

--- a/cmd/src/args/topic.rs
+++ b/cmd/src/args/topic.rs
@@ -1,5 +1,12 @@
 use crate::args::common::ListMode;
 use clap::{Args, Subcommand};
+use humantime::format_duration;
+use humantime::Duration as HumanDuration;
+use std::fmt::Display;
+use std::iter::Sum;
+use std::ops::Add;
+use std::time::Duration;
+use std::{convert::From, str::FromStr};
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum TopicAction {
@@ -26,8 +33,10 @@ pub(crate) struct TopicCreateArgs {
     pub(crate) partitions_count: u32,
     /// Name of the topic
     pub(crate) name: String,
-    /// Message expiry time in seconds
-    pub(crate) message_expiry: Option<u32>,
+    /// Message expiry time in human readable format like 15days 2min 2s
+    /// ("none" or skipping parameter disables message expiry functionality in topic)
+    #[arg(value_parser = clap::value_parser!(MessageExpiry))]
+    pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
 }
 
 #[derive(Debug, Args)]
@@ -46,9 +55,89 @@ pub(crate) struct TopicUpdateArgs {
     pub(crate) topic_id: u32,
     /// New name for the topic
     pub(crate) name: String,
-    /// New message expiry time in seconds
-    /// (skipping parameter causes removal of expiry parameter in topic)
-    pub(crate) message_expiry: Option<u32>,
+    /// New message expiry time in human readable format like 15days 2min 2s
+    /// ("none" or skipping parameter causes removal of expiry parameter in topic)
+    #[arg(value_parser = clap::value_parser!(MessageExpiry))]
+    pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) enum MessageExpiry {
+    /// Set message expiry time to given value
+    ExpireDuration(Duration),
+    /// Never expire messages
+    NeverExpire,
+}
+
+impl MessageExpiry {
+    pub(crate) fn new(values: Option<Vec<MessageExpiry>>) -> Option<Self> {
+        values.map(|items| items.iter().cloned().sum())
+    }
+}
+
+impl From<&MessageExpiry> for Option<u32> {
+    fn from(value: &MessageExpiry) -> Self {
+        match value {
+            MessageExpiry::ExpireDuration(value) => Some(value.as_secs() as u32),
+            MessageExpiry::NeverExpire => None,
+        }
+    }
+}
+
+impl Display for MessageExpiry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NeverExpire => write!(f, "none"),
+            Self::ExpireDuration(value) => write!(f, "{}", format_duration(*value)),
+        }
+    }
+}
+
+impl Sum for MessageExpiry {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        iter.into_iter()
+            .fold(MessageExpiry::NeverExpire, |acc, x| acc + x)
+    }
+}
+
+impl Add for MessageExpiry {
+    type Output = MessageExpiry;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match (self, rhs) {
+            (MessageExpiry::NeverExpire, MessageExpiry::NeverExpire) => MessageExpiry::NeverExpire,
+            (MessageExpiry::NeverExpire, message_expiry) => message_expiry,
+            (message_expiry, MessageExpiry::NeverExpire) => message_expiry,
+            (
+                MessageExpiry::ExpireDuration(lhs_duration),
+                MessageExpiry::ExpireDuration(rhs_duration),
+            ) => MessageExpiry::ExpireDuration(lhs_duration + rhs_duration),
+        }
+    }
+}
+
+impl FromStr for MessageExpiry {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let result = match s {
+            "none" => MessageExpiry::NeverExpire,
+            value => {
+                let duration = value.parse::<HumanDuration>().map_err(|e| format!("{e}"))?;
+
+                if duration.as_secs() > u32::MAX as u64 {
+                    return Err(format!(
+                        "Value too big for message expiry time, maximum value is {}",
+                        format_duration(Duration::from_secs(u32::MAX as u64))
+                    ));
+                }
+
+                MessageExpiry::ExpireDuration(Duration::from_secs(duration.as_secs()))
+            }
+        };
+
+        Ok(result)
+    }
 }
 
 #[derive(Debug, Args)]

--- a/cmd/src/args/topic.rs
+++ b/cmd/src/args/topic.rs
@@ -1,0 +1,70 @@
+use crate::args::common::ListMode;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum TopicAction {
+    /// Create topic with given ID, name, number of partitions
+    /// and expiry time for given stream ID
+    Create(TopicCreateArgs),
+    /// Delete topic with given ID in given stream ID
+    Delete(TopicDeleteArgs),
+    /// Update topic name an message expiry time for given topic ID in given stream ID
+    Update(TopicUpdateArgs),
+    /// Get topic detail for given topic ID and stream ID
+    Get(TopicGetArgs),
+    /// List all topics in given stream ID
+    List(TopicListArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TopicCreateArgs {
+    /// Stream ID to create topic
+    pub(crate) stream_id: u32,
+    /// Topic ID to create
+    pub(crate) topic_id: u32,
+    /// Number of partitions inside the topic
+    pub(crate) partitions_count: u32,
+    /// Name of the topic
+    pub(crate) name: String,
+    /// Message expiry time in seconds
+    pub(crate) message_expiry: Option<u32>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TopicDeleteArgs {
+    /// Stream ID to delete topic
+    pub(crate) stream_id: u32,
+    /// Topic ID to delete
+    pub(crate) topic_id: u32,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TopicUpdateArgs {
+    /// Stream ID to update topic
+    pub(crate) stream_id: u32,
+    /// Topic ID to update
+    pub(crate) topic_id: u32,
+    /// New name for the topic
+    pub(crate) name: String,
+    /// New message expiry time in seconds
+    /// (skipping parameter causes removal of expiry parameter in topic)
+    pub(crate) message_expiry: Option<u32>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TopicGetArgs {
+    /// Stream ID to get topic
+    pub(crate) stream_id: u32,
+    /// Topic ID to get
+    pub(crate) topic_id: u32,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct TopicListArgs {
+    /// Stream ID to list topics
+    pub(crate) stream_id: u32,
+
+    /// List mode (table or list)
+    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
+    pub(crate) list_mode: ListMode,
+}

--- a/cmd/src/cmd/mod.rs
+++ b/cmd/src/cmd/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod stream;
+pub(crate) mod topic;

--- a/cmd/src/cmd/stream/list.rs
+++ b/cmd/src/cmd/stream/list.rs
@@ -1,4 +1,4 @@
-use crate::args::ListMode;
+use crate::args::common::ListMode;
 use crate::cli::CliCommand;
 
 use anyhow::{Context, Error, Result};

--- a/cmd/src/cmd/stream/list.rs
+++ b/cmd/src/cmd/stream/list.rs
@@ -45,7 +45,9 @@ impl CliCommand for StreamList {
             ListMode::Table => {
                 let mut table = Table::new();
 
-                table.set_header(vec!["ID", "Created", "Name", "Size", "Messages", "Topics"]);
+                table.set_header(vec![
+                    "ID", "Created", "Name", "Size (B)", "Messages", "Topics",
+                ]);
 
                 streams.iter().for_each(|stream| {
                     table.add_row(vec![

--- a/cmd/src/cmd/topic/create.rs
+++ b/cmd/src/cmd/topic/create.rs
@@ -1,0 +1,82 @@
+use crate::cli::CliCommand;
+
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::topics::create_topic::CreateTopic;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct TopicCreate {
+    stream_id: u32,
+    topic_id: u32,
+    partitions_count: u32,
+    message_expiry: Option<u32>,
+    name: String,
+}
+
+impl TopicCreate {
+    pub(crate) fn new(
+        stream_id: u32,
+        topic_id: u32,
+        partitions_count: u32,
+        message_expiry: Option<u32>,
+        name: String,
+    ) -> Self {
+        Self {
+            stream_id,
+            topic_id,
+            partitions_count,
+            message_expiry,
+            name,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for TopicCreate {
+    fn explain(&self) -> String {
+        let expiry_text = match self.message_expiry {
+            Some(value) => format!("message expire time: {}", value),
+            None => String::from("without message expire time"),
+        };
+        format!(
+            "create topic with ID: {}, name: {}, partitions count: {} and {} in stream with ID: {}",
+            self.topic_id, self.name, self.partitions_count, expiry_text, self.stream_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
+        client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id)
+                    .expect("Expected numeric identifier"),
+                topic_id: self.topic_id,
+                partitions_count: self.partitions_count,
+                message_expiry: self.message_expiry,
+                name: self.name.clone(),
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem creating topic (ID: {}, name: {}, partitions count: {}) in stream with ID: {}",
+                    self.topic_id, self.name, self.partitions_count, self.stream_id
+                )
+            })?;
+
+        info!(
+            "Topic with ID: {}, name: {}, partitions count: {} and {} created in stream with ID: {}",
+            self.topic_id,
+            self.name,
+            self.partitions_count,
+            match self.message_expiry {
+                Some(value) => format!("message expire time: {}", value),
+                None => String::from("without message expire time"),
+            },
+            self.stream_id,
+        );
+
+        Ok(())
+    }
+}

--- a/cmd/src/cmd/topic/create.rs
+++ b/cmd/src/cmd/topic/create.rs
@@ -1,3 +1,4 @@
+use crate::args::topic::MessageExpiry;
 use crate::cli::CliCommand;
 
 use anyhow::{Context, Error, Result};
@@ -12,8 +13,8 @@ pub(crate) struct TopicCreate {
     stream_id: u32,
     topic_id: u32,
     partitions_count: u32,
-    message_expiry: Option<u32>,
     name: String,
+    message_expiry: Option<MessageExpiry>,
 }
 
 impl TopicCreate {
@@ -21,15 +22,15 @@ impl TopicCreate {
         stream_id: u32,
         topic_id: u32,
         partitions_count: u32,
-        message_expiry: Option<u32>,
         name: String,
+        message_expiry: Option<MessageExpiry>,
     ) -> Self {
         Self {
             stream_id,
             topic_id,
             partitions_count,
-            message_expiry,
             name,
+            message_expiry,
         }
     }
 }
@@ -37,7 +38,7 @@ impl TopicCreate {
 #[async_trait]
 impl CliCommand for TopicCreate {
     fn explain(&self) -> String {
-        let expiry_text = match self.message_expiry {
+        let expiry_text = match &self.message_expiry {
             Some(value) => format!("message expire time: {}", value),
             None => String::from("without message expire time"),
         };
@@ -54,7 +55,10 @@ impl CliCommand for TopicCreate {
                     .expect("Expected numeric identifier"),
                 topic_id: self.topic_id,
                 partitions_count: self.partitions_count,
-                message_expiry: self.message_expiry,
+                message_expiry: match &self.message_expiry {
+                    None => None,
+                    Some(value) => value.into(),
+                },
                 name: self.name.clone(),
             })
             .await
@@ -70,7 +74,7 @@ impl CliCommand for TopicCreate {
             self.topic_id,
             self.name,
             self.partitions_count,
-            match self.message_expiry {
+            match &self.message_expiry {
                 Some(value) => format!("message expire time: {}", value),
                 None => String::from("without message expire time"),
             },

--- a/cmd/src/cmd/topic/delete.rs
+++ b/cmd/src/cmd/topic/delete.rs
@@ -1,0 +1,57 @@
+use crate::cli::CliCommand;
+
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::topics::delete_topic::DeleteTopic;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct TopicDelete {
+    stream_id: u32,
+    topic_id: u32,
+}
+
+impl TopicDelete {
+    pub(crate) fn new(stream_id: u32, topic_id: u32) -> Self {
+        Self {
+            stream_id,
+            topic_id,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for TopicDelete {
+    fn explain(&self) -> String {
+        format!(
+            "delete topic with ID: {} in stream with ID: {}",
+            self.topic_id, self.stream_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
+        client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id)
+                    .expect("Expected numeric identifier for stream_id"),
+                topic_id: Identifier::numeric(self.topic_id)
+                    .expect("Expected numeric identifier for topic_id"),
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem deleting topic with ID: {} in stream {}",
+                    self.topic_id, self.stream_id
+                )
+            })?;
+
+        info!(
+            "Topic with ID: {} in stream with ID: {} deleted",
+            self.topic_id, self.stream_id
+        );
+
+        Ok(())
+    }
+}

--- a/cmd/src/cmd/topic/get.rs
+++ b/cmd/src/cmd/topic/get.rs
@@ -1,0 +1,87 @@
+use crate::cli::CliCommand;
+
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use comfy_table::Table;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::topics::get_topic::GetTopic;
+use iggy::utils::timestamp::TimeStamp;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct TopicGet {
+    stream_id: u32,
+    topic_id: u32,
+}
+
+impl TopicGet {
+    pub(crate) fn new(stream_id: u32, topic_id: u32) -> Self {
+        Self {
+            stream_id,
+            topic_id,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for TopicGet {
+    fn explain(&self) -> String {
+        format!(
+            "get topic with ID: {} from stream with ID: {}",
+            self.topic_id, self.stream_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
+        let topic = client
+            .get_topic(&GetTopic {
+                stream_id: Identifier::numeric(self.stream_id)
+                    .expect("Expected numeric identifier for stream_id"),
+                topic_id: Identifier::numeric(self.topic_id)
+                    .expect("Expected numeric identifier for topic_id"),
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem getting topic with ID: {} in stream {}",
+                    self.topic_id, self.stream_id
+                )
+            })?;
+
+        let mut table = Table::new();
+
+        table.set_header(vec!["Property", "Value"]);
+        table.add_row(vec!["Topic id", format!("{}", topic.id).as_str()]);
+        table.add_row(vec![
+            "Created",
+            TimeStamp::from(topic.created_at)
+                .to_string("%Y-%m-%d %H:%M:%S")
+                .as_str(),
+        ]);
+        table.add_row(vec!["Topic name", topic.name.as_str()]);
+        table.add_row(vec!["Topic size", format!("{}", topic.size_bytes).as_str()]);
+        table.add_row(vec![
+            "Message expiry",
+            match topic.message_expiry {
+                Some(value) => format!("{}", value),
+                None => String::from("None"),
+            }
+            .as_str(),
+        ]);
+        table.add_row(vec![
+            "Topic message count",
+            format!("{}", topic.messages_count).as_str(),
+        ]);
+        table.add_row(vec![
+            "Partitions count",
+            format!("{}", topic.partitions_count).as_str(),
+        ]);
+
+        info!("{table}");
+
+        info!("{:?}", topic);
+
+        Ok(())
+    }
+}

--- a/cmd/src/cmd/topic/list.rs
+++ b/cmd/src/cmd/topic/list.rs
@@ -48,8 +48,8 @@ impl CliCommand for TopicList {
                     "ID",
                     "Created",
                     "Name",
-                    "Size",
-                    "Message Expiry",
+                    "Size (B)",
+                    "Message Expiry (s)",
                     "Messages Count",
                     "Partitions Count",
                 ]);

--- a/cmd/src/cmd/topic/list.rs
+++ b/cmd/src/cmd/topic/list.rs
@@ -1,0 +1,95 @@
+use crate::args::common::ListMode;
+use crate::cli::CliCommand;
+
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use comfy_table::Table;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::topics::get_topics::GetTopics;
+use iggy::utils::timestamp::TimeStamp;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct TopicList {
+    stream_id: u32,
+    list_mode: ListMode,
+}
+
+impl TopicList {
+    pub(crate) fn new(stream_id: u32, list_mode: ListMode) -> Self {
+        Self {
+            stream_id,
+            list_mode,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for TopicList {
+    fn explain(&self) -> String {
+        format!("get topics from stream with ID: {}", self.stream_id)
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
+        let topics = client
+            .get_topics(&GetTopics {
+                stream_id: Identifier::numeric(self.stream_id)
+                    .expect("Expected numeric identifier for stream_id"),
+            })
+            .await
+            .with_context(|| format!("Problem getting topics from stream {}", self.stream_id))?;
+
+        match self.list_mode {
+            ListMode::Table => {
+                let mut table = Table::new();
+
+                table.set_header(vec![
+                    "ID",
+                    "Created",
+                    "Name",
+                    "Size",
+                    "Message Expiry",
+                    "Messages Count",
+                    "Partitions Count",
+                ]);
+
+                topics.iter().for_each(|topic| {
+                    table.add_row(vec![
+                        format!("{}", topic.id),
+                        TimeStamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        topic.name.clone(),
+                        format!("{}", topic.size_bytes),
+                        match topic.message_expiry {
+                            Some(value) => format!("{}", value),
+                            None => String::from("None"),
+                        },
+                        format!("{}", topic.messages_count),
+                        format!("{}", topic.partitions_count),
+                    ]);
+                });
+
+                info!("{table}");
+            }
+            ListMode::List => {
+                topics.iter().for_each(|topic| {
+                    info!(
+                        "{}|{}|{}|{}|{}|{}|{}",
+                        topic.id,
+                        TimeStamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        topic.name,
+                        topic.size_bytes,
+                        match topic.message_expiry {
+                            Some(value) => format!("{}", value),
+                            None => String::from("None"),
+                        },
+                        topic.messages_count,
+                        topic.partitions_count
+                    );
+                });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/cmd/src/cmd/topic/mod.rs
+++ b/cmd/src/cmd/topic/mod.rs
@@ -1,0 +1,5 @@
+pub(crate) mod create;
+pub(crate) mod delete;
+pub(crate) mod get;
+pub(crate) mod list;
+pub(crate) mod update;

--- a/cmd/src/cmd/topic/update.rs
+++ b/cmd/src/cmd/topic/update.rs
@@ -1,0 +1,84 @@
+use crate::cli::CliCommand;
+
+use anyhow::{Context, Error, Result};
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::topics::update_topic::UpdateTopic;
+use tracing::info;
+
+#[derive(Debug)]
+pub(crate) struct TopicUpdate {
+    stream_id: u32,
+    topic_id: u32,
+    name: String,
+    message_expiry: Option<u32>,
+}
+
+impl TopicUpdate {
+    pub(crate) fn new(
+        stream_id: u32,
+        topic_id: u32,
+        name: String,
+        message_expiry: Option<u32>,
+    ) -> Self {
+        Self {
+            stream_id,
+            topic_id,
+            name,
+            message_expiry,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for TopicUpdate {
+    fn explain(&self) -> String {
+        let expiry_text = match self.message_expiry {
+            Some(value) => format!(" and message expire time: {}", value),
+            None => String::from(""),
+        };
+        format!(
+            "update topic with ID: {}, name: {}{} in stream with ID: {}",
+            self.topic_id, self.name, expiry_text, self.stream_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
+        client
+            .update_topic(&UpdateTopic {
+                stream_id: Identifier::numeric(self.stream_id)
+                    .expect("Expected numeric identifier for stream ID"),
+                topic_id: Identifier::numeric(self.topic_id)
+                    .expect("Expected numeric identifier for topic ID"),
+                message_expiry: self.message_expiry,
+                name: self.name.clone(),
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem updating topic (ID: {}, name: {}{}) in stream with ID: {}",
+                    self.topic_id,
+                    self.name,
+                    match self.message_expiry {
+                        Some(value) => format!(" and message expire time: {}", value),
+                        None => String::from(""),
+                    },
+                    self.stream_id
+                )
+            })?;
+
+        info!(
+            "Topic with ID: {} updated name: {}{} in stream with ID: {}",
+            self.topic_id,
+            self.name,
+            match self.message_expiry {
+                Some(value) => format!(" and message expire time: {}", value),
+                None => String::from(""),
+            },
+            self.stream_id,
+        );
+
+        Ok(())
+    }
+}

--- a/cmd/src/cmd/topic/update.rs
+++ b/cmd/src/cmd/topic/update.rs
@@ -1,3 +1,4 @@
+use crate::args::topic::MessageExpiry;
 use crate::cli::CliCommand;
 
 use anyhow::{Context, Error, Result};
@@ -12,7 +13,7 @@ pub(crate) struct TopicUpdate {
     stream_id: u32,
     topic_id: u32,
     name: String,
-    message_expiry: Option<u32>,
+    message_expiry: Option<MessageExpiry>,
 }
 
 impl TopicUpdate {
@@ -20,7 +21,7 @@ impl TopicUpdate {
         stream_id: u32,
         topic_id: u32,
         name: String,
-        message_expiry: Option<u32>,
+        message_expiry: Option<MessageExpiry>,
     ) -> Self {
         Self {
             stream_id,
@@ -34,7 +35,7 @@ impl TopicUpdate {
 #[async_trait]
 impl CliCommand for TopicUpdate {
     fn explain(&self) -> String {
-        let expiry_text = match self.message_expiry {
+        let expiry_text = match &self.message_expiry {
             Some(value) => format!(" and message expire time: {}", value),
             None => String::from(""),
         };
@@ -51,7 +52,10 @@ impl CliCommand for TopicUpdate {
                     .expect("Expected numeric identifier for stream ID"),
                 topic_id: Identifier::numeric(self.topic_id)
                     .expect("Expected numeric identifier for topic ID"),
-                message_expiry: self.message_expiry,
+                message_expiry: match &self.message_expiry {
+                    None => None,
+                    Some(value) => value.into(),
+                },
                 name: self.name.clone(),
             })
             .await
@@ -60,7 +64,7 @@ impl CliCommand for TopicUpdate {
                     "Problem updating topic (ID: {}, name: {}{}) in stream with ID: {}",
                     self.topic_id,
                     self.name,
-                    match self.message_expiry {
+                    match &self.message_expiry {
                         Some(value) => format!(" and message expire time: {}", value),
                         None => String::from(""),
                     },
@@ -72,7 +76,7 @@ impl CliCommand for TopicUpdate {
             "Topic with ID: {} updated name: {}{} in stream with ID: {}",
             self.topic_id,
             self.name,
-            match self.message_expiry {
+            match &self.message_expiry {
                 Some(value) => format!(" and message expire time: {}", value),
                 None => String::from(""),
             },

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -4,7 +4,7 @@ mod cmd;
 mod error;
 mod logging;
 
-use crate::args::{topic::TopicAction, Command, IggyConsoleArgs, StreamAction};
+use crate::args::{stream::StreamAction, topic::TopicAction, Command, IggyConsoleArgs};
 use crate::cmd::{
     stream::{
         create::StreamCreate, delete::StreamDelete, get::StreamGet, list::StreamList,
@@ -30,11 +30,15 @@ fn get_command(command: &Command) -> Box<dyn CliCommand> {
     #[warn(clippy::let_and_return)]
     match command {
         Command::Stream(command) => match command {
+            StreamAction::Create(args) => {
+                Box::new(StreamCreate::new(args.stream_id, args.name.clone()))
+            }
+            StreamAction::Delete(args) => Box::new(StreamDelete::new(args.stream_id)),
+            StreamAction::Update(args) => {
+                Box::new(StreamUpdate::new(args.stream_id, args.name.clone()))
+            }
+            StreamAction::Get(args) => Box::new(StreamGet::new(args.stream_id)),
             StreamAction::List(args) => Box::new(StreamList::new(args.list_mode)),
-            StreamAction::Create { id, name } => Box::new(StreamCreate::new(*id, name.clone())),
-            StreamAction::Delete { id } => Box::new(StreamDelete::new(*id)),
-            StreamAction::Get { id } => Box::new(StreamGet::new(*id)),
-            StreamAction::Update { id, name } => Box::new(StreamUpdate::new(*id, name.clone())),
         },
         Command::Topic(command) => match command {
             TopicAction::Create(args) => Box::new(TopicCreate::new(
@@ -45,13 +49,13 @@ fn get_command(command: &Command) -> Box<dyn CliCommand> {
                 args.name.clone(),
             )),
             TopicAction::Delete(args) => Box::new(TopicDelete::new(args.stream_id, args.topic_id)),
-            TopicAction::Get(args) => Box::new(TopicGet::new(args.stream_id, args.topic_id)),
             TopicAction::Update(args) => Box::new(TopicUpdate::new(
                 args.stream_id,
                 args.topic_id,
                 args.name.clone(),
                 args.message_expiry,
             )),
+            TopicAction::Get(args) => Box::new(TopicGet::new(args.stream_id, args.topic_id)),
             TopicAction::List(args) => Box::new(TopicList::new(args.stream_id, args.list_mode)),
         },
     }

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -4,14 +4,19 @@ mod cmd;
 mod error;
 mod logging;
 
-use crate::args::{IggyConsoleArgs, StreamAction};
-use crate::cmd::stream::{
-    create::StreamCreate, delete::StreamDelete, get::StreamGet, list::StreamList,
-    update::StreamUpdate,
+use crate::args::{topic::TopicAction, Command, IggyConsoleArgs, StreamAction};
+use crate::cmd::{
+    stream::{
+        create::StreamCreate, delete::StreamDelete, get::StreamGet, list::StreamList,
+        update::StreamUpdate,
+    },
+    topic::{
+        create::TopicCreate, delete::TopicDelete, get::TopicGet, list::TopicList,
+        update::TopicUpdate,
+    },
 };
 use crate::error::IggyConsoleError;
 use crate::logging::{Logging, PRINT_TARGET};
-use args::Command;
 use clap::Parser;
 use cli::CliCommand;
 use iggy::client_provider;
@@ -30,6 +35,24 @@ fn get_command(command: &Command) -> Box<dyn CliCommand> {
             StreamAction::Delete { id } => Box::new(StreamDelete::new(*id)),
             StreamAction::Get { id } => Box::new(StreamGet::new(*id)),
             StreamAction::Update { id, name } => Box::new(StreamUpdate::new(*id, name.clone())),
+        },
+        Command::Topic(command) => match command {
+            TopicAction::Create(args) => Box::new(TopicCreate::new(
+                args.stream_id,
+                args.topic_id,
+                args.partitions_count,
+                args.message_expiry,
+                args.name.clone(),
+            )),
+            TopicAction::Delete(args) => Box::new(TopicDelete::new(args.stream_id, args.topic_id)),
+            TopicAction::Get(args) => Box::new(TopicGet::new(args.stream_id, args.topic_id)),
+            TopicAction::Update(args) => Box::new(TopicUpdate::new(
+                args.stream_id,
+                args.topic_id,
+                args.name.clone(),
+                args.message_expiry,
+            )),
+            TopicAction::List(args) => Box::new(TopicList::new(args.stream_id, args.list_mode)),
         },
     }
 }

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -17,6 +17,7 @@ use crate::cmd::{
 };
 use crate::error::IggyConsoleError;
 use crate::logging::{Logging, PRINT_TARGET};
+use args::topic::MessageExpiry;
 use clap::Parser;
 use cli::CliCommand;
 use iggy::client_provider;
@@ -45,15 +46,15 @@ fn get_command(command: &Command) -> Box<dyn CliCommand> {
                 args.stream_id,
                 args.topic_id,
                 args.partitions_count,
-                args.message_expiry,
                 args.name.clone(),
+                MessageExpiry::new(args.message_expiry.clone()),
             )),
             TopicAction::Delete(args) => Box::new(TopicDelete::new(args.stream_id, args.topic_id)),
             TopicAction::Update(args) => Box::new(TopicUpdate::new(
                 args.stream_id,
                 args.topic_id,
                 args.name.clone(),
-                args.message_expiry,
+                MessageExpiry::new(args.message_expiry.clone()),
             )),
             TopicAction::Get(args) => Box::new(TopicGet::new(args.stream_id, args.topic_id)),
             TopicAction::List(args) => Box::new(TopicList::new(args.stream_id, args.list_mode)),


### PR DESCRIPTION
Adding set of modules under cmd::topic module which implement topic
specific commands. Adding also args::topic and args::common modules
which contain command line args parser definitions and help messages.
Move stream related command line parser structures to separate module
Update create version to 0.2.0