### PR TITLE
Fix problem with mandatory login for ping command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1196,7 +1196,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cmd"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cmd"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/credentials.rs
+++ b/cmd/src/credentials.rs
@@ -1,7 +1,8 @@
 use crate::args::IggyConsoleArgs;
 use crate::error::{CmdToolError, IggyCmdError};
 use anyhow::Context;
-use iggy::client::Client;
+use iggy::client::UserClient;
+use iggy::clients::client::IggyClient;
 use iggy::users::{login_user::LoginUser, logout_user::LogoutUser};
 use passterm::{isatty, prompt_password_stdin, prompt_password_tty, Stream};
 use std::env::var;
@@ -9,13 +10,30 @@ use std::env::var;
 static ENV_IGGY_USERNAME: &str = "IGGY_USERNAME";
 static ENV_IGGY_PASSWORD: &str = "IGGY_PASSWORD";
 
-pub(crate) struct IggyCredentials {
+struct IggyUserClient {
     username: String,
     password: String,
 }
 
-impl IggyCredentials {
-    pub(crate) fn new(args: &IggyConsoleArgs) -> anyhow::Result<Self, anyhow::Error> {
+pub(crate) struct IggyCredentials<'a> {
+    credentials: Option<IggyUserClient>,
+    iggy_client: Option<&'a IggyClient>,
+    login_required: bool,
+}
+
+impl<'a> IggyCredentials<'a> {
+    pub(crate) fn new(
+        args: &IggyConsoleArgs,
+        login_required: bool,
+    ) -> anyhow::Result<Self, anyhow::Error> {
+        if !login_required {
+            return Ok(Self {
+                credentials: None,
+                iggy_client: None,
+                login_required,
+            });
+        }
+
         if let Some(username) = &args.username {
             let password = match &args.password {
                 Some(password) => password.clone(),
@@ -29,48 +47,61 @@ impl IggyCredentials {
             };
 
             Ok(Self {
-                username: username.clone(),
-                password,
+                credentials: Some(IggyUserClient {
+                    username: username.clone(),
+                    password,
+                }),
+                iggy_client: None,
+                login_required,
             })
         } else if var(ENV_IGGY_USERNAME).is_ok() && var(ENV_IGGY_PASSWORD).is_ok() {
             Ok(Self {
-                username: var(ENV_IGGY_USERNAME).unwrap(),
-                password: var(ENV_IGGY_PASSWORD).unwrap(),
+                credentials: Some(IggyUserClient {
+                    username: var(ENV_IGGY_USERNAME).unwrap(),
+                    password: var(ENV_IGGY_PASSWORD).unwrap(),
+                }),
+                iggy_client: None,
+                login_required,
             })
         } else {
             Err(IggyCmdError::CmdToolError(CmdToolError::MissingCredentials).into())
         }
     }
 
-    pub(crate) async fn login_user(
-        &self,
-        client: &dyn Client,
-    ) -> anyhow::Result<(), anyhow::Error> {
-        // let user = self.username.clone();
-        let _ = client
-            .login_user(&LoginUser {
-                username: self.username.clone(),
-                password: self.password.clone(),
-            })
-            .await
-            .with_context(|| {
-                format!(
-                    "Problem with server login for username: {}",
-                    self.username.clone()
-                )
-            })?;
+    pub(crate) fn set_iggy_client(&mut self, iggy_client: &'a IggyClient) {
+        self.iggy_client = Some(iggy_client);
+    }
+
+    pub(crate) async fn login_user(&self) -> anyhow::Result<(), anyhow::Error> {
+        if let Some(client) = self.iggy_client {
+            if self.login_required {
+                let _ = client
+                    .login_user(&LoginUser {
+                        username: self.credentials.as_ref().unwrap().username.clone(),
+                        password: self.credentials.as_ref().unwrap().password.clone(),
+                    })
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Problem with server login for username: {}",
+                            self.credentials.as_ref().unwrap().username.clone()
+                        )
+                    })?;
+            }
+        }
 
         Ok(())
     }
 
-    pub(crate) async fn logout_user(
-        &self,
-        client: &dyn Client,
-    ) -> anyhow::Result<(), anyhow::Error> {
-        client
-            .logout_user(&LogoutUser {})
-            .await
-            .with_context(|| "Problem with server logout".to_string())?;
+    pub(crate) async fn logout_user(&self) -> anyhow::Result<(), anyhow::Error> {
+        if let Some(client) = self.iggy_client {
+            if self.login_required {
+                client
+                    .logout_user(&LogoutUser {})
+                    .await
+                    .with_context(|| "Problem with server logout".to_string())?;
+            }
+        }
 
         Ok(())
     }

--- a/iggy/src/cli_command.rs
+++ b/iggy/src/cli_command.rs
@@ -7,5 +7,8 @@ pub static PRINT_TARGET: &str = "iggy::cmd::output";
 #[async_trait]
 pub trait CliCommand {
     fn explain(&self) -> String;
+    fn login_required(&self) -> bool {
+        true
+    }
     async fn execute_cmd(&mut self, client: &dyn Client) -> Result<(), Error>;
 }

--- a/iggy/src/cmd/system/ping.rs
+++ b/iggy/src/cmd/system/ping.rs
@@ -94,6 +94,10 @@ impl CliCommand for PingCmd {
         "ping command".to_owned()
     }
 
+    fn login_required(&self) -> bool {
+        false
+    }
+
     async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
         let print_width = (self.count.ilog10() + 1) as usize;
         let mut ping_stats = PingStats::new();


### PR DESCRIPTION
Ping command usage is allowed without login to iggy server. Extending CliCommand trait with additional method which controls whether command needs server login and making adaptations in IggyCredentials to support object creation with and without mandatory login.