### PR TITLE
Add integration tests for help messages for other iggy commands #146

### DIFF
--- a/integration/tests/cmd/general/mod.rs
+++ b/integration/tests/cmd/general/mod.rs
@@ -1,2 +1,3 @@
+mod test_help_command;
 mod test_missing_credentials;
 mod test_quiet_mode;

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -1,0 +1,89 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest, CLAP_INDENT, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["help"],
+            format!(
+                r#"Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second.
+
+{USAGE_PREFIX} [OPTIONS] <COMMAND>
+
+Commands:
+  stream     stream operations
+  topic      topic operations
+  partition  partition operations
+  ping       ping iggy server
+  me         get current client info
+  stats      get iggy server statistics
+  help       Print this message or the help of the given subcommand(s)
+
+Options:
+      --transport <TRANSPORT>
+          [default: tcp]
+      --encryption-key <ENCRYPTION_KEY>
+          [default: ]
+      --http-api-url <HTTP_API_URL>
+          [default: http://localhost:3000]
+      --http-retries <HTTP_RETRIES>
+          [default: 3]
+      --tcp-server-address <TCP_SERVER_ADDRESS>
+          [default: 127.0.0.1:8090]
+      --tcp-reconnection-retries <TCP_RECONNECTION_RETRIES>
+          [default: 3]
+      --tcp-reconnection-interval <TCP_RECONNECTION_INTERVAL>
+          [default: 1000]
+      --tcp-tls-enabled
+{CLAP_INDENT}
+      --tcp-tls-domain <TCP_TLS_DOMAIN>
+          [default: localhost]
+      --quic-client-address <QUIC_CLIENT_ADDRESS>
+          [default: 127.0.0.1:0]
+      --quic-server-address <QUIC_SERVER_ADDRESS>
+          [default: 127.0.0.1:8080]
+      --quic-server-name <QUIC_SERVER_NAME>
+          [default: localhost]
+      --quic-reconnection-retries <QUIC_RECONNECTION_RETRIES>
+          [default: 3]
+      --quic-reconnection-interval <QUIC_RECONNECTION_INTERVAL>
+          [default: 1000]
+      --quic-max-concurrent-bidi-streams <QUIC_MAX_CONCURRENT_BIDI_STREAMS>
+          [default: 10000]
+      --quic-datagram-send-buffer-size <QUIC_DATAGRAM_SEND_BUFFER_SIZE>
+          [default: 100000]
+      --quic-initial-mtu <QUIC_INITIAL_MTU>
+          [default: 1200]
+      --quic-send-window <QUIC_SEND_WINDOW>
+          [default: 100000]
+      --quic-receive-window <QUIC_RECEIVE_WINDOW>
+          [default: 100000]
+      --quic-response-buffer-size <QUIC_RESPONSE_BUFFER_SIZE>
+          [default: 1048576]
+      --quic-keep-alive-interval <QUIC_KEEP_ALIVE_INTERVAL>
+          [default: 5000]
+      --quic-max-idle-timeout <QUIC_MAX_IDLE_TIMEOUT>
+          [default: 10000]
+      --quic-validate-certificate
+{CLAP_INDENT}
+  -q, --quiet
+          Quiet mode (disabled stdout printing)
+  -d, --debug <DEBUG>
+          Debug mode (verbose printing to given file)
+  -u, --username <USERNAME>
+          Iggy server username
+  -p, --password <PASSWORD>
+          Iggy server password
+  -h, --help
+          Print help
+  -V, --version
+          Print version
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/stream/mod.rs
+++ b/integration/tests/cmd/stream/mod.rs
@@ -1,5 +1,6 @@
 mod test_stream_create_command;
 mod test_stream_delete_command;
 mod test_stream_get_command;
+mod test_stream_help_command;
 mod test_stream_list_command;
 mod test_stream_update_command;

--- a/integration/tests/cmd/stream/test_stream_create_command.rs
+++ b/integration/tests/cmd/stream/test_stream_create_command.rs
@@ -1,4 +1,4 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, USAGE_PREFIX};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::streams::get_stream::GetStream;
@@ -61,5 +61,63 @@ pub async fn should_be_successful() {
     iggy_cmd_test.setup().await;
     iggy_cmd_test
         .execute_test(TestStreamCreateCmd::new(stream_id, String::from("main")))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "create", "--help"],
+            format!(
+                r#"Create stream with given ID and name
+
+Examples:
+ iggy stream create 1 prod
+ iggy stream create 2 test
+
+{USAGE_PREFIX} stream create <STREAM_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to create topic
+
+  <NAME>
+          Name of the stream
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "create", "-h"],
+            format!(
+                r#"Create stream with given ID and name
+
+{USAGE_PREFIX} stream create <STREAM_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>  Stream ID to create topic
+  <NAME>       Name of the stream
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
         .await;
 }

--- a/integration/tests/cmd/stream/test_stream_delete_command.rs
+++ b/integration/tests/cmd/stream/test_stream_delete_command.rs
@@ -1,4 +1,7 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
@@ -91,6 +94,64 @@ pub async fn should_be_successful() {
             2,
             String::from("production"),
             TestStreamId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "delete", "--help"],
+            format!(
+                r"Delete stream with given ID
+
+Stream ID can be specified as a stream name or ID
+
+Examples:
+ iggy stream delete 1
+ iggy stream delete test
+
+{USAGE_PREFIX} stream delete <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to delete
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+",
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "delete", "-h"],
+            format!(
+                r#"Delete stream with given ID
+
+{USAGE_PREFIX} stream delete <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>  Stream ID to delete
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
         ))
         .await;
 }

