### PR TITLE
Add two default features to iggy username-in-args and password-in-args

### DIFF
--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
 
 [dependencies]
-iggy = { path = "../iggy" }
+iggy = { path = "../iggy", default-features = false }
 clap = { version = "4.1.11", features = ["derive"] }
 tokio = { version = "1.28.2", features = ["full"] }
 async-trait = "0.1.68"

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -49,3 +49,8 @@ serde = { version = "1.0.188", features = ["derive", "rc"] }
 serde_derive = "1.0.188"
 sled = "0.34.7"
 convert_case = "0.6.0"
+
+[features]
+default = ["username-in-args", "password-in-args"]
+username-in-args = []
+password-in-args = []

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -51,6 +51,5 @@ sled = "0.34.7"
 convert_case = "0.6.0"
 
 [features]
-default = ["username-in-args", "password-in-args"]
-username-in-args = []
-password-in-args = []
+default = ["credentials-in-args"]
+credentials-in-args = []

--- a/iggy/src/args.rs
+++ b/iggy/src/args.rs
@@ -6,9 +6,11 @@ pub struct Args {
     #[arg(long, default_value = "tcp")]
     pub transport: String,
 
+    #[cfg(feature = "username-in-args")]
     #[arg(long, default_value = "iggy")]
     pub username: String,
 
+    #[cfg(feature = "password-in-args")]
     #[arg(long, default_value = "iggy")]
     pub password: String,
 

--- a/iggy/src/args.rs
+++ b/iggy/src/args.rs
@@ -6,11 +6,11 @@ pub struct Args {
     #[arg(long, default_value = "tcp")]
     pub transport: String,
 
-    #[cfg(feature = "username-in-args")]
+    #[cfg(feature = "credentials-in-args")]
     #[arg(long, default_value = "iggy")]
     pub username: String,
 
-    #[cfg(feature = "password-in-args")]
+    #[cfg(feature = "credentials-in-args")]
     #[arg(long, default_value = "iggy")]
     pub password: String,
 


### PR DESCRIPTION
Features control presence of username and password members in Args struct used for iggy SDK parameters parsing. Both features are enabled by default in iggy crate. Both are disabled in iggy-cmd crate in order to be able to introduce different handling of both parameters in iggy command line tool.