### PR TITLE
Add username and password command line options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cmd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1206,6 +1206,7 @@ dependencies = [
  "comfy-table",
  "humantime",
  "iggy",
+ "passterm",
  "thiserror",
  "tokio",
  "tracing",
@@ -1649,6 +1650,16 @@ dependencies = [
  "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "passterm"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6421520445baa36401ded73e4820ad3a3e04316a0eb1bdb13b94987739de5fa2"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cmd"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -17,6 +17,7 @@ tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17" }
 tracing-appender = "0.2.2"
 humantime = "2.1.0"
+passterm = "2.0.1"
 
 [[bin]]
 name = "iggy"

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -25,6 +25,14 @@ pub(crate) struct IggyConsoleArgs {
     /// Debug mode (verbose printing to given file)
     #[clap(short, long)]
     pub(crate) debug: Option<PathBuf>,
+
+    /// Iggy server username
+    #[clap(short, long)]
+    pub(crate) username: String,
+
+    /// Iggy server password
+    #[clap(short, long)]
+    pub(crate) password: Option<String>,
 }
 
 #[derive(Debug, Subcommand)]

--- a/cmd/src/error.rs
+++ b/cmd/src/error.rs
@@ -1,10 +1,13 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-pub(crate) enum IggyConsoleError {
+pub(crate) enum ConsoleError {
     #[error("Iggy client error")]
     IggyClientError(#[from] iggy::client_error::ClientError),
 
     #[error("Iggy sdk or command error")]
     IggyCommandError(#[from] anyhow::Error),
+
+    #[error("Iggy password prompt error")]
+    IggyPasswordPromptError(#[from] passterm::PromptError),
 }

--- a/cmd/src/login.rs
+++ b/cmd/src/login.rs
@@ -1,0 +1,42 @@
+use anyhow::{Context, Error, Result};
+use iggy::client::Client;
+use iggy::users::{login_user::LoginUser, logout_user::LogoutUser};
+use passterm::{isatty, prompt_password_stdin, prompt_password_tty, Stream};
+
+pub(crate) async fn login_user(
+    client: &dyn Client,
+    username: String,
+    password: String,
+) -> anyhow::Result<(), anyhow::Error> {
+    let user = username.clone();
+    let _ = client
+        .login_user(&LoginUser { username, password })
+        .await
+        .with_context(|| format!("Problem with server login for username: {}", user))?;
+
+    Ok(())
+}
+
+pub(crate) async fn logout_user(client: &dyn Client) -> Result<(), Error> {
+    client
+        .logout_user(&LogoutUser {})
+        .await
+        .with_context(|| "Problem with server logout".to_string())?;
+
+    Ok(())
+}
+
+pub(crate) fn get_password(cli_password: Option<String>) -> anyhow::Result<String> {
+    let password = match cli_password {
+        Some(password) => password,
+        None => {
+            if isatty(Stream::Stdin) {
+                prompt_password_tty(Some("Password: "))?
+            } else {
+                prompt_password_stdin(None, Stream::Stdout)?
+            }
+        }
+    };
+
+    Ok(password)
+}


### PR DESCRIPTION
Since Iggy server requires authentication adding username and password which allows users to provide credentials to log into iggy server. If password is not provided in command line arguments iggy tool asks for password.