--- a/integration/tests/cmd/stream/test_stream_get_command.rs
+++ b/integration/tests/cmd/stream/test_stream_get_command.rs
@@ -1,4 +1,7 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestStreamId};
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
@@ -89,6 +92,64 @@ pub async fn should_be_successful() {
             2,
             String::from("testing"),
             TestStreamId::Numeric,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "get", "--help"],
+            format!(
+                r#"Get details of a single stream with given ID
+
+Stream ID can be specified as a stream name or ID
+
+Examples:
+ iggy stream get 1
+ iggy stream get test
+
+{USAGE_PREFIX} stream get <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to get
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "get", "-h"],
+            format!(
+                r#"Get details of a single stream with given ID
+
+{USAGE_PREFIX} stream get <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>  Stream ID to get
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
         ))
         .await;
 }

--- a/integration/tests/cmd/stream/test_stream_help_command.rs
+++ b/integration/tests/cmd/stream/test_stream_help_command.rs
@@ -8,19 +8,18 @@ pub async fn should_help_match() {
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(
-            vec!["topic", "help"],
+            vec!["stream", "help"],
             format!(
-                r#"topic operations
+                r#"stream operations
 
-{USAGE_PREFIX} topic <COMMAND>
+{USAGE_PREFIX} stream <COMMAND>
 
 Commands:
-  create  Create topic with given ID, name, number of partitions
-              and expiry time for given stream ID
-  delete  Delete topic with given ID in given stream ID
-  update  Update topic name an message expiry time for given topic ID in given stream ID
-  get     Get topic detail for given topic ID and stream ID
-  list    List all topics in given stream ID
+  create  Create stream with given ID and name
+  delete  Delete stream with given ID
+  update  Update stream name for given stream ID
+  get     Get details of a single stream with given ID
+  list    List all streams
   help    Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cmd/stream/test_stream_list_command.rs
+++ b/integration/tests/cmd/stream/test_stream_list_command.rs
@@ -1,4 +1,7 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, OutputFormat};
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, OutputFormat, TestHelpCmd, CLAP_INDENT,
+    USAGE_PREFIX,
+};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
@@ -84,6 +87,61 @@ pub async fn should_be_successful() {
             3,
             String::from("misc"),
             OutputFormat::Table,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "list", "--help"],
+            format!(
+                r#"List all streams
+
+Examples:
+ iggy stream list
+ iggy stream list --list-mode table
+ iggy stream list -l table
+
+{USAGE_PREFIX} stream list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>
+          List mode (table or list)
+{CLAP_INDENT}
+          [default: table]
+          [possible values: table, list]
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "list", "-h"],
+            format!(
+                r#"List all streams
+
+{USAGE_PREFIX} stream list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>  List mode (table or list) [default: table] [possible values: table, list]
+  -h, --help                   Print help (see more with '--help')
+"#,
+            ),
         ))
         .await;
 }

