### PR TITLE
Add integration tests to iggy-cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-dropper"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f04ec9ce0e813d22c058bfc87f60d855f30d37c2108df1096c29b3058a9184b"
+dependencies = [
+ "async-dropper-derive",
+ "async-dropper-simple",
+ "async-trait",
+ "futures",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-derive"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e2309f4a0c0c9bfe4313eba29f4d0caccc86da995d1430c6cfe3c55bf1fb224"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+ "tokio",
+]
+
+[[package]]
+name = "async-dropper-simple"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec03cf9c2d591f1b394223edfa657cff3f8f2b163c30ba6ff00645a58c024b95"
+dependencies = [
+ "async-trait",
+ "futures",
+ "rustc_version",
+ "tokio",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,15 +1236,21 @@ name = "iggy-cmd"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "assert_cmd",
+ "async-dropper",
  "async-trait",
  "clap",
  "iggy",
+ "libc",
  "passterm",
+ "predicates",
+ "serial_test",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1267,9 +1310,9 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -1770,9 +1813,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "6dfc28575c2e3f19cb3c73b93af36460ae898d426eba6fc15b9bd2a5220758a0"
 dependencies = [
  "anstyle",
  "difflib",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -17,6 +17,14 @@ tracing-subscriber = { version = "0.3.17" }
 tracing-appender = "0.2.2"
 passterm = "2.0.1"
 
+[dev-dependencies]
+uuid = { version = "1.3.3", features = ["v4", "fast-rng", "zerocopy"] }
+assert_cmd = "2.0.12"
+predicates = "3.0.3"
+libc = "0.2.147"
+serial_test = "2.0.0"
+async-dropper = { version = "0.2.3", features = ["tokio"] }
+
 [[bin]]
 name = "iggy"
 path = "src/main.rs"

--- a/cmd/tests/common/command.rs
+++ b/cmd/tests/common/command.rs
@@ -1,0 +1,59 @@
+use iggy::users::defaults::{DEFAULT_ROOT_PASSWORD, DEFAULT_ROOT_USERNAME};
+use std::collections::HashMap;
+
+pub(crate) struct IggyCmdCommand {
+    opts: Vec<String>,
+    args: Vec<String>,
+    env: HashMap<String, String>,
+}
+
+impl IggyCmdCommand {
+    pub(crate) fn new() -> Self {
+        Self {
+            opts: vec![],
+            args: vec![],
+            env: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn opt(mut self, arg: impl Into<String>) -> Self {
+        self.opts.push(arg.into());
+        self
+    }
+
+    pub(crate) fn opts(mut self, opts: Vec<impl Into<String>>) -> Self {
+        self.opts.append(
+            opts.into_iter()
+                .map(|a| a.into())
+                .collect::<Vec<_>>()
+                .as_mut(),
+        );
+        self
+    }
+
+    pub(crate) fn arg(mut self, arg: impl Into<String>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    pub(crate) fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env.insert(key.into(), value.into());
+        self
+    }
+
+    pub(crate) fn with_credentials(self) -> Self {
+        self.env("IGGY_USERNAME", DEFAULT_ROOT_USERNAME)
+            .env("IGGY_PASSWORD", DEFAULT_ROOT_PASSWORD)
+    }
+
+    pub(crate) fn get_opts_and_args(&self) -> Vec<String> {
+        let mut cmd = vec![];
+        cmd.append(&mut self.opts.clone());
+        cmd.append(&mut self.args.clone());
+        cmd
+    }
+
+    pub(crate) fn get_env(&self) -> HashMap<String, String> {
+        self.env.clone()
+    }
+}

--- a/cmd/tests/common/mod.rs
+++ b/cmd/tests/common/mod.rs
@@ -1,0 +1,106 @@
+pub(crate) mod command;
+pub(crate) mod server;
+
+pub(crate) use crate::common::command::IggyCmdCommand;
+use crate::common::server::TestServer;
+use assert_cmd::assert::{Assert, OutputAssertExt};
+use assert_cmd::prelude::CommandCargoExt;
+use async_dropper::simple::AsyncDrop;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::client::{SystemClient, UserClient};
+use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::system::ping::Ping;
+use iggy::tcp::client::TcpClient;
+use iggy::tcp::config::TcpClientConfig;
+use iggy::users::defaults::*;
+use iggy::users::login_user::LoginUser;
+use iggy::users::logout_user::LogoutUser;
+use std::process::Command;
+use std::sync::Arc;
+
+#[async_trait]
+pub(crate) trait IggyCmdTestCase {
+    async fn prepare_server_state(&self, client: &dyn Client);
+    fn get_command(&self) -> IggyCmdCommand;
+    fn verify_command(&self, command_state: Assert);
+    async fn verify_server_state(&self, client: &dyn Client);
+}
+
+pub(crate) struct IggyCmdTest {
+    server: TestServer,
+    client: IggyClient,
+}
+
+impl IggyCmdTest {
+    pub(crate) fn new() -> Self {
+        let server = TestServer::default();
+        let client = Box::new(TcpClient::create(Arc::new(TcpClientConfig::default())).unwrap());
+        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+
+        Self { server, client }
+    }
+
+    pub(crate) async fn setup(&mut self) {
+        self.server.start();
+        self.client.connect().await.unwrap();
+
+        let ping_result = self.client.ping(&Ping {}).await;
+
+        assert!(ping_result.is_ok());
+
+        let identity_info = self
+            .client
+            .login_user(&LoginUser {
+                username: DEFAULT_ROOT_USERNAME.to_string(),
+                password: DEFAULT_ROOT_PASSWORD.to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(identity_info.user_id, 1);
+    }
+
+    pub(crate) async fn execute_test(&mut self, test_case: impl IggyCmdTestCase) {
+        // Prepare iggy server state before test
+        test_case.prepare_server_state(&self.client).await;
+        // Get iggy tool
+        let mut command = Command::cargo_bin("iggy").unwrap();
+        // Get command line arguments and environment variables from test case and execute command
+        let command_args = test_case.get_command();
+        // Set environment variables for the command
+        command.envs(command_args.get_env());
+
+        // When running action from github CI, binary needs to be started via QEMU.
+        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
+            let mut runner_command = Command::new(runner);
+            runner_command.arg(command.get_program().to_str().unwrap());
+            runner_command.envs(command_args.get_env());
+            command = runner_command;
+        };
+
+        // Execute test command
+        let assert = command.args(command_args.get_opts_and_args()).assert();
+        // Verify command output, exit code, etc in the test (if needed)
+        test_case.verify_command(assert);
+        // Verify iggy server state after the test
+        test_case.verify_server_state(&self.client).await;
+    }
+
+    pub(crate) async fn teardown(&mut self) {
+        let _ = self.client.logout_user(&LogoutUser {}).await;
+    }
+}
+
+impl Default for IggyCmdTest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AsyncDrop for IggyCmdTest {
+    async fn async_drop(&mut self) {
+        self.teardown().await;
+    }
+}

--- a/cmd/tests/common/server.rs
+++ b/cmd/tests/common/server.rs
@@ -1,0 +1,139 @@
+use assert_cmd::prelude::CommandCargoExt;
+use std::collections::HashMap;
+use std::fs;
+use std::process::{Child, Command, Stdio};
+use std::thread::{panicking, sleep};
+use std::time::Duration;
+use uuid::Uuid;
+
+const SYSTEM_PATH_ENV_VAR: &str = "IGGY_SYSTEM_PATH";
+
+pub struct TestServer {
+    files_path: String,
+    envs: Option<HashMap<String, String>>,
+    child_handle: Option<Child>,
+    stdout: String,
+    stderr: String,
+}
+
+impl TestServer {
+    pub fn new(envs: Option<HashMap<String, String>>) -> Self {
+        Self::create(TestServer::get_random_path(), envs)
+    }
+
+    pub fn create(files_path: String, envs: Option<HashMap<String, String>>) -> Self {
+        Self {
+            files_path,
+            envs,
+            child_handle: None,
+            stdout: String::new(),
+            stderr: String::new(),
+        }
+    }
+
+    pub fn start(&mut self) {
+        // Sleep before starting server - it takes some time for the OS to release the port
+        let iggy_ci_build = std::env::var("IGGY_CI_BUILD").is_ok();
+        let duration = if iggy_ci_build {
+            Duration::from_secs(5)
+        } else {
+            Duration::from_secs(1)
+        };
+        sleep(duration);
+
+        self.cleanup();
+        let files_path = self.files_path.clone();
+        let mut command = Command::cargo_bin("iggy-server").unwrap();
+        command.env(SYSTEM_PATH_ENV_VAR, files_path.clone());
+        if let Some(env) = &self.envs {
+            command.envs(env);
+        }
+
+        // When running action from github CI, binary needs to be started via QEMU.
+        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
+            let mut runner_command = Command::new(runner);
+            runner_command
+                .arg(command.get_program().to_str().unwrap())
+                .env(SYSTEM_PATH_ENV_VAR, files_path);
+            if let Some(env) = &self.envs {
+                runner_command.envs(env);
+            }
+            command = runner_command;
+        };
+
+        // By default, server all logs are redirected to local variable
+        // and dumped to stderr when test fails. With IGGY_TEST_VERBOSE=1
+        // logs are dumped to stdout during test execution.
+        if std::env::var("IGGY_TEST_VERBOSE").is_err() {
+            command.stdout(Stdio::piped());
+            command.stderr(Stdio::piped());
+        }
+
+        self.child_handle = Some(command.spawn().unwrap());
+
+        // Sleep after starting server - it needs some time to bind to given port and start listening
+        let duration = if cfg!(any(
+            target = "aarch64-unknown-linux-musl",
+            target = "arm-unknown-linux-musleabi"
+        )) {
+            Duration::from_secs(40)
+        } else if iggy_ci_build {
+            Duration::from_secs(5)
+        } else {
+            Duration::from_secs(1)
+        };
+        sleep(duration);
+    }
+
+    pub fn stop(&mut self) {
+        if let Some(mut child_handle) = self.child_handle.take() {
+            #[cfg(unix)]
+            unsafe {
+                use libc::kill;
+                use libc::SIGTERM;
+                kill(child_handle.id() as libc::pid_t, SIGTERM);
+            }
+
+            #[cfg(not(unix))]
+            child_handle.kill().unwrap();
+
+            if let Ok(output) = child_handle.wait_with_output() {
+                self.stdout
+                    .push_str(String::from_utf8_lossy(&output.stdout).to_string().as_str());
+                self.stderr
+                    .push_str(String::from_utf8_lossy(&output.stderr).to_string().as_str());
+            }
+        }
+        self.cleanup();
+    }
+
+    fn cleanup(&self) {
+        if fs::metadata(&self.files_path).is_ok() {
+            fs::remove_dir_all(&self.files_path).unwrap();
+        }
+    }
+
+    pub fn get_random_path() -> String {
+        format!("local_data_{}", Uuid::new_v4().to_u128_le())
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        self.stop();
+        if panicking() {
+            if !self.stdout.is_empty() {
+                eprintln!("Iggy server stdout:\n{}", self.stdout);
+            }
+            if !self.stderr.is_empty() {
+                eprintln!("Iggy server stderr:\n{}", self.stderr);
+            }
+        }
+    }
+}
+
+impl Default for TestServer {
+    fn default() -> Self {
+        TestServer::new(None)
+    }
+}

--- a/cmd/tests/common/tcp.rs
+++ b/cmd/tests/common/tcp.rs
@@ -1,0 +1,21 @@
+use crate::iggy_tests::common::ClientFactory;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::tcp::client::TcpClient;
+use iggy::tcp::config::TcpClientConfig;
+use std::sync::Arc;
+
+#[derive(Debug, Copy, Clone)]
+pub struct TcpClientFactory {}
+
+#[async_trait]
+impl ClientFactory for TcpClientFactory {
+    async fn create_client(&self) -> Box<dyn Client> {
+        let mut client = TcpClient::create(Arc::new(TcpClientConfig::default())).unwrap();
+        client.connect().await.unwrap();
+        Box::new(client)
+    }
+}
+
+unsafe impl Send for TcpClientFactory {}
+unsafe impl Sync for TcpClientFactory {}

--- a/cmd/tests/general/mod.rs
+++ b/cmd/tests/general/mod.rs
@@ -1,0 +1,2 @@
+mod test_missing_credentials;
+mod test_quiet_mode;

--- a/cmd/tests/general/test_missing_credentials.rs
+++ b/cmd/tests/general/test_missing_credentials.rs
@@ -1,0 +1,36 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use predicates::str::diff;
+use serial_test::serial;
+
+struct TestNoCredentialsCmd {}
+
+#[async_trait]
+impl IggyCmdTestCase for TestNoCredentialsCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new().arg("me")
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .failure()
+            .stderr(diff(
+                "Error: CommandError(Iggy command line tool error\n\nCaused by:\n    Missing iggy server credentials)\n",
+            ));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_missing_credentials() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestNoCredentialsCmd {}).await;
+}

--- a/cmd/tests/general/test_quiet_mode.rs
+++ b/cmd/tests/general/test_quiet_mode.rs
@@ -1,0 +1,32 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use predicates::str::diff;
+use serial_test::serial;
+
+struct TestQuietModCmd {}
+
+#[async_trait]
+impl IggyCmdTestCase for TestQuietModCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new().arg("ping").opt("-q")
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state.success().stdout(diff(""));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_quiet_mode() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestQuietModCmd {}).await;
+}

