### PR TITLE
Improve TestServer, fix topic and stream update, make tests parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ version = "0.0.103"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-dropper",
  "async-trait",
  "base64 0.21.3",
  "byte-unit",
@@ -1332,10 +1333,10 @@ name = "integration"
 version = "0.0.1"
 dependencies = [
  "assert_cmd",
- "async-dropper",
  "async-trait",
  "byte-unit",
  "bytes",
+ "futures",
  "humantime",
  "iggy",
  "libc",

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -42,6 +42,7 @@ anyhow = "1.0.75"
 comfy-table = { version = "7.0.1", optional = true }
 humantime = { version = "2.1.0", optional = true }
 byte-unit = { version = "4.0.19", optional = true }
+async-dropper = { version = "0.2.3", features = ["tokio"] }
 
 [build-dependencies]
 rmp-serde = "1.1.2"

--- a/iggy/src/clients/client.rs
+++ b/iggy/src/clients/client.rs
@@ -59,6 +59,7 @@ use crate::users::logout_user::LogoutUser;
 use crate::users::update_permissions::UpdatePermissions;
 use crate::users::update_user::UpdateUser;
 use crate::utils::crypto::Encryptor;
+use async_dropper::simple::AsyncDrop;
 use async_trait::async_trait;
 use bytes::Bytes;
 use flume::{Receiver, Sender};
@@ -759,5 +760,12 @@ impl ConsumerGroupClient for IggyClient {
 
     async fn leave_consumer_group(&self, command: &LeaveConsumerGroup) -> Result<(), Error> {
         self.client.read().await.leave_consumer_group(command).await
+    }
+}
+
+#[async_trait]
+impl AsyncDrop for IggyClient {
+    async fn async_drop(&mut self) {
+        let _ = self.client.read().await.logout_user(&LogoutUser {}).await;
     }
 }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -11,10 +11,10 @@ predicates = "3.0.3"
 libc = "0.2.147"
 serial_test = "2.0.0"
 uuid = { version = "1.3.3", features = ["v4", "fast-rng", "zerocopy"] }
-async-dropper = { version = "0.2.3", features = ["tokio"] }
 tokio = { version = "1.28.2", features = ["full"] }
 bytes = "1.4.0"
 async-trait = "0.1.68"
 sled = "0.34.7"
 byte-unit = "4.0.19"
 humantime = "2.1.0"
+futures = "0.3.28"

--- a/integration/tests/cmd/general/test_missing_credentials.rs
+++ b/integration/tests/cmd/general/test_missing_credentials.rs
@@ -3,7 +3,7 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestNoCredentialsCmd {}
 
@@ -27,7 +27,7 @@ impl IggyCmdTestCase for TestNoCredentialsCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_fail_with_error_message() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/general/test_quiet_mode.rs
+++ b/integration/tests/cmd/general/test_quiet_mode.rs
@@ -3,7 +3,7 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestQuietModCmd {}
 
@@ -23,7 +23,7 @@ impl IggyCmdTestCase for TestQuietModCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_no_output() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/stream/test_stream_create_command.rs
+++ b/integration/tests/cmd/stream/test_stream_create_command.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use iggy::streams::get_stream::GetStream;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestStreamCreateCmd {
     stream_id: u32,
@@ -53,7 +53,7 @@ impl IggyCmdTestCase for TestStreamCreateCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let stream_id = 123;
     let mut iggy_cmd_test = IggyCmdTest::default();

--- a/integration/tests/cmd/stream/test_stream_delete_command.rs
+++ b/integration/tests/cmd/stream/test_stream_delete_command.rs
@@ -1,46 +1,37 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
+use iggy::client::Client;
 use iggy::streams::create_stream::CreateStream;
-use iggy::streams::get_stream::GetStream;
-use iggy::{client::Client, identifier::Identifier};
+use iggy::streams::get_streams::GetStreams;
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
-enum TestStreamId {
-    Numeric,
-    Named,
-}
-
-struct TestStreamUpdateCmd {
+struct TestStreamDeleteCmd {
     stream_id: u32,
     name: String,
-    new_name: String,
     using_identifier: TestStreamId,
 }
 
-impl TestStreamUpdateCmd {
-    fn new(stream_id: u32, name: String, new_name: String, using_identifier: TestStreamId) -> Self {
+impl TestStreamDeleteCmd {
+    fn new(stream_id: u32, name: String, using_identifier: TestStreamId) -> Self {
         Self {
             stream_id,
             name,
-            new_name,
             using_identifier,
         }
     }
 
-    fn to_args(&self) -> Vec<String> {
+    fn to_arg(&self) -> String {
         match self.using_identifier {
-            TestStreamId::Named => vec![self.name.clone(), self.new_name.clone()],
-            TestStreamId::Numeric => {
-                vec![format!("{}", self.stream_id), self.new_name.clone()]
-            }
+            TestStreamId::Named => self.name.clone(),
+            TestStreamId::Numeric => format!("{}", self.stream_id),
         }
     }
 }
 
 #[async_trait]
-impl IggyCmdTestCase for TestStreamUpdateCmd {
+impl IggyCmdTestCase for TestStreamDeleteCmd {
     async fn prepare_server_state(&self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
@@ -54,51 +45,51 @@ impl IggyCmdTestCase for TestStreamUpdateCmd {
     fn get_command(&self) -> IggyCmdCommand {
         IggyCmdCommand::new()
             .arg("stream")
-            .arg("update")
-            .args(self.to_args())
+            .arg("delete")
+            .arg(self.to_arg())
             .with_credentials()
     }
 
     fn verify_command(&self, command_state: Assert) {
         let message = match self.using_identifier {
-            TestStreamId::Named => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.name, self.new_name, self.name, self.new_name),
-            TestStreamId::Numeric => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.stream_id, self.new_name, self.stream_id, self.new_name),
+            TestStreamId::Named => format!(
+                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
+                self.name, self.name
+            ),
+            TestStreamId::Numeric => format!(
+                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
+                self.stream_id, self.stream_id
+            ),
         };
 
         command_state.success().stdout(diff(message));
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {
-        let stream = client
-            .get_stream(&GetStream {
-                stream_id: Identifier::numeric(self.stream_id).unwrap(),
-            })
-            .await;
-        assert!(stream.is_ok());
-        let stream = stream.unwrap();
-        assert_eq!(stream.name, self.new_name);
+        let streams = client.get_streams(&GetStreams {}).await;
+        assert!(streams.is_ok());
+        let streams = streams.unwrap();
+        assert_eq!(streams.len(), 0);
     }
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;
     iggy_cmd_test
-        .execute_test(TestStreamUpdateCmd::new(
+        .execute_test(TestStreamDeleteCmd::new(
             1,
             String::from("testing"),
-            String::from("development"),
             TestStreamId::Numeric,
         ))
         .await;
     iggy_cmd_test
-        .execute_test(TestStreamUpdateCmd::new(
+        .execute_test(TestStreamDeleteCmd::new(
             2,
             String::from("production"),
-            String::from("prototype"),
             TestStreamId::Named,
         ))
         .await;

--- a/integration/tests/cmd/stream/test_stream_get_command.rs
+++ b/integration/tests/cmd/stream/test_stream_get_command.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use iggy::client::Client;
 use iggy::streams::create_stream::CreateStream;
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestStreamGetCmd {
     stream_id: u32,
@@ -72,7 +72,7 @@ impl IggyCmdTestCase for TestStreamGetCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/stream/test_stream_list_command.rs
+++ b/integration/tests/cmd/stream/test_stream_list_command.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use iggy::client::Client;
 use iggy::streams::create_stream::CreateStream;
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestStreamListCmd {
     stream_id: u32,
@@ -60,7 +60,7 @@ impl IggyCmdTestCase for TestStreamListCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/stream/test_stream_update_command.rs
+++ b/integration/tests/cmd/stream/test_stream_update_command.rs
@@ -1,37 +1,46 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
-use iggy::client::Client;
 use iggy::streams::create_stream::CreateStream;
-use iggy::streams::get_streams::GetStreams;
+use iggy::streams::get_stream::GetStream;
+use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
-struct TestStreamDeleteCmd {
+enum TestStreamId {
+    Numeric,
+    Named,
+}
+
+struct TestStreamUpdateCmd {
     stream_id: u32,
     name: String,
+    new_name: String,
     using_identifier: TestStreamId,
 }
 
-impl TestStreamDeleteCmd {
-    fn new(stream_id: u32, name: String, using_identifier: TestStreamId) -> Self {
+impl TestStreamUpdateCmd {
+    fn new(stream_id: u32, name: String, new_name: String, using_identifier: TestStreamId) -> Self {
         Self {
             stream_id,
             name,
+            new_name,
             using_identifier,
         }
     }
 
-    fn to_arg(&self) -> String {
+    fn to_args(&self) -> Vec<String> {
         match self.using_identifier {
-            TestStreamId::Named => self.name.clone(),
-            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => vec![self.name.clone(), self.new_name.clone()],
+            TestStreamId::Numeric => {
+                vec![format!("{}", self.stream_id), self.new_name.clone()]
+            }
         }
     }
 }
 
 #[async_trait]
-impl IggyCmdTestCase for TestStreamDeleteCmd {
+impl IggyCmdTestCase for TestStreamUpdateCmd {
     async fn prepare_server_state(&self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
@@ -45,51 +54,51 @@ impl IggyCmdTestCase for TestStreamDeleteCmd {
     fn get_command(&self) -> IggyCmdCommand {
         IggyCmdCommand::new()
             .arg("stream")
-            .arg("delete")
-            .arg(self.to_arg())
+            .arg("update")
+            .args(self.to_args())
             .with_credentials()
     }
 
     fn verify_command(&self, command_state: Assert) {
         let message = match self.using_identifier {
-            TestStreamId::Named => format!(
-                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
-                self.name, self.name
-            ),
-            TestStreamId::Numeric => format!(
-                "Executing delete stream with ID: {}\nStream with ID: {} deleted\n",
-                self.stream_id, self.stream_id
-            ),
+            TestStreamId::Named => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.name, self.new_name, self.name, self.new_name),
+            TestStreamId::Numeric => format!("Executing update stream with ID: {} and name: {}\nStream with ID: {} updated name: {}\n", self.stream_id, self.new_name, self.stream_id, self.new_name),
         };
 
         command_state.success().stdout(diff(message));
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {
-        let streams = client.get_streams(&GetStreams {}).await;
-        assert!(streams.is_ok());
-        let streams = streams.unwrap();
-        assert_eq!(streams.len(), 0);
+        let stream = client
+            .get_stream(&GetStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+        let stream = stream.unwrap();
+        assert_eq!(stream.name, self.new_name);
     }
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;
     iggy_cmd_test
-        .execute_test(TestStreamDeleteCmd::new(
+        .execute_test(TestStreamUpdateCmd::new(
             1,
             String::from("testing"),
+            String::from("development"),
             TestStreamId::Numeric,
         ))
         .await;
     iggy_cmd_test
-        .execute_test(TestStreamDeleteCmd::new(
+        .execute_test(TestStreamUpdateCmd::new(
             2,
             String::from("production"),
+            String::from("prototype"),
             TestStreamId::Named,
         ))
         .await;

--- a/integration/tests/cmd/system/test_ping_command.rs
+++ b/integration/tests/cmd/system/test_ping_command.rs
@@ -3,7 +3,7 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestPingCmd {
     count: usize,
@@ -48,7 +48,7 @@ impl IggyCmdTestCase for TestPingCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/system/test_stats_command.rs
+++ b/integration/tests/cmd/system/test_stats_command.rs
@@ -5,7 +5,7 @@ use iggy::streams::create_stream::CreateStream;
 use iggy::topics::create_topic::CreateTopic;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestStatsCmd {}
 
@@ -54,7 +54,7 @@ impl IggyCmdTestCase for TestStatsCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/config_provider/mod.rs
+++ b/integration/tests/config_provider/mod.rs
@@ -1,15 +1,7 @@
+use crate::utils::file::{file_exists, get_root_path};
+use serial_test::serial;
 use server::configs::config_provider::{ConfigProvider, FileConfigProvider};
 use std::env;
-use std::path::{Path, PathBuf};
-
-fn file_exists(file_path: &str) -> bool {
-    Path::new(file_path).is_file()
-}
-
-fn get_root_path() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set!");
-    PathBuf::from(manifest_dir)
-}
 
 async fn scenario_parsing_from_file(extension: &str) {
     let mut config_path = get_root_path().join("../configs/server");
@@ -38,6 +30,9 @@ async fn validate_server_config_json_from_repository() {
     scenario_parsing_from_file("json").await;
 }
 
+// This test needs to be run in serial because it modifies the environment variables
+// which are shared, since all tests run in parallel by default.
+#[serial]
 #[tokio::test]
 async fn validate_custom_env_provider() {
     env::set_var("IGGY_SYSTEM_DATABASE_PATH", "awesome_database_path");

--- a/integration/tests/server/http_server.rs
+++ b/integration/tests/server/http_server.rs
@@ -1,12 +1,34 @@
 use crate::server::scenarios::{message_headers_scenario, system_scenario, user_scenario};
 use crate::utils::http_client::HttpClientFactory;
-use serial_test::serial;
+use crate::utils::test_server::TestServer;
+use serial_test::parallel;
 
 #[tokio::test]
-#[serial]
+#[parallel]
 async fn system_scenario_should_be_valid() {
-    let client_factory = HttpClientFactory {};
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_http_api_addr().unwrap();
+    let client_factory = HttpClientFactory { server_addr };
     system_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn user_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_http_api_addr().unwrap();
+    let client_factory = HttpClientFactory { server_addr };
     user_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn message_headers_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_http_api_addr().unwrap();
+    let client_factory = HttpClientFactory { server_addr };
     message_headers_scenario::run(&client_factory).await;
 }

--- a/integration/tests/server/quic_server.rs
+++ b/integration/tests/server/quic_server.rs
@@ -4,16 +4,65 @@ use crate::server::scenarios::{
     system_scenario, user_scenario,
 };
 use crate::utils::quic_client::QuicClientFactory;
-use serial_test::serial;
+use crate::utils::test_server::TestServer;
+use serial_test::parallel;
 
 #[tokio::test]
-#[serial]
-async fn system_and_consumer_group_scenarios_should_be_valid() {
-    let client_factory = QuicClientFactory {};
+#[parallel]
+async fn system_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     system_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn user_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     user_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn message_headers_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     message_headers_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_join_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     consumer_group_join_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_with_single_client_polling_messages_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     consumer_group_with_single_client_polling_messages_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_with_multiple_clients_polling_messages_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
     consumer_group_with_multiple_clients_polling_messages_scenario::run(&client_factory).await;
 }

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -1,4 +1,4 @@
-use crate::utils::test_server::{ClientFactory, TestServer};
+use crate::utils::test_server::{assert_clean_system, ClientFactory};
 use bytes::Bytes;
 use iggy::client::{
     ConsumerGroupClient, ConsumerOffsetClient, MessageClient, PartitionClient, StreamClient,
@@ -50,8 +50,6 @@ const CONSUMER_GROUP_NAME: &str = "test-consumer-group";
 const MESSAGES_COUNT: u32 = 1000;
 
 pub async fn run(client_factory: &dyn ClientFactory) {
-    let mut test_server = TestServer::default();
-    test_server.start();
     let client = client_factory.create_client().await;
     let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
 
@@ -665,7 +663,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 
     assert!(clients.len() <= 1);
 
-    test_server.stop();
+    assert_clean_system(&client).await;
 }
 
 fn assert_message(message: &iggy::models::messages::Message, offset: u64) {

--- a/integration/tests/server/scenarios/user_scenario.rs
+++ b/integration/tests/server/scenarios/user_scenario.rs
@@ -1,4 +1,4 @@
-use crate::utils::test_server::{ClientFactory, TestServer};
+use crate::utils::test_server::{assert_clean_system, ClientFactory};
 use iggy::client::{PersonalAccessTokenClient, SystemClient, UserClient};
 use iggy::clients::client::{IggyClient, IggyClientConfig};
 use iggy::identifier::Identifier;
@@ -21,8 +21,6 @@ use iggy::users::update_permissions::UpdatePermissions;
 use iggy::users::update_user::UpdateUser;
 
 pub async fn run(client_factory: &dyn ClientFactory) {
-    let mut test_server = TestServer::default();
-    test_server.start();
     let client = client_factory.create_client().await;
     let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
 
@@ -282,12 +280,12 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 
     assert!(delete_root_user.is_err());
 
+    assert_clean_system(&client).await;
+
     // 25. Logout
     client.logout_user(&LogoutUser {}).await.unwrap();
 
     // 26. Trying to perform any secured operation after logout should fail
     let get_users = client.get_users(&GetUsers {}).await;
     assert!(get_users.is_err());
-
-    test_server.stop();
 }

--- a/integration/tests/server/tcp_server.rs
+++ b/integration/tests/server/tcp_server.rs
@@ -4,16 +4,65 @@ use crate::server::scenarios::{
     system_scenario, user_scenario,
 };
 use crate::utils::tcp_client::TcpClientFactory;
-use serial_test::serial;
+use crate::utils::test_server::TestServer;
+use serial_test::parallel;
 
 #[tokio::test]
-#[serial]
-async fn system_and_consumer_group_scenarios_should_be_valid() {
-    let client_factory = TcpClientFactory {};
+#[parallel]
+async fn system_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     system_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn user_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     user_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn message_headers_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     message_headers_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_join_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     consumer_group_join_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_with_single_client_polling_messages_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     consumer_group_with_single_client_polling_messages_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn consumer_group_with_multiple_clients_polling_messages_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
     consumer_group_with_multiple_clients_polling_messages_scenario::run(&client_factory).await;
 }

--- a/integration/tests/utils/file.rs
+++ b/integration/tests/utils/file.rs
@@ -1,0 +1,10 @@
+use std::path::{Path, PathBuf};
+
+pub fn get_root_path() -> PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set!");
+    PathBuf::from(manifest_dir)
+}
+
+pub fn file_exists(file_path: &str) -> bool {
+    Path::new(file_path).is_file()
+}

--- a/integration/tests/utils/http_client.rs
+++ b/integration/tests/utils/http_client.rs
@@ -5,13 +5,19 @@ use iggy::http::client::HttpClient;
 use iggy::http::config::HttpClientConfig;
 use std::sync::Arc;
 
-#[derive(Debug, Copy, Clone)]
-pub struct HttpClientFactory {}
+#[derive(Debug, Clone)]
+pub struct HttpClientFactory {
+    pub server_addr: String,
+}
 
 #[async_trait]
 impl ClientFactory for HttpClientFactory {
     async fn create_client(&self) -> Box<dyn Client> {
-        let client = HttpClient::create(Arc::new(HttpClientConfig::default())).unwrap();
+        let config = HttpClientConfig {
+            api_url: format!("http://{}", self.server_addr.clone()),
+            ..HttpClientConfig::default()
+        };
+        let client = HttpClient::create(Arc::new(config)).unwrap();
         Box::new(client)
     }
 }

--- a/integration/tests/utils/mod.rs
+++ b/integration/tests/utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod file;
 pub mod http_client;
 pub mod quic_client;
 pub mod tcp_client;

--- a/integration/tests/utils/quic_client.rs
+++ b/integration/tests/utils/quic_client.rs
@@ -5,13 +5,19 @@ use iggy::quic::client::QuicClient;
 use iggy::quic::config::QuicClientConfig;
 use std::sync::Arc;
 
-#[derive(Debug, Copy, Clone)]
-pub struct QuicClientFactory {}
+#[derive(Debug, Clone)]
+pub struct QuicClientFactory {
+    pub server_addr: String,
+}
 
 #[async_trait]
 impl ClientFactory for QuicClientFactory {
     async fn create_client(&self) -> Box<dyn Client> {
-        let mut client = QuicClient::create(Arc::new(QuicClientConfig::default())).unwrap();
+        let config = QuicClientConfig {
+            server_address: self.server_addr.clone(),
+            ..QuicClientConfig::default()
+        };
+        let mut client = QuicClient::create(Arc::new(config)).unwrap();
         client.connect().await.unwrap();
         Box::new(client)
     }

--- a/integration/tests/utils/tcp_client.rs
+++ b/integration/tests/utils/tcp_client.rs
@@ -5,13 +5,19 @@ use iggy::tcp::client::TcpClient;
 use iggy::tcp::config::TcpClientConfig;
 use std::sync::Arc;
 
-#[derive(Debug, Copy, Clone)]
-pub struct TcpClientFactory {}
+#[derive(Debug, Clone)]
+pub struct TcpClientFactory {
+    pub server_addr: String,
+}
 
 #[async_trait]
 impl ClientFactory for TcpClientFactory {
     async fn create_client(&self) -> Box<dyn Client> {
-        let mut client = TcpClient::create(Arc::new(TcpClientConfig::default())).unwrap();
+        let config = TcpClientConfig {
+            server_address: self.server_addr.clone(),
+            ..TcpClientConfig::default()
+        };
+        let mut client = TcpClient::create(Arc::new(config)).unwrap();
         client.connect().await.unwrap();
         Box::new(client)
     }

--- a/integration/tests/utils/test_server.rs
+++ b/integration/tests/utils/test_server.rs
@@ -1,60 +1,90 @@
 use assert_cmd::prelude::CommandCargoExt;
 use async_trait::async_trait;
-use iggy::client::{Client, UserClient};
+use iggy::client::{Client, StreamClient, UserClient};
 use iggy::clients::client::IggyClient;
+use iggy::identifier::Identifier;
 use iggy::models::permissions::{GlobalPermissions, Permissions};
 use iggy::models::user_status::UserStatus::Active;
+use iggy::streams::get_streams::GetStreams;
 use iggy::users::create_user::CreateUser;
 use iggy::users::defaults::*;
+use iggy::users::delete_user::DeleteUser;
+use iggy::users::get_users::GetUsers;
 use iggy::users::login_user::LoginUser;
 use std::collections::HashMap;
-use std::fs;
-use std::process::{Child, Command, Stdio};
+use std::fmt::Display;
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream, UdpSocket};
+use std::path::PathBuf;
+use std::process::{Child, Command};
 use std::thread::{panicking, sleep};
 use std::time::Duration;
+use std::{fmt, fs};
 use uuid::Uuid;
 
 const SYSTEM_PATH_ENV_VAR: &str = "IGGY_SYSTEM_PATH";
 const USER_PASSWORD: &str = "secret";
+const MAX_PORT_WAIT_DURATION_S: u64 = 120;
+const SLEEP_INTERVAL_MS: u64 = 20;
 
 #[async_trait]
 pub trait ClientFactory: Sync + Send {
     async fn create_client(&self) -> Box<dyn Client>;
 }
 
+enum ServerProtocolAddr {
+    RawTcp(SocketAddr),
+    HttpTcp(SocketAddr),
+    QuicUdp(SocketAddr),
+}
+
+impl Display for ServerProtocolAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ServerProtocolAddr::RawTcp(addr) => write!(f, "RAW_TCP:{}", addr),
+            ServerProtocolAddr::HttpTcp(addr) => write!(f, "HTTP_TCP:{}", addr),
+            ServerProtocolAddr::QuicUdp(addr) => write!(f, "QUIC_UDP:{}", addr),
+        }
+    }
+}
+
 pub struct TestServer {
     files_path: String,
     envs: Option<HashMap<String, String>>,
     child_handle: Option<Child>,
-    stdout: String,
-    stderr: String,
+    server_addrs: Vec<ServerProtocolAddr>,
+    stdout_file_path: Option<PathBuf>,
+    stderr_file_path: Option<PathBuf>,
 }
 
 impl TestServer {
-    pub fn new(envs: Option<HashMap<String, String>>) -> Self {
-        Self::create(TestServer::get_random_path(), envs)
+    pub fn new(extra_envs: Option<HashMap<String, String>>) -> Self {
+        let mut envs = HashMap::new();
+        if let Some(extra) = extra_envs {
+            for (key, value) in extra {
+                envs.insert(key, value);
+            }
+        }
+
+        Self::create(TestServer::get_random_path(), Some(envs))
     }
 
     pub fn create(files_path: String, envs: Option<HashMap<String, String>>) -> Self {
+        let server_addrs = Self::get_free_addrs();
         Self {
             files_path,
             envs,
             child_handle: None,
-            stdout: String::new(),
-            stderr: String::new(),
+            server_addrs,
+            stdout_file_path: None,
+            stderr_file_path: None,
         }
     }
 
     pub fn start(&mut self) {
-        // Sleep before starting server - it takes some time for the OS to release the port
-        let iggy_ci_build = std::env::var("IGGY_CI_BUILD").is_ok();
-        let duration = if iggy_ci_build {
-            Duration::from_secs(5)
-        } else {
-            Duration::from_secs(1)
-        };
-        sleep(duration);
-
+        self.set_server_addrs_from_env();
+        self.wait_until_server_freed_ports();
         self.cleanup();
         let files_path = self.files_path.clone();
         let mut command = Command::cargo_bin("iggy-server").unwrap();
@@ -75,31 +105,21 @@ impl TestServer {
             command = runner_command;
         };
 
-        // By default, server all logs are redirected to local variable
+        // By default, server all logs are redirected to files,
         // and dumped to stderr when test fails. With IGGY_TEST_VERBOSE=1
         // logs are dumped to stdout during test execution.
         if std::env::var("IGGY_TEST_VERBOSE").is_err() {
-            command.stdout(Stdio::piped());
-            command.stderr(Stdio::piped());
+            command.stdout(self.get_stdout_file());
+            self.stdout_file_path = Some(fs::canonicalize(self.get_stdout_file_path()).unwrap());
+            command.stderr(self.get_stderr_file());
+            self.stderr_file_path = Some(fs::canonicalize(self.get_stderr_file_path()).unwrap());
         }
 
         self.child_handle = Some(command.spawn().unwrap());
-
-        // Sleep after starting server - it needs some time to bind to given port and start listening
-        let duration = if cfg!(any(
-            target = "aarch64-unknown-linux-musl",
-            target = "arm-unknown-linux-musleabi"
-        )) {
-            Duration::from_secs(40)
-        } else if iggy_ci_build {
-            Duration::from_secs(5)
-        } else {
-            Duration::from_secs(1)
-        };
-        sleep(duration);
+        self.wait_until_server_has_bound();
     }
 
-    pub fn stop(&mut self) {
+    fn stop(&mut self) {
         #[allow(unused_mut)]
         if let Some(mut child_handle) = self.child_handle.take() {
             #[cfg(unix)]
@@ -113,12 +133,30 @@ impl TestServer {
             child_handle.kill().unwrap();
 
             if let Ok(output) = child_handle.wait_with_output() {
-                self.stdout
-                    .push_str(String::from_utf8_lossy(&output.stdout).to_string().as_str());
-                self.stderr
-                    .push_str(String::from_utf8_lossy(&output.stderr).to_string().as_str());
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                if let Some(stderr_file_path) = &self.stderr_file_path {
+                    OpenOptions::new()
+                        .append(true)
+                        .create(true)
+                        .open(stderr_file_path)
+                        .unwrap()
+                        .write_all(stderr.as_bytes())
+                        .unwrap();
+                }
+
+                if let Some(stdout_file_path) = &self.stdout_file_path {
+                    OpenOptions::new()
+                        .append(true)
+                        .create(true)
+                        .open(stdout_file_path)
+                        .unwrap()
+                        .write_all(stdout.as_bytes())
+                        .unwrap();
+                }
             }
         }
+        self.wait_until_server_freed_ports();
         self.cleanup();
     }
 
@@ -132,20 +170,209 @@ impl TestServer {
         }
     }
 
+    fn get_free_addrs() -> Vec<ServerProtocolAddr> {
+        let tcp_port1 = Self::get_free_tcp_port();
+        let tcp_port2 = Self::get_free_tcp_port();
+        let udp_port = Self::get_free_udp_port();
+
+        vec![
+            ServerProtocolAddr::QuicUdp(SocketAddr::new(
+                Ipv4Addr::new(127, 0, 0, 1).into(),
+                udp_port,
+            )),
+            ServerProtocolAddr::RawTcp(SocketAddr::new(
+                Ipv4Addr::new(127, 0, 0, 1).into(),
+                tcp_port1,
+            )),
+            ServerProtocolAddr::HttpTcp(SocketAddr::new(
+                Ipv4Addr::new(127, 0, 0, 1).into(),
+                tcp_port2,
+            )),
+        ]
+    }
+
+    fn set_server_addrs_from_env(&mut self) {
+        for server_protocol_addr in &self.server_addrs {
+            match server_protocol_addr {
+                ServerProtocolAddr::RawTcp(addr) => {
+                    self.envs
+                        .as_mut()
+                        .unwrap()
+                        .insert("IGGY_TCP_ADDRESS".to_string(), addr.to_string());
+                }
+                ServerProtocolAddr::HttpTcp(addr) => {
+                    self.envs
+                        .as_mut()
+                        .unwrap()
+                        .insert("IGGY_HTTP_ADDRESS".to_string(), addr.to_string());
+                }
+                ServerProtocolAddr::QuicUdp(addr) => {
+                    self.envs
+                        .as_mut()
+                        .unwrap()
+                        .insert("IGGY_QUIC_ADDRESS".to_string(), addr.to_string());
+                }
+            }
+        }
+    }
+
+    fn wait_until_server_has_bound(&self) {
+        #[cfg(unix)]
+        for addr in &self.server_addrs {
+            Self::ensure_server_bound(addr);
+        }
+
+        // Dirty hack for Windows
+        #[cfg(not(unix))]
+        sleep(Duration::from_secs(5))
+    }
+
+    fn wait_until_server_freed_ports(&self) {
+        #[cfg(unix)]
+        for addr in &self.server_addrs {
+            Self::wait_until_port_is_free(addr);
+        }
+
+        // Dirty hack for Windows
+        #[cfg(not(unix))]
+        sleep(Duration::from_secs(5))
+    }
+
+    fn ensure_server_bound(server_protocol_addr: &ServerProtocolAddr) {
+        let max_attempts = (MAX_PORT_WAIT_DURATION_S * 1000) / SLEEP_INTERVAL_MS;
+        for _ in 0..max_attempts {
+            let success = match server_protocol_addr {
+                ServerProtocolAddr::RawTcp(addr) => TcpStream::connect(addr).is_ok(),
+                ServerProtocolAddr::HttpTcp(addr) => TcpStream::connect(addr).is_ok(),
+                ServerProtocolAddr::QuicUdp(addr) => {
+                    let socket =
+                        UdpSocket::bind("0.0.0.0:0").expect("Failed to bind to local port");
+                    socket.send_to(&[0], addr).is_ok()
+                }
+            };
+
+            if success {
+                return;
+            }
+            sleep(Duration::from_millis(SLEEP_INTERVAL_MS));
+        }
+
+        panic!(
+            "Failed to connect to the server at {} in {} seconds!",
+            server_protocol_addr, MAX_PORT_WAIT_DURATION_S
+        );
+    }
+
+    fn get_free_tcp_port() -> u16 {
+        let listener = TcpListener::bind(("0.0.0.0", 0)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+        port
+    }
+
+    fn get_free_udp_port() -> u16 {
+        let socket = UdpSocket::bind(("0.0.0.0", 0)).unwrap();
+        let port = socket.local_addr().unwrap().port();
+        drop(socket);
+        port
+    }
+
+    fn wait_until_port_is_free(server_protocol_addr: &ServerProtocolAddr) {
+        let max_attempts = (MAX_PORT_WAIT_DURATION_S * 1000) / SLEEP_INTERVAL_MS;
+        for _ in 0..max_attempts {
+            let success = match server_protocol_addr {
+                ServerProtocolAddr::RawTcp(addr) => TcpListener::bind(addr).is_ok(),
+                ServerProtocolAddr::HttpTcp(addr) => TcpListener::bind(addr).is_ok(),
+                ServerProtocolAddr::QuicUdp(addr) => UdpSocket::bind(addr).is_ok(),
+            };
+
+            if success {
+                return;
+            }
+            sleep(Duration::from_millis(SLEEP_INTERVAL_MS));
+        }
+
+        panic!(
+            "{} is still in use after {} seconds",
+            server_protocol_addr, MAX_PORT_WAIT_DURATION_S
+        );
+    }
+
+    fn get_stdout_file_path(&self) -> PathBuf {
+        format!("{}_stdout.txt", self.files_path).into()
+    }
+
+    fn get_stderr_file_path(&self) -> PathBuf {
+        format!("{}_stderr.txt", self.files_path).into()
+    }
+
+    fn get_stdout_file(&self) -> File {
+        File::create(self.get_stdout_file_path()).unwrap()
+    }
+
+    fn get_stderr_file(&self) -> File {
+        File::create(self.get_stderr_file_path()).unwrap()
+    }
+
+    fn read_file_to_string(path: &str) -> String {
+        fs::read_to_string(path).unwrap()
+    }
+
     pub fn get_random_path() -> String {
         format!("local_data_{}", Uuid::new_v4().to_u128_le())
     }
+
+    pub fn get_http_api_addr(&self) -> Option<String> {
+        for server_protocol_addr in &self.server_addrs {
+            if let ServerProtocolAddr::HttpTcp(a) = server_protocol_addr {
+                return Some(a.to_string());
+            }
+        }
+        None
+    }
+
+    pub fn get_raw_tcp_addr(&self) -> Option<String> {
+        for server_protocol_addr in &self.server_addrs {
+            if let ServerProtocolAddr::RawTcp(a) = server_protocol_addr {
+                return Some(a.to_string());
+            }
+        }
+        None
+    }
+
+    pub fn get_quic_udp_addr(&self) -> Option<String> {
+        for server_protocol_addr in &self.server_addrs {
+            if let ServerProtocolAddr::QuicUdp(a) = server_protocol_addr {
+                return Some(a.to_string());
+            }
+        }
+        None
+    }
 }
+
 impl Drop for TestServer {
     fn drop(&mut self) {
         self.stop();
         if panicking() {
-            if !self.stdout.is_empty() {
-                eprintln!("Iggy server stdout:\n{}", self.stdout);
+            if let Some(stdout_file_path) = &self.stdout_file_path {
+                eprintln!(
+                    "Iggy server stdout:\n{}",
+                    Self::read_file_to_string(stdout_file_path.to_str().unwrap())
+                );
             }
-            if !self.stderr.is_empty() {
-                eprintln!("Iggy server stderr:\n{}", self.stderr);
+
+            if let Some(stderr_file_path) = &self.stderr_file_path {
+                eprintln!(
+                    "Iggy server stderr:\n{}",
+                    Self::read_file_to_string(stderr_file_path.to_str().unwrap())
+                );
             }
+        }
+        if let Some(stdout_file_path) = &self.stdout_file_path {
+            fs::remove_file(stdout_file_path).unwrap();
+        }
+        if let Some(stderr_file_path) = &self.stderr_file_path {
+            fs::remove_file(stderr_file_path).unwrap();
         }
     }
 }
@@ -182,6 +409,15 @@ pub async fn create_user(client: &IggyClient, username: &str) {
         .unwrap();
 }
 
+pub async fn delete_user(client: &IggyClient, username: &str) {
+    client
+        .delete_user(&DeleteUser {
+            user_id: Identifier::named(username).unwrap(),
+        })
+        .await
+        .unwrap();
+}
+
 pub async fn login_root(client: &IggyClient) {
     client
         .login_user(&LoginUser {
@@ -200,4 +436,12 @@ pub async fn login_user(client: &IggyClient, username: &str) {
         })
         .await
         .unwrap();
+}
+
+pub async fn assert_clean_system(system_client: &IggyClient) {
+    let streams = system_client.get_streams(&GetStreams {}).await.unwrap();
+    assert!(streams.is_empty());
+
+    let users = system_client.get_users(&GetUsers {}).await.unwrap();
+    assert_eq!(users.len(), 1);
 }

--- a/server/src/streaming/storage.rs
+++ b/server/src/streaming/storage.rs
@@ -57,12 +57,6 @@ pub trait StreamStorage: Storage<Stream> {}
 
 #[async_trait]
 pub trait TopicStorage: Storage<Topic> {
-    async fn save_partitions(&self, topic: &Topic, partition_ids: &[u32]) -> Result<(), Error>;
-    async fn delete_partitions(
-        &self,
-        topic: &mut Topic,
-        partition_ids: &[u32],
-    ) -> Result<(), Error>;
     async fn save_consumer_group(
         &self,
         topic: &Topic,
@@ -352,22 +346,6 @@ pub(crate) mod tests {
 
     #[async_trait]
     impl TopicStorage for TestTopicStorage {
-        async fn save_partitions(
-            &self,
-            _topic: &Topic,
-            _partition_ids: &[u32],
-        ) -> Result<(), Error> {
-            Ok(())
-        }
-
-        async fn delete_partitions(
-            &self,
-            _topic: &mut Topic,
-            _partition_ids: &[u32],
-        ) -> Result<(), Error> {
-            Ok(())
-        }
-
         async fn save_consumer_group(
             &self,
             _topic: &Topic,

--- a/server/src/streaming/streams/persistence.rs
+++ b/server/src/streaming/streams/persistence.rs
@@ -14,6 +14,10 @@ impl Stream {
     }
 
     pub async fn delete(&self) -> Result<(), Error> {
+        for topic in self.get_topics() {
+            topic.delete().await?;
+        }
+
         self.storage.stream.delete(self).await
     }
 

--- a/server/src/streaming/streams/topics.rs
+++ b/server/src/streaming/streams/topics.rs
@@ -71,8 +71,13 @@ impl Stream {
             }
         }
 
+        let old_topic_name = {
+            let topic = self.get_topic(id)?;
+            topic.name.clone()
+        };
+
         {
-            self.topics_ids.remove(&updated_name.clone());
+            self.topics_ids.remove(&old_topic_name.clone());
             self.topics_ids.insert(updated_name.clone(), topic_id);
             let topic = self.get_topic_mut(id)?;
             topic.name = updated_name;

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -206,15 +206,23 @@ impl System {
             }
         }
 
+        let old_name;
         {
-            self.streams_ids.remove(&updated_name.clone());
-            self.streams_ids.insert(updated_name.clone(), stream_id);
             let stream = self.get_stream_mut(id)?;
-            stream.name = updated_name;
+            old_name = stream.name.clone();
+            stream.name = updated_name.clone();
             stream.persist().await?;
-            info!("Updated stream: {} with ID: {}", stream.name, id);
         }
 
+        {
+            self.streams_ids.remove(&old_name);
+            self.streams_ids.insert(updated_name.clone(), stream_id);
+        }
+
+        info!(
+            "Stream with ID '{}' updated. Old name: '{}' changed to: '{}'.",
+            id, old_name, updated_name
+        );
         Ok(())
     }
 

--- a/server/src/streaming/topics/storage.rs
+++ b/server/src/streaming/topics/storage.rs
@@ -36,50 +36,6 @@ struct ConsumerGroupData {
 
 #[async_trait]
 impl TopicStorage for FileTopicStorage {
-    async fn save_partitions(&self, topic: &Topic, partition_ids: &[u32]) -> Result<(), Error> {
-        for partition_id in partition_ids {
-            if !topic.partitions.contains_key(partition_id) {
-                return Err(Error::PartitionNotFound(
-                    *partition_id,
-                    topic.topic_id,
-                    topic.stream_id,
-                ));
-            }
-        }
-
-        for partition_id in partition_ids {
-            let partition = topic.partitions.get(partition_id).unwrap();
-            let partition = partition.read().await;
-            partition.persist().await?;
-        }
-
-        Ok(())
-    }
-
-    async fn delete_partitions(
-        &self,
-        topic: &mut Topic,
-        partition_ids: &[u32],
-    ) -> Result<(), Error> {
-        for partition_id in partition_ids {
-            if !topic.partitions.contains_key(partition_id) {
-                return Err(Error::PartitionNotFound(
-                    *partition_id,
-                    topic.topic_id,
-                    topic.stream_id,
-                ));
-            }
-        }
-
-        for partition_id in partition_ids {
-            let partition = topic.partitions.get(partition_id).unwrap();
-            let partition = partition.read().await;
-            partition.delete().await?;
-        }
-
-        Ok(())
-    }
-
     async fn save_consumer_group(
         &self,
         topic: &Topic,

--- a/server/src/tcp/tcp_listener.rs
+++ b/server/src/tcp/tcp_listener.rs
@@ -9,9 +9,9 @@ use tracing::{error, info};
 pub fn start(address: &str, system: Arc<RwLock<System>>) {
     let address = address.to_string();
     tokio::spawn(async move {
-        let listener = TcpListener::bind(address).await;
+        let listener = TcpListener::bind(address.clone()).await;
         if listener.is_err() {
-            panic!("Unable to start TCP server.");
+            panic!("Unable to start TCP server on addr {}.", address);
         }
 
         let listener = listener.unwrap();


### PR DESCRIPTION
Instead of sleeping, we poll on bind().
This way, it's exactly known when it's possible
to start server for testing purposes.

When server is stared, we wait till it's bound
to all sockets.

All tests are started in parallel.

IggyClient is properly logged out upon drop.

Besides that, fixes #188.