### PR TITLE
Update aes-gcm to 0.10.3 in order to fix CVE-2023-42811

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209b47e8954a928e1d72e86eca7000ebb6655fe1436d33eefc2201cad027e237"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
  "aes",

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/spetz/iggy"
 readme = "../README.md"
 
 [dependencies]
-aes-gcm = "0.10.2"
+aes-gcm = "0.10.3"
 async-trait = "0.1.68"
 base64 = "0.21.2"
 bytes = "1.4.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -41,7 +41,7 @@ tokio-graceful-shutdown = "0.13.0"
 rcgen = "0.11.1"
 quinn = "0.10.0"
 rustls = { version = "0.21.1", features = ["dangerous_configuration", "quic"] }
-aes-gcm = "0.10.2"
+aes-gcm = "0.10.3"
 bcrypt = "0.15.0"
 futures = "0.3.28"
 ringbuffer = "0.14.2"


### PR DESCRIPTION
This commit fix #2 security alert related to aes-gcm crate and CVE-2023-42811