--- a/cmd/tests/mod.rs
+++ b/cmd/tests/mod.rs
@@ -1,0 +1,3 @@
+mod common;
+mod general;
+mod system;

--- a/cmd/tests/system/mod.rs
+++ b/cmd/tests/system/mod.rs
@@ -1,0 +1,3 @@
+mod test_me_command;
+mod test_ping_command;
+mod test_stats_command;

--- a/cmd/tests/system/test_me_command.rs
+++ b/cmd/tests/system/test_me_command.rs
@@ -1,0 +1,103 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use predicates::str::{contains, starts_with};
+use serial_test::serial;
+use std::fmt::Display;
+
+#[derive(Debug)]
+enum Protocol {
+    Default,
+    Tcp,
+    Quic,
+}
+
+impl Protocol {
+    fn as_arg(&self) -> Vec<&str> {
+        match self {
+            Self::Default => vec![],
+            Self::Tcp => vec!["--transport", "tcp"],
+            Self::Quic => vec!["--transport", "quic"],
+        }
+    }
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Self::Default
+    }
+}
+
+impl Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Default => write!(f, "TCP"),
+            Self::Tcp => write!(f, "TCP"),
+            Self::Quic => write!(f, "QUIC"),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct TestMeCmd {
+    protocol: Protocol,
+}
+
+impl TestMeCmd {
+    fn new(protocol: Protocol) -> Self {
+        Self { protocol }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestMeCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .with_credentials()
+            .opts(self.protocol.as_arg())
+            .arg("me")
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with("Executing me command\n"))
+            .stdout(contains(format!("Transport | {}", self.protocol)));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_me_command() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestMeCmd::default()).await;
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_me_command_transport_tcp() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestMeCmd::new(Protocol::Tcp))
+        .await;
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_me_command_transport_quic() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestMeCmd::new(Protocol::Quic))
+        .await;
+}

