### PR TITLE
chore: own-defined types for various simple types

### DIFF
--- a/iggy/src/models/identity_info.rs
+++ b/iggy/src/models/identity_info.rs
@@ -1,7 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+use super::user_info::UserId;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct IdentityInfo {
-    pub user_id: u32,
+    pub user_id: UserId,
     pub token: Option<String>,
 }

--- a/iggy/src/models/user_info.rs
+++ b/iggy/src/models/user_info.rs
@@ -2,9 +2,11 @@ use crate::models::permissions::Permissions;
 use crate::models::user_status::UserStatus;
 use serde::{Deserialize, Serialize};
 
+pub type UserId = u32;
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UserInfo {
-    pub id: u32,
+    pub id: UserId,
     pub created_at: u64,
     pub status: UserStatus,
     pub username: String,
@@ -12,7 +14,7 @@ pub struct UserInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UserInfoDetails {
-    pub id: u32,
+    pub id: UserId,
     pub created_at: u64,
     pub status: UserStatus,
     pub username: String,

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -1,5 +1,6 @@
 use bytes::BufMut;
 use iggy::models::consumer_offset_info::ConsumerOffsetInfo;
+use iggy::models::user_info::UserId;
 
 use crate::streaming::clients::client_manager::{Client, Transport};
 use crate::streaming::models::messages::PolledMessages;
@@ -94,7 +95,7 @@ pub fn map_users(users: &[User]) -> Vec<u8> {
     bytes
 }
 
-pub fn map_identity_info(user_id: u32) -> Vec<u8> {
+pub fn map_identity_info(user_id: UserId) -> Vec<u8> {
     let mut bytes = Vec::with_capacity(4);
     bytes.put_u32_le(user_id);
     bytes

--- a/server/src/http/jwt.rs
+++ b/server/src/http/jwt.rs
@@ -7,6 +7,7 @@ use axum::{
     response::Response,
 };
 use iggy::error::Error;
+use iggy::models::user_info::UserId;
 use iggy::utils::timestamp::TimeStamp;
 use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use serde::{Deserialize, Serialize};
@@ -18,7 +19,7 @@ const UNAUTHORIZED: StatusCode = StatusCode::UNAUTHORIZED;
 
 #[derive(Debug, Clone)]
 pub struct Identity {
-    pub user_id: u32,
+    pub user_id: UserId,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -119,7 +120,7 @@ impl JwtManager {
         )
     }
 
-    pub fn generate(&self, user_id: u32) -> String {
+    pub fn generate(&self, user_id: UserId) -> String {
         let header = Header::new(self.algorithm);
         let iat = TimeStamp::now().to_micros();
         let exp = iat + 1_000_000 * self.expiry;

--- a/server/src/streaming/cache/memory_tracker.rs
+++ b/server/src/streaming/cache/memory_tracker.rs
@@ -16,6 +16,8 @@ pub struct CacheMemoryTracker {
     limit_bytes: u64,
 }
 
+type MessageSize = u64;
+
 impl CacheMemoryTracker {
     pub fn initialize(config: &CacheConfig) -> Option<Arc<CacheMemoryTracker>> {
         unsafe {
@@ -58,7 +60,7 @@ impl CacheMemoryTracker {
         }
     }
 
-    pub fn increment_used_memory(&self, message_size: u64) {
+    pub fn increment_used_memory(&self, message_size: MessageSize) {
         let mut current_cache_size_bytes = self.used_memory_bytes.load(Ordering::SeqCst);
         loop {
             let new_size = current_cache_size_bytes + message_size;
@@ -74,7 +76,7 @@ impl CacheMemoryTracker {
         }
     }
 
-    pub fn decrement_used_memory(&self, message_size: u64) {
+    pub fn decrement_used_memory(&self, message_size: MessageSize) {
         let mut current_cache_size_bytes = self.used_memory_bytes.load(Ordering::SeqCst);
         loop {
             let new_size = current_cache_size_bytes - message_size;

--- a/server/src/streaming/clients/client_manager.rs
+++ b/server/src/streaming/clients/client_manager.rs
@@ -1,5 +1,6 @@
 use crate::streaming::utils::hash;
 use iggy::error::Error;
+use iggy::models::user_info::UserId;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::net::SocketAddr;
@@ -57,7 +58,7 @@ impl ClientManager {
         id
     }
 
-    pub async fn set_user_id(&mut self, client_id: u32, user_id: u32) -> Result<(), Error> {
+    pub async fn set_user_id(&mut self, client_id: u32, user_id: UserId) -> Result<(), Error> {
         let client = self.clients.get(&client_id);
         if client.is_none() {
             return Err(Error::ClientNotFound(client_id));
@@ -100,7 +101,7 @@ impl ClientManager {
         self.clients.values().cloned().collect()
     }
 
-    pub async fn delete_clients_for_user(&mut self, user_id: u32) -> Result<(), Error> {
+    pub async fn delete_clients_for_user(&mut self, user_id: UserId) -> Result<(), Error> {
         let mut clients_to_remove = Vec::new();
         for client in self.clients.values() {
             let client = client.read().await;

--- a/server/src/streaming/session.rs
+++ b/server/src/streaming/session.rs
@@ -1,18 +1,20 @@
 use std::fmt::Display;
 
+use iggy::models::user_info::UserId;
+
 // This might be extended with more fields in the future e.g. custom name, permissions etc.
 #[derive(Debug)]
 pub struct Session {
-    pub user_id: u32,
+    pub user_id: UserId,
     pub client_id: u32,
 }
 
 impl Session {
-    pub fn new(client_id: u32, user_id: u32) -> Self {
+    pub fn new(client_id: u32, user_id: UserId) -> Self {
         Self { client_id, user_id }
     }
 
-    pub fn stateless(user_id: u32) -> Self {
+    pub fn stateless(user_id: UserId) -> Self {
         Self::new(0, user_id)
     }
 
@@ -20,7 +22,7 @@ impl Session {
         Self::new(client_id, 0)
     }
 
-    pub fn set_user_id(&mut self, user_id: u32) {
+    pub fn set_user_id(&mut self, user_id: UserId) {
         self.user_id = user_id;
     }
 

--- a/server/src/streaming/users/permissioner.rs
+++ b/server/src/streaming/users/permissioner.rs
@@ -1,16 +1,17 @@
 use crate::streaming::users::user::User;
 use iggy::models::permissions::{GlobalPermissions, StreamPermissions};
+use iggy::models::user_info::UserId;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Permissioner {
-    pub(super) users_permissions: HashMap<u32, GlobalPermissions>,
-    pub(super) users_streams_permissions: HashMap<(u32, u32), StreamPermissions>,
-    pub(super) users_that_can_poll_messages_from_all_streams: HashSet<u32>,
-    pub(super) users_that_can_send_messages_to_all_streams: HashSet<u32>,
-    pub(super) users_that_can_poll_messages_from_specific_streams: HashSet<(u32, u32)>,
-    pub(super) users_that_can_send_messages_to_specific_streams: HashSet<(u32, u32)>,
+    pub(super) users_permissions: HashMap<UserId, GlobalPermissions>,
+    pub(super) users_streams_permissions: HashMap<(UserId, u32), StreamPermissions>,
+    pub(super) users_that_can_poll_messages_from_all_streams: HashSet<UserId>,
+    pub(super) users_that_can_send_messages_to_all_streams: HashSet<UserId>,
+    pub(super) users_that_can_poll_messages_from_specific_streams: HashSet<(UserId, u32)>,
+    pub(super) users_that_can_send_messages_to_specific_streams: HashSet<(UserId, u32)>,
 }
 
 impl Permissioner {
@@ -63,7 +64,7 @@ impl Permissioner {
         self.init_permissions_for_user(user);
     }
 
-    pub fn delete_permissions_for_user(&mut self, user_id: u32) {
+    pub fn delete_permissions_for_user(&mut self, user_id: UserId) {
         self.users_permissions.remove(&user_id);
         self.users_that_can_poll_messages_from_all_streams
             .remove(&user_id);

--- a/server/src/streaming/users/storage.rs
+++ b/server/src/streaming/users/storage.rs
@@ -2,6 +2,7 @@ use crate::streaming::storage::{Storage, UserStorage};
 use crate::streaming::users::user::User;
 use async_trait::async_trait;
 use iggy::error::Error;
+use iggy::models::user_info::UserId;
 use sled::Db;
 use std::sync::Arc;
 use tracing::{error, info};
@@ -24,7 +25,7 @@ unsafe impl Sync for FileUserStorage {}
 
 #[async_trait]
 impl UserStorage for FileUserStorage {
-    async fn load_by_id(&self, id: u32) -> Result<User, Error> {
+    async fn load_by_id(&self, id: UserId) -> Result<User, Error> {
         let mut user = User::empty(id);
         self.load(&mut user).await?;
         Ok(user)
@@ -145,7 +146,7 @@ impl Storage<User> for FileUserStorage {
     }
 }
 
-fn get_key(user_id: u32) -> String {
+fn get_key(user_id: UserId) -> String {
     format!("{}:{}", KEY_PREFIX, user_id)
 }
 

--- a/server/src/streaming/users/user.rs
+++ b/server/src/streaming/users/user.rs
@@ -1,13 +1,13 @@
 use crate::streaming::utils::crypto;
-use iggy::models::permissions::Permissions;
 use iggy::models::user_status::UserStatus;
+use iggy::models::{permissions::Permissions, user_info::UserId};
 use iggy::users::defaults::*;
 use iggy::utils::timestamp::TimeStamp;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct User {
-    pub id: u32,
+    pub id: UserId,
     pub status: UserStatus,
     pub username: String,
     pub password: String,
@@ -29,7 +29,7 @@ impl Default for User {
 }
 
 impl User {
-    pub fn empty(id: u32) -> Self {
+    pub fn empty(id: UserId) -> Self {
         Self {
             id,
             ..Default::default()


### PR DESCRIPTION
Applied two type aliases for 
- `user_id`
- `message_size`

Reasoning for using alias (`type X = u32`) over newtype (`struct X(u32)`)
- Client facing types get cluttered by newtype, requires recreating type which can unneccessarily clutter the SDK:
```rust
let user = UserInfoDetails {
        id: 1,
        ...
    };
```
becomes
```rust
let user = UserInfoDetails {
        id: UserId(1),
        ...
    };
```
which may be more confusing, likewise similar issue on getting an attribute's value
type alias 
```rust
user.id
```
newtype
```rust
user.id.0
```
which imo is not as nice and makes the SDK harder to use.

Therefore on client facing types I think its best to use type aliases.

newstruct types also lose the traits of the internal type, requiring which requires a larger refactor/custom implementations for non-derivable attributes as shown in the screenshot or accessing the internal value using the above syntax
![Screenshot 2023-10-04 at 21 31 49](https://github.com/iggy-rs/iggy/assets/47698091/d3c3c063-6327-45e6-a9a9-3a15d2e9ce03)

---

newtype structs might be useful on types internal to the server - they allow us to implement custom functions to reduce code reuse so its worth analysing on a case by case basis, but for client facing types e.g. the SDK I think type aliases are best