--- a/integration/tests/cmd/stream/test_stream_update_command.rs
+++ b/integration/tests/cmd/stream/test_stream_update_command.rs
@@ -1,4 +1,7 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::streams::create_stream::CreateStream;
@@ -6,11 +9,6 @@ use iggy::streams::get_stream::GetStream;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
 use serial_test::parallel;
-
-enum TestStreamId {
-    Numeric,
-    Named,
-}
 
 struct TestStreamUpdateCmd {
     stream_id: u32,
@@ -100,6 +98,68 @@ pub async fn should_be_successful() {
             String::from("production"),
             String::from("prototype"),
             TestStreamId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "update", "--help"],
+            format!(
+                r#"Update stream name for given stream ID
+
+Stream ID can be specified as a stream name or ID
+
+Examples:
+ iggy stream update 1 production
+ iggy stream update test development
+
+{USAGE_PREFIX} stream update <STREAM_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to update
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <NAME>
+          New name for the stream
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "update", "-h"],
+            format!(
+                r#"Update stream name for given stream ID
+
+{USAGE_PREFIX} stream update <STREAM_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>  Stream ID to update
+  <NAME>       New name for the stream
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
         ))
         .await;
 }

--- a/integration/tests/cmd/system/test_me_command.rs
+++ b/integration/tests/cmd/system/test_me_command.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase},
+    cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, USAGE_PREFIX},
     utils::test_server::TestServer,
 };
 use assert_cmd::assert::Assert;
