### PR TITLE
Add integration tests for stream commands

### DIFF
--- a/cmd/tests/common/command.rs
+++ b/cmd/tests/common/command.rs
@@ -36,6 +36,16 @@ impl IggyCmdCommand {
         self
     }
 
+    pub(crate) fn args(mut self, args: Vec<impl Into<String>>) -> Self {
+        self.args.append(
+            args.into_iter()
+                .map(|a| a.into())
+                .collect::<Vec<_>>()
+                .as_mut(),
+        );
+        self
+    }
+
     pub(crate) fn env(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.env.insert(key.into(), value.into());
         self

--- a/cmd/tests/common/mod.rs
+++ b/cmd/tests/common/mod.rs
@@ -62,6 +62,11 @@ impl IggyCmdTest {
     }
 
     pub(crate) async fn execute_test(&mut self, test_case: impl IggyCmdTestCase) {
+        // Make sure server is started
+        assert!(
+            self.server.is_started(),
+            "Server is not running, make sure it has been started with IggyCmdTest::setup()"
+        );
         // Prepare iggy server state before test
         test_case.prepare_server_state(&self.client).await;
         // Get iggy tool

--- a/cmd/tests/common/mod.rs
+++ b/cmd/tests/common/mod.rs
@@ -19,6 +19,11 @@ use iggy::users::logout_user::LogoutUser;
 use std::process::Command;
 use std::sync::Arc;
 
+pub(crate) enum TestStreamId {
+    Numeric,
+    Named,
+}
+
 #[async_trait]
 pub(crate) trait IggyCmdTestCase {
     async fn prepare_server_state(&self, client: &dyn Client);
@@ -83,7 +88,6 @@ impl IggyCmdTest {
             runner_command.envs(command_args.get_env());
             command = runner_command;
         };
-
         // Execute test command
         let assert = command.args(command_args.get_opts_and_args()).assert();
         // Verify command output, exit code, etc in the test (if needed)

--- a/cmd/tests/common/server.rs
+++ b/cmd/tests/common/server.rs
@@ -108,6 +108,10 @@ impl TestServer {
         self.cleanup();
     }
 
+    pub(crate) fn is_started(&self) -> bool {
+        self.child_handle.is_some()
+    }
+
     fn cleanup(&self) {
         if fs::metadata(&self.files_path).is_ok() {
             fs::remove_dir_all(&self.files_path).unwrap();

--- a/cmd/tests/general/test_missing_credentials.rs
+++ b/cmd/tests/general/test_missing_credentials.rs
@@ -28,7 +28,7 @@ impl IggyCmdTestCase for TestNoCredentialsCmd {
 
 #[tokio::test]
 #[serial]
-pub async fn test_missing_credentials() {
+pub async fn should_fail_with_error_message() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;

--- a/cmd/tests/general/test_quiet_mode.rs
+++ b/cmd/tests/general/test_quiet_mode.rs
@@ -24,7 +24,7 @@ impl IggyCmdTestCase for TestQuietModCmd {
 
 #[tokio::test]
 #[serial]
-pub async fn test_quiet_mode() {
+pub async fn should_be_no_output() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;

--- a/cmd/tests/mod.rs
+++ b/cmd/tests/mod.rs
@@ -1,3 +1,4 @@
 mod common;
 mod general;
+mod stream;
 mod system;

--- a/cmd/tests/stream/mod.rs
+++ b/cmd/tests/stream/mod.rs
@@ -1,0 +1,5 @@
+mod test_stream_create_command;
+mod test_stream_delete_command;
+mod test_stream_get_command;
+mod test_stream_list_command;
+mod test_stream_update_command;

--- a/cmd/tests/stream/test_stream_create_command.rs
+++ b/cmd/tests/stream/test_stream_create_command.rs
@@ -1,0 +1,65 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::streams::get_stream::GetStream;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::serial;
+
+struct TestStreamCreateCmd {
+    stream_id: u32,
+    name: String,
+}
+
+impl TestStreamCreateCmd {
+    fn new(stream_id: u32, name: String) -> Self {
+        Self { stream_id, name }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        vec![format!("{}", self.stream_id), self.name.clone()]
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamCreateCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("create")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(diff(format!("Executing create stream with ID: {} and name: {}\nStream with ID: {} and name: {} created\n", self.stream_id, self.name, self.stream_id, self.name)));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .get_stream(&GetStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+        let stream = stream.unwrap();
+        assert_eq!(stream.name, self.name);
+        assert_eq!(stream.id, self.stream_id);
+    }
+}
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let stream_id = 123;
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamCreateCmd::new(stream_id, String::from("main")))
+        .await;
+}

--- a/cmd/tests/stream/test_stream_delete_command.rs
+++ b/cmd/tests/stream/test_stream_delete_command.rs
@@ -1,0 +1,105 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::get_stream::GetStream;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::serial;
+
+enum TestStreamId {
+    Numeric,
+    Named,
+}
+
+struct TestStreamUpdateCmd {
+    stream_id: u32,
+    name: String,
+    new_name: String,
+    using_identifier: TestStreamId,
+}
+
+impl TestStreamUpdateCmd {
+    fn new(stream_id: u32, name: String, new_name: String, using_identifier: TestStreamId) -> Self {
+        Self {
+            stream_id,
+            name,
+            new_name,
+            using_identifier,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        match self.using_identifier {
+            TestStreamId::Named => vec![self.name.clone(), self.new_name.clone()],
+            TestStreamId::Numeric => {
+                vec![format!("{}", self.stream_id), self.new_name.clone()]
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamUpdateCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("update")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let message = match self.using_identifier {
+            TestStreamId::Named => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.name, self.new_name, self.name, self.new_name),
+            TestStreamId::Numeric => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.stream_id, self.new_name, self.stream_id, self.new_name),
+        };
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .get_stream(&GetStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+        let stream = stream.unwrap();
+        assert_eq!(stream.name, self.new_name);
+    }
+}
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamUpdateCmd::new(
+            1,
+            String::from("testing"),
+            String::from("development"),
+            TestStreamId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamUpdateCmd::new(
+            2,
+            String::from("production"),
+            String::from("prototype"),
+            TestStreamId::Named,
+        ))
+        .await;
+}

--- a/cmd/tests/stream/test_stream_get_command.rs
+++ b/cmd/tests/stream/test_stream_get_command.rs
@@ -1,0 +1,94 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::streams::create_stream::CreateStream;
+use predicates::str::{contains, starts_with};
+use serial_test::serial;
+
+struct TestStreamGetCmd {
+    stream_id: u32,
+    name: String,
+    using_identifier: TestStreamId,
+}
+
+impl TestStreamGetCmd {
+    fn new(stream_id: u32, name: String, using_identifier: TestStreamId) -> Self {
+        Self {
+            stream_id,
+            name,
+            using_identifier,
+        }
+    }
+
+    fn to_arg(&self) -> String {
+        match self.using_identifier {
+            TestStreamId::Named => self.name.clone(),
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamGetCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("get")
+            .arg(self.to_arg())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let start_message = match self.using_identifier {
+            TestStreamId::Named => format!("Executing get stream with ID: {}\n", self.name.clone()),
+            TestStreamId::Numeric => format!("Executing get stream with ID: {}\n", self.stream_id),
+        };
+
+        command_state
+            .success()
+            .stdout(starts_with(start_message))
+            .stdout(contains(format!(
+                "Stream ID            | {}",
+                self.stream_id
+            )))
+            .stdout(contains(format!("Stream name          | {}", self.name)))
+            .stdout(contains("Stream size          | 0"))
+            .stdout(contains("Stream message count | 0"))
+            .stdout(contains("Stream topics count  | 0"));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamGetCmd::new(
+            1,
+            String::from("production"),
+            TestStreamId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamGetCmd::new(
+            2,
+            String::from("testing"),
+            TestStreamId::Numeric,
+        ))
+        .await;
+}

--- a/cmd/tests/stream/test_stream_list_command.rs
+++ b/cmd/tests/stream/test_stream_list_command.rs
@@ -1,0 +1,117 @@
+use std::fmt::{Display, Formatter, Result};
+
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::streams::create_stream::CreateStream;
+use predicates::str::{contains, starts_with};
+use serial_test::serial;
+
+enum OutputFormat {
+    Default,
+    List,
+    Table,
+}
+
+impl Display for OutputFormat {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        match self {
+            Self::Default => write!(f, "table"),
+            Self::List => write!(f, "list"),
+            Self::Table => write!(f, "table"),
+        }
+    }
+}
+
+impl OutputFormat {
+    fn to_args(&self) -> Vec<&str> {
+        match self {
+            Self::Default => vec![],
+            Self::List => vec!["--list-mode", "list"],
+            Self::Table => vec!["--list-mode", "table"],
+        }
+    }
+}
+
+struct TestStreamListCmd {
+    stream_id: u32,
+    name: String,
+    output: OutputFormat,
+}
+
+impl TestStreamListCmd {
+    fn new(stream_id: u32, name: String, output: OutputFormat) -> Self {
+        Self {
+            stream_id,
+            name,
+            output,
+        }
+    }
+
+    fn to_args(&self) -> Vec<&str> {
+        self.output.to_args()
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamListCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("list")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with(format!(
+                "Executing list streams in {} mode",
+                self.output
+            )))
+            .stdout(contains(self.name.clone()));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamListCmd::new(
+            1,
+            String::from("prod"),
+            OutputFormat::Default,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamListCmd::new(
+            2,
+            String::from("testing"),
+            OutputFormat::List,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamListCmd::new(
+            3,
+            String::from("misc"),
+            OutputFormat::Table,
+        ))
+        .await;
+}

--- a/cmd/tests/stream/test_stream_update_command.rs
+++ b/cmd/tests/stream/test_stream_update_command.rs
@@ -1,0 +1,96 @@
+use crate::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::get_streams::GetStreams;
+use predicates::str::diff;
+use serial_test::serial;
+
+struct TestStreamDeleteCmd {
+    stream_id: u32,
+    name: String,
+    using_identifier: TestStreamId,
+}
+
+impl TestStreamDeleteCmd {
+    fn new(stream_id: u32, name: String, using_identifier: TestStreamId) -> Self {
+        Self {
+            stream_id,
+            name,
+            using_identifier,
+        }
+    }
+
+    fn to_arg(&self) -> String {
+        match self.using_identifier {
+            TestStreamId::Named => self.name.clone(),
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamDeleteCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("delete")
+            .arg(self.to_arg())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let message = match self.using_identifier {
+            TestStreamId::Named => format!(
+                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
+                self.name, self.name
+            ),
+            TestStreamId::Numeric => format!(
+                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
+                self.stream_id, self.stream_id
+            ),
+        };
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let streams = client.get_streams(&GetStreams {}).await;
+        assert!(streams.is_ok());
+        let streams = streams.unwrap();
+        assert_eq!(streams.len(), 0);
+    }
+}
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamDeleteCmd::new(
+            1,
+            String::from("testing"),
+            TestStreamId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamDeleteCmd::new(
+            2,
+            String::from("production"),
+            TestStreamId::Named,
+        ))
+        .await;
+}

--- a/cmd/tests/system/test_me_command.rs
+++ b/cmd/tests/system/test_me_command.rs
@@ -73,7 +73,7 @@ impl IggyCmdTestCase for TestMeCmd {
 
 #[tokio::test]
 #[serial]
-pub async fn test_me_command() {
+pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;
@@ -82,7 +82,7 @@ pub async fn test_me_command() {
 
 #[tokio::test]
 #[serial]
-pub async fn test_me_command_transport_tcp() {
+pub async fn should_be_successful_using_transport_tcp() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;
@@ -93,7 +93,7 @@ pub async fn test_me_command_transport_tcp() {
 
 #[tokio::test]
 #[serial]
-pub async fn test_me_command_transport_quic() {
+pub async fn should_be_successful_using_transport_quic() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;

--- a/cmd/tests/system/test_ping_command.rs
+++ b/cmd/tests/system/test_ping_command.rs
@@ -49,7 +49,7 @@ impl IggyCmdTestCase for TestPingCmd {
 
 #[tokio::test]
 #[serial]
-pub async fn test_ping_command() {
+pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;

--- a/cmd/tests/system/test_stats_command.rs
+++ b/cmd/tests/system/test_stats_command.rs
@@ -55,7 +55,7 @@ impl IggyCmdTestCase for TestStatsCmd {
 
 #[tokio::test]
 #[serial]
-pub async fn test_stats_command() {
+pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;

--- a/iggy/src/cmd/streams/update_stream.rs
+++ b/iggy/src/cmd/streams/update_stream.rs
@@ -39,7 +39,7 @@ impl CliCommand for UpdateStreamCmd {
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
-            "Stream with ID: {} updated name: {} ",
+            "Stream with ID: {} updated name: {}",
             self.update_stream.stream_id, self.update_stream.name
         );
 


### PR DESCRIPTION
Add integration tests for stream commands. This partially implements #146.
Rename existing test names to more meaningful. Add check in test framework
if iggy server is running.

