### PR TITLE
Keep mut child handle in iggy-cmd tests

### DIFF
--- a/cmd/tests/common/server.rs
+++ b/cmd/tests/common/server.rs
@@ -86,6 +86,7 @@ impl TestServer {
     }
 
     pub fn stop(&mut self) {
+        #[allow(unused_mut)]
         if let Some(mut child_handle) = self.child_handle.take() {
             #[cfg(unix)]
             unsafe {


### PR DESCRIPTION
mut is not needed by Linux but due to usage of child_handle.kill() only for Windows handle must stay mutable.