@@ -112,5 +112,50 @@ pub async fn should_be_successful_using_transport_quic() {
     iggy_cmd_test.setup().await;
     iggy_cmd_test
         .execute_test(TestMeCmd::new(Protocol::Quic))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["me", "--help"],
+            format!(
+                r#"get current client info
+
+Command connects to Iggy server and collects client info like client ID, user ID server address and protocol type.
+
+{USAGE_PREFIX} me
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["me", "-h"],
+            format!(
+                r#"get current client info
+
+{USAGE_PREFIX} me
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
         .await;
 }

--- a/integration/tests/cmd/system/test_ping_command.rs
+++ b/integration/tests/cmd/system/test_ping_command.rs
@@ -1,4 +1,6 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, CLAP_INDENT, USAGE_PREFIX,
+};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
@@ -54,4 +56,55 @@ pub async fn should_be_successful() {
 
     iggy_cmd_test.setup().await;
     iggy_cmd_test.execute_test(TestPingCmd::default()).await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["ping", "--help"],
+            format!(
+                r#"ping iggy server
+
+Check if iggy server is up and running and what's the response ping response time
+
+{USAGE_PREFIX} ping [OPTIONS]
+
+Options:
+  -c, --count <COUNT>
+          Stop after sending count Ping packets
+{CLAP_INDENT}
+          [default: 1]
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["ping", "-h"],
+            format!(
+                r#"ping iggy server
+
+{USAGE_PREFIX} ping [OPTIONS]
+
+Options:
+  -c, --count <COUNT>  Stop after sending count Ping packets [default: 1]
+  -h, --help           Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
 }

--- a/integration/tests/cmd/system/test_stats_command.rs
+++ b/integration/tests/cmd/system/test_stats_command.rs
@@ -1,4 +1,4 @@
-use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, USAGE_PREFIX};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::streams::create_stream::CreateStream;
@@ -60,4 +60,49 @@ pub async fn should_be_successful() {
 
     iggy_cmd_test.setup().await;
     iggy_cmd_test.execute_test(TestStatsCmd {}).await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stats", "--help"],
+            format!(
+                r#"get iggy server statistics
+
+Collect basic Iggy server statistics like number of streams, topics, partitions, etc. Server OS name, version, etc. are also collected.
+
+{USAGE_PREFIX} stats
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stats", "-h"],
+            format!(
+                r#"get iggy server statistics
+
+{USAGE_PREFIX} stats
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
 }

--- a/integration/tests/cmd/topic/test_topic_create_command.rs
+++ b/integration/tests/cmd/topic/test_topic_create_command.rs
@@ -10,7 +10,7 @@ use iggy::streams::create_stream::CreateStream;
 use iggy::topics::get_topic::GetTopic;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 use std::time::Duration;
 
 struct TestTopicCreateCmd {
@@ -132,7 +132,7 @@ impl IggyCmdTestCase for TestTopicCreateCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -189,7 +189,7 @@ pub async fn should_be_successful() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -237,7 +237,7 @@ Options:
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_short_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/topic/test_topic_delete_command.rs
+++ b/integration/tests/cmd/topic/test_topic_delete_command.rs
@@ -9,7 +9,7 @@ use iggy::topics::create_topic::CreateTopic;
 use iggy::topics::get_topics::GetTopics;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestTopicDeleteCmd {
     stream_id: u32,
@@ -118,7 +118,7 @@ impl IggyCmdTestCase for TestTopicDeleteCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -166,7 +166,7 @@ pub async fn should_be_successful() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -208,7 +208,7 @@ Options:
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_short_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/topic/test_topic_get_command.rs
+++ b/integration/tests/cmd/topic/test_topic_get_command.rs
@@ -10,7 +10,7 @@ use iggy::topics::create_topic::CreateTopic;
 use iggy::topics::delete_topic::DeleteTopic;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestTopicGetCmd {
     stream_id: u32,
@@ -135,7 +135,7 @@ impl IggyCmdTestCase for TestTopicGetCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -183,7 +183,7 @@ pub async fn should_be_successful() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -225,7 +225,7 @@ Options:
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_short_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/topic/test_topic_list_command.rs
+++ b/integration/tests/cmd/topic/test_topic_list_command.rs
@@ -10,7 +10,7 @@ use iggy::topics::create_topic::CreateTopic;
 use iggy::topics::delete_topic::DeleteTopic;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::{contains, starts_with};
-use serial_test::serial;
+use serial_test::parallel;
 
 struct TestTopicListCmd {
     stream_id: u32,
@@ -117,7 +117,7 @@ impl IggyCmdTestCase for TestTopicListCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -155,7 +155,7 @@ pub async fn should_be_successful() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -195,7 +195,7 @@ Options:
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_short_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 

--- a/integration/tests/cmd/topic/test_topic_update_command.rs
+++ b/integration/tests/cmd/topic/test_topic_update_command.rs
@@ -13,7 +13,7 @@ use iggy::topics::delete_topic::DeleteTopic;
 use iggy::topics::get_topic::GetTopic;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
-use serial_test::serial;
+use serial_test::parallel;
 use std::time::Duration;
 
 struct TestTopicUpdateCmd {
@@ -190,7 +190,7 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -285,7 +285,7 @@ pub async fn should_be_successful() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
@@ -334,7 +334,7 @@ Options:
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 pub async fn should_short_help_match() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 


### PR DESCRIPTION
Add integration tests for help messages for other iggy commands #146
  
Add integration tests for checking help message output for general, system and stream related commands in iggy-cmd. Replace serial with parallel in all iggy cmd integration tests.

This fixes #146. Implementation of missing SDK commands in iggy cmd will cover also testing.
