### PR TITLE
Extend help for each command with examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1164,7 +1164,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cmd"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cmd"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/stream.rs
+++ b/cmd/src/args/stream.rs
@@ -1,5 +1,6 @@
 use crate::args::common::ListMode;
 use clap::{Args, Subcommand};
+use iggy::identifier::Identifier;
 
 #[derive(Debug, Subcommand)]
 pub(crate) enum StreamAction {
@@ -26,13 +27,17 @@ pub(crate) struct StreamCreateArgs {
 #[derive(Debug, Args)]
 pub(crate) struct StreamDeleteArgs {
     /// Stream ID to delete
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    pub(crate) stream_id: Identifier,
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct StreamUpdateArgs {
     /// Stream ID to update
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    pub(crate) stream_id: Identifier,
     /// New name for the stream
     pub(crate) name: String,
 }
@@ -40,7 +45,9 @@ pub(crate) struct StreamUpdateArgs {
 #[derive(Debug, Args)]
 pub(crate) struct StreamGetArgs {
     /// Stream ID to get
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    pub(crate) stream_id: Identifier,
 }
 
 #[derive(Debug, Args)]

--- a/cmd/src/args/stream.rs
+++ b/cmd/src/args/stream.rs
@@ -5,14 +5,46 @@ use iggy::identifier::Identifier;
 #[derive(Debug, Subcommand)]
 pub(crate) enum StreamAction {
     /// Create stream with given ID and name
+    ///
+    /// Examples:
+    ///  iggy stream create 1 prod
+    ///  iggy stream create 2 test
+    #[clap(verbatim_doc_comment)]
     Create(StreamCreateArgs),
     /// Delete stream with given ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples:
+    ///  iggy stream delete 1
+    ///  iggy stream delete test
+    #[clap(verbatim_doc_comment)]
     Delete(StreamDeleteArgs),
     /// Update stream name for given stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples:
+    ///  iggy stream update 1 production
+    ///  iggy stream update test development
+    #[clap(verbatim_doc_comment)]
     Update(StreamUpdateArgs),
     /// Get details of a single stream with given ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples:
+    ///  iggy stream get 1
+    ///  iggy stream get test
+    #[clap(verbatim_doc_comment)]
     Get(StreamGetArgs),
     /// List all streams
+    ///
+    /// Examples:
+    ///  iggy stream list
+    ///  iggy stream list --list-mode table
+    ///  iggy stream list -l table
+    #[clap(verbatim_doc_comment)]
     List(StreamListArgs),
 }
 

--- a/cmd/src/args/topic.rs
+++ b/cmd/src/args/topic.rs
@@ -2,6 +2,7 @@ use crate::args::common::ListMode;
 use clap::{Args, Subcommand};
 use humantime::format_duration;
 use humantime::Duration as HumanDuration;
+use iggy::identifier::Identifier;
 use std::fmt::Display;
 use std::iter::Sum;
 use std::ops::Add;
@@ -26,7 +27,10 @@ pub(crate) enum TopicAction {
 #[derive(Debug, Args)]
 pub(crate) struct TopicCreateArgs {
     /// Stream ID to create topic
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
     /// Topic ID to create
     pub(crate) topic_id: u32,
     /// Number of partitions inside the topic
@@ -42,17 +46,29 @@ pub(crate) struct TopicCreateArgs {
 #[derive(Debug, Args)]
 pub(crate) struct TopicDeleteArgs {
     /// Stream ID to delete topic
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
     /// Topic ID to delete
-    pub(crate) topic_id: u32,
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct TopicUpdateArgs {
     /// Stream ID to update topic
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
     /// Topic ID to update
-    pub(crate) topic_id: u32,
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
     /// New name for the topic
     pub(crate) name: String,
     /// New message expiry time in human readable format like 15days 2min 2s
@@ -143,15 +159,24 @@ impl FromStr for MessageExpiry {
 #[derive(Debug, Args)]
 pub(crate) struct TopicGetArgs {
     /// Stream ID to get topic
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
     /// Topic ID to get
-    pub(crate) topic_id: u32,
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
 }
 
 #[derive(Debug, Args)]
 pub(crate) struct TopicListArgs {
     /// Stream ID to list topics
-    pub(crate) stream_id: u32,
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
 
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]

--- a/cmd/src/args/topic.rs
+++ b/cmd/src/args/topic.rs
@@ -13,14 +13,60 @@ use std::{convert::From, str::FromStr};
 pub(crate) enum TopicAction {
     /// Create topic with given ID, name, number of partitions
     /// and expiry time for given stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples
+    ///  iggy topic create 1 1 2 sensor1 15days
+    ///  iggy topic create prod 2 2 sensor2
+    ///  iggy topic create test 3 2 debugs 1day 1hour 1min 1sec
+    #[clap(verbatim_doc_comment)]
     Create(TopicCreateArgs),
     /// Delete topic with given ID in given stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples
+    ///  iggy topic delete 1 1
+    ///  iggy topic delete prod 2
+    ///  iggy topic delete test debugs
+    ///  iggy topic delete 2 debugs
+    #[clap(verbatim_doc_comment)]
     Delete(TopicDeleteArgs),
     /// Update topic name an message expiry time for given topic ID in given stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples
+    ///  iggy update 1 1 sensor3
+    ///  iggy update prod sensor3 old-sensor
+    ///  iggy update test debugs ready 15days
+    ///  iggy update 1 1 new-name
+    ///  iggy update 1 2 new-name 1day 1hour 1min 1sec
+    #[clap(verbatim_doc_comment)]
     Update(TopicUpdateArgs),
     /// Get topic detail for given topic ID and stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples
+    ///  iggy topic get 1 1
+    ///  iggy topic get prod 2
+    ///  iggy topic get test debugs
+    ///  iggy topic get 2 debugs
+    #[clap(verbatim_doc_comment)]
     Get(TopicGetArgs),
     /// List all topics in given stream ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples
+    ///  iggy topic list 1
+    ///  iggy topic list prod
+    #[clap(verbatim_doc_comment)]
     List(TopicListArgs),
 }
 

--- a/cmd/src/cmd/stream/delete.rs
+++ b/cmd/src/cmd/stream/delete.rs
@@ -9,30 +9,30 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct StreamDelete {
-    id: u32,
+    stream_id: Identifier,
 }
 
 impl StreamDelete {
-    pub(crate) fn new(id: u32) -> Self {
-        Self { id }
+    pub(crate) fn new(stream_id: Identifier) -> Self {
+        Self { stream_id }
     }
 }
 
 #[async_trait]
 impl CliCommand for StreamDelete {
     fn explain(&self) -> String {
-        format!("delete stream with ID: {}", self.id)
+        format!("delete stream with ID: {}", self.stream_id)
     }
 
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         client
             .delete_stream(&DeleteStream {
-                stream_id: Identifier::numeric(self.id).expect("Expected numeric identifier"),
+                stream_id: self.stream_id.clone(),
             })
             .await
-            .with_context(|| format!("Problem deleting stream with ID: {}", self.id))?;
+            .with_context(|| format!("Problem deleting stream with ID: {}", self.stream_id))?;
 
-        info!("Stream with ID: {} deleted", self.id);
+        info!("Stream with ID: {} deleted", self.stream_id);
 
         Ok(())
     }

--- a/cmd/src/cmd/stream/get.rs
+++ b/cmd/src/cmd/stream/get.rs
@@ -1,5 +1,4 @@
 use crate::cli::CliCommand;
-// use crate::error::IggyConsoleError;
 
 use anyhow::{Context, Error, Result};
 use async_trait::async_trait;
@@ -12,28 +11,28 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct StreamGet {
-    id: u32,
+    stream_id: Identifier,
 }
 
 impl StreamGet {
-    pub(crate) fn new(id: u32) -> Self {
-        Self { id }
+    pub(crate) fn new(stream_id: Identifier) -> Self {
+        Self { stream_id }
     }
 }
 
 #[async_trait]
 impl CliCommand for StreamGet {
     fn explain(&self) -> String {
-        format!("get stream with ID: {}", self.id)
+        format!("get stream with ID: {}", self.stream_id)
     }
 
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         let stream = client
             .get_stream(&GetStream {
-                stream_id: Identifier::numeric(self.id).expect("Expected numeric identifier"),
+                stream_id: self.stream_id.clone(),
             })
             .await
-            .with_context(|| format!("Problem getting stream with ID: {}", self.id))?;
+            .with_context(|| format!("Problem getting stream with ID: {}", self.stream_id))?;
 
         let mut table = Table::new();
 

--- a/cmd/src/cmd/stream/update.rs
+++ b/cmd/src/cmd/stream/update.rs
@@ -9,37 +9,43 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct StreamUpdate {
-    id: u32,
+    stream_id: Identifier,
     name: String,
 }
 
 impl StreamUpdate {
-    pub(crate) fn new(id: u32, name: String) -> Self {
-        Self { id, name }
+    pub(crate) fn new(stream_id: Identifier, name: String) -> Self {
+        Self { stream_id, name }
     }
 }
 
 #[async_trait]
 impl CliCommand for StreamUpdate {
     fn explain(&self) -> String {
-        format!("update stream with ID: {} and name: {}", self.id, self.name)
+        format!(
+            "update stream with ID: {} and name: {}",
+            self.stream_id, self.name
+        )
     }
 
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         client
             .update_stream(&UpdateStream {
-                stream_id: Identifier::numeric(self.id).expect("Expected numeric identifier"),
+                stream_id: self.stream_id.clone(),
                 name: self.name.clone(),
             })
             .await
             .with_context(|| {
                 format!(
                     "Problem updating stream with ID: {} and name: {}",
-                    self.id, self.name
+                    self.stream_id, self.name
                 )
             })?;
 
-        info!("Stream with ID: {} updated name: {} ", self.id, self.name);
+        info!(
+            "Stream with ID: {} updated name: {} ",
+            self.stream_id, self.name
+        );
 
         Ok(())
     }

--- a/cmd/src/cmd/topic/create.rs
+++ b/cmd/src/cmd/topic/create.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct TopicCreate {
-    stream_id: u32,
+    stream_id: Identifier,
     topic_id: u32,
     partitions_count: u32,
     name: String,
@@ -19,7 +19,7 @@ pub(crate) struct TopicCreate {
 
 impl TopicCreate {
     pub(crate) fn new(
-        stream_id: u32,
+        stream_id: Identifier,
         topic_id: u32,
         partitions_count: u32,
         name: String,
@@ -51,8 +51,7 @@ impl CliCommand for TopicCreate {
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
-                stream_id: Identifier::numeric(self.stream_id)
-                    .expect("Expected numeric identifier"),
+                stream_id: self.stream_id.clone(),
                 topic_id: self.topic_id,
                 partitions_count: self.partitions_count,
                 message_expiry: match &self.message_expiry {

--- a/cmd/src/cmd/topic/delete.rs
+++ b/cmd/src/cmd/topic/delete.rs
@@ -9,12 +9,12 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct TopicDelete {
-    stream_id: u32,
-    topic_id: u32,
+    stream_id: Identifier,
+    topic_id: Identifier,
 }
 
 impl TopicDelete {
-    pub(crate) fn new(stream_id: u32, topic_id: u32) -> Self {
+    pub(crate) fn new(stream_id: Identifier, topic_id: Identifier) -> Self {
         Self {
             stream_id,
             topic_id,
@@ -34,10 +34,8 @@ impl CliCommand for TopicDelete {
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         client
             .delete_topic(&DeleteTopic {
-                stream_id: Identifier::numeric(self.stream_id)
-                    .expect("Expected numeric identifier for stream_id"),
-                topic_id: Identifier::numeric(self.topic_id)
-                    .expect("Expected numeric identifier for topic_id"),
+                stream_id: self.stream_id.clone(),
+                topic_id: self.topic_id.clone(),
             })
             .await
             .with_context(|| {

--- a/cmd/src/cmd/topic/get.rs
+++ b/cmd/src/cmd/topic/get.rs
@@ -78,8 +78,6 @@ impl CliCommand for TopicGet {
 
         info!("{table}");
 
-        info!("{:?}", topic);
-
         Ok(())
     }
 }

--- a/cmd/src/cmd/topic/get.rs
+++ b/cmd/src/cmd/topic/get.rs
@@ -11,12 +11,12 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct TopicGet {
-    stream_id: u32,
-    topic_id: u32,
+    stream_id: Identifier,
+    topic_id: Identifier,
 }
 
 impl TopicGet {
-    pub(crate) fn new(stream_id: u32, topic_id: u32) -> Self {
+    pub(crate) fn new(stream_id: Identifier, topic_id: Identifier) -> Self {
         Self {
             stream_id,
             topic_id,
@@ -36,10 +36,8 @@ impl CliCommand for TopicGet {
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         let topic = client
             .get_topic(&GetTopic {
-                stream_id: Identifier::numeric(self.stream_id)
-                    .expect("Expected numeric identifier for stream_id"),
-                topic_id: Identifier::numeric(self.topic_id)
-                    .expect("Expected numeric identifier for topic_id"),
+                stream_id: self.stream_id.clone(),
+                topic_id: self.topic_id.clone(),
             })
             .await
             .with_context(|| {

--- a/cmd/src/cmd/topic/list.rs
+++ b/cmd/src/cmd/topic/list.rs
@@ -12,12 +12,12 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct TopicList {
-    stream_id: u32,
+    stream_id: Identifier,
     list_mode: ListMode,
 }
 
 impl TopicList {
-    pub(crate) fn new(stream_id: u32, list_mode: ListMode) -> Self {
+    pub(crate) fn new(stream_id: Identifier, list_mode: ListMode) -> Self {
         Self {
             stream_id,
             list_mode,
@@ -34,8 +34,7 @@ impl CliCommand for TopicList {
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         let topics = client
             .get_topics(&GetTopics {
-                stream_id: Identifier::numeric(self.stream_id)
-                    .expect("Expected numeric identifier for stream_id"),
+                stream_id: self.stream_id.clone(),
             })
             .await
             .with_context(|| format!("Problem getting topics from stream {}", self.stream_id))?;

--- a/cmd/src/cmd/topic/update.rs
+++ b/cmd/src/cmd/topic/update.rs
@@ -10,16 +10,16 @@ use tracing::info;
 
 #[derive(Debug)]
 pub(crate) struct TopicUpdate {
-    stream_id: u32,
-    topic_id: u32,
+    stream_id: Identifier,
+    topic_id: Identifier,
     name: String,
     message_expiry: Option<MessageExpiry>,
 }
 
 impl TopicUpdate {
     pub(crate) fn new(
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: Identifier,
+        topic_id: Identifier,
         name: String,
         message_expiry: Option<MessageExpiry>,
     ) -> Self {
@@ -48,10 +48,8 @@ impl CliCommand for TopicUpdate {
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error> {
         client
             .update_topic(&UpdateTopic {
-                stream_id: Identifier::numeric(self.stream_id)
-                    .expect("Expected numeric identifier for stream ID"),
-                topic_id: Identifier::numeric(self.topic_id)
-                    .expect("Expected numeric identifier for topic ID"),
+                stream_id: self.stream_id.clone(),
+                topic_id: self.topic_id.clone(),
                 message_expiry: match &self.message_expiry {
                     None => None,
                     Some(value) => value.into(),

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -34,30 +34,37 @@ fn get_command(command: &Command) -> Box<dyn CliCommand> {
             StreamAction::Create(args) => {
                 Box::new(StreamCreate::new(args.stream_id, args.name.clone()))
             }
-            StreamAction::Delete(args) => Box::new(StreamDelete::new(args.stream_id)),
+            StreamAction::Delete(args) => Box::new(StreamDelete::new(args.stream_id.clone())),
             StreamAction::Update(args) => {
-                Box::new(StreamUpdate::new(args.stream_id, args.name.clone()))
+                Box::new(StreamUpdate::new(args.stream_id.clone(), args.name.clone()))
             }
-            StreamAction::Get(args) => Box::new(StreamGet::new(args.stream_id)),
+            StreamAction::Get(args) => Box::new(StreamGet::new(args.stream_id.clone())),
             StreamAction::List(args) => Box::new(StreamList::new(args.list_mode)),
         },
         Command::Topic(command) => match command {
             TopicAction::Create(args) => Box::new(TopicCreate::new(
-                args.stream_id,
+                args.stream_id.clone(),
                 args.topic_id,
                 args.partitions_count,
                 args.name.clone(),
                 MessageExpiry::new(args.message_expiry.clone()),
             )),
-            TopicAction::Delete(args) => Box::new(TopicDelete::new(args.stream_id, args.topic_id)),
+            TopicAction::Delete(args) => Box::new(TopicDelete::new(
+                args.stream_id.clone(),
+                args.topic_id.clone(),
+            )),
             TopicAction::Update(args) => Box::new(TopicUpdate::new(
-                args.stream_id,
-                args.topic_id,
+                args.stream_id.clone(),
+                args.topic_id.clone(),
                 args.name.clone(),
                 MessageExpiry::new(args.message_expiry.clone()),
             )),
-            TopicAction::Get(args) => Box::new(TopicGet::new(args.stream_id, args.topic_id)),
-            TopicAction::List(args) => Box::new(TopicList::new(args.stream_id, args.list_mode)),
+            TopicAction::Get(args) => {
+                Box::new(TopicGet::new(args.stream_id.clone(), args.topic_id.clone()))
+            }
+            TopicAction::List(args) => {
+                Box::new(TopicList::new(args.stream_id.clone(), args.list_mode))
+            }
         },
     }
 }

--- a/iggy/src/identifier.rs
+++ b/iggy/src/identifier.rs
@@ -9,7 +9,7 @@ use std::fmt::Display;
 use std::str::FromStr;
 
 #[serde_as]
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct Identifier {
     pub kind: IdKind,
     #[serde(skip)]


### PR DESCRIPTION
Add to each command long help with additional information and section with examples of command usage. Remove debug print for topic get command.