--- a/cmd/tests/system/test_ping_command.rs
+++ b/cmd/tests/system/test_ping_command.rs
@@ -1,0 +1,57 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use predicates::str::{contains, starts_with};
+use serial_test::serial;
+
+struct TestPingCmd {
+    count: usize,
+}
+
+impl Default for TestPingCmd {
+    fn default() -> Self {
+        Self { count: 3 }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestPingCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("ping")
+            .arg("-c")
+            .arg(format!("{}", self.count))
+    }
+
+    // Executing ping command
+    // Ping sequence id:  1 time: 0.39 ms
+    // Ping sequence id:  2 time: 0.69 ms
+    // Ping sequence id:  3 time: 0.73 ms
+
+    // Ping statistics for 3 ping commands
+    // min/avg/max77/mdev = 0.393/0.618/0.746/0.116 ms
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with("Executing ping command\n"))
+            .stdout(contains(format!(
+                "Ping statistics for {} ping commands",
+                self.count
+            )));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_ping_command() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestPingCmd::default()).await;
+}

--- a/cmd/tests/system/test_stats_command.rs
+++ b/cmd/tests/system/test_stats_command.rs
@@ -1,0 +1,63 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::streams::create_stream::CreateStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::{contains, starts_with};
+use serial_test::serial;
+
+struct TestStatsCmd {}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStatsCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let stream_id = Identifier::from_str_value("logs").unwrap();
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: 1,
+                name: stream_id.as_string(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                topic_id: 1,
+                stream_id,
+                partitions_count: 5,
+                message_expiry: None,
+                name: String::from("topic"),
+            })
+            .await;
+        assert!(topic.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new().arg("stats").with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with("Executing stats command\n"))
+            .stdout(contains("Streams Count            | 1"))
+            .stdout(contains("Topics Count             | 1"))
+            .stdout(contains("Partitions Count         | 5"))
+            .stdout(contains("Segments Count           | 5"))
+            .stdout(contains("Message Count            | 0"))
+            .stdout(contains("Clients Count            | 2")) // 2 clients are connected during test
+            .stdout(contains("Consumer Groups Count    | 0"));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn test_stats_command() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestStatsCmd {}).await;
+}

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -15,8 +15,8 @@ clap = { version = "4.1.11", features = ["derive"] }
 rand = "0.8.5"
 rcgen = "0.11.1"
 rustls = { version = "0.21.1", features = ["dangerous_configuration", "quic"] }
-tracing = { version = "0.1.37"}
-tracing-subscriber = {version = "0.3.16"}
+tracing = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.16" }
 thiserror = "1.0.40"
 tokio = { version = "1.28.2", features = ["full"] }
 tokio-rustls = "0.24.0"


### PR DESCRIPTION
Add framework for building tests for iggy-cmd using same logic as in tests for iggy-server where server instance is started with supporting iggy tcp client for test setup and teardown. Adding trait for single test case implementation and logic to execute such tests. Add some basic tests for
- general functionality - quiet mode, missing credentials
- system commands - me, ping, stats