### PR TITLE
Add support for personal access tokens to iggy-cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1234,7 +1234,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.0.111"
+version = "0.0.112"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/common.rs
+++ b/cmd/src/args/common.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use iggy::cmd::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokensOutput;
 use iggy::cmd::streams::get_streams::GetStreamsOutput;
 use iggy::cmd::topics::get_topics::GetTopicsOutput;
 
@@ -22,6 +23,15 @@ impl From<ListMode> for GetTopicsOutput {
         match mode {
             ListMode::Table => GetTopicsOutput::Table,
             ListMode::List => GetTopicsOutput::List,
+        }
+    }
+}
+
+impl From<ListMode> for GetPersonalAccessTokensOutput {
+    fn from(mode: ListMode) -> Self {
+        match mode {
+            ListMode::Table => GetPersonalAccessTokensOutput::Table,
+            ListMode::List => GetPersonalAccessTokensOutput::List,
         }
     }
 }

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -1,11 +1,13 @@
 pub(crate) mod common;
 pub(crate) mod partition;
+pub(crate) mod personal_access_token;
 pub(crate) mod stream;
 pub(crate) mod system;
 pub(crate) mod topic;
 
 use crate::args::{
-    partition::PartitionAction, stream::StreamAction, system::PingArgs, topic::TopicAction,
+    partition::PartitionAction, personal_access_token::PersonalAccessTokenAction,
+    stream::StreamAction, system::PingArgs, topic::TopicAction,
 };
 use clap::{Parser, Subcommand};
 use iggy::args::Args as IggyArgs;
@@ -62,4 +64,7 @@ pub(crate) enum Command {
     /// Collect basic Iggy server statistics like number of streams, topics, partitions, etc.
     /// Server OS name, version, etc. are also collected.
     Stats,
+    /// personal access token operations
+    #[clap(subcommand)]
+    Pat(PersonalAccessTokenAction),
 }

--- a/cmd/src/args/personal_access_token.rs
+++ b/cmd/src/args/personal_access_token.rs
@@ -1,0 +1,58 @@
+use crate::args::common::ListMode;
+use clap::{Args, Subcommand};
+use iggy::cmd::utils::personal_access_token_expiry::PersonalAccessTokenExpiry;
+use std::convert::From;
+
+#[derive(Debug, Subcommand)]
+pub(crate) enum PersonalAccessTokenAction {
+    /// Create personal access token
+    ///
+    /// Create personal access token which allow authenticating the clients using
+    /// a token, instead of the regular credentials (username and password)
+    /// In quiet mode only the personal access token name is printed
+    ///
+    /// Examples
+    ///  iggy pat create name
+    ///  iggy pat create client 1day
+    ///  iggy pat create sensor 3weeks
+    #[clap(verbatim_doc_comment)]
+    Create(PersonalAccessTokenCreateArgs),
+    /// Delete personal access token
+    ///
+    /// Examples
+    ///  iggy pat delete name
+    ///  iggy pat delete client
+    #[clap(verbatim_doc_comment)]
+    Delete(PersonalAccessTokenDeleteArgs),
+    /// List all personal access tokens
+    ///
+    /// Examples
+    ///  iggy pat list
+    #[clap(verbatim_doc_comment)]
+    List(PersonalAccessTokenListArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonalAccessTokenCreateArgs {
+    /// Name of the personal access token
+    pub(crate) name: String,
+    /// Personal access token expiry time in human readable format
+    ///
+    /// Expiry time must be expressed in human readable format like 15days 2min 2s
+    /// ("none" or skipping parameter disables personal access token expiry)
+    #[arg(value_parser = clap::value_parser!(PersonalAccessTokenExpiry))]
+    pub(crate) expiry: Option<Vec<PersonalAccessTokenExpiry>>,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonalAccessTokenDeleteArgs {
+    /// Personal access token name to delete
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct PersonalAccessTokenListArgs {
+    /// List mode (table or list)
+    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
+    pub(crate) list_mode: ListMode,
+}

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.0.111"
+version = "0.0.112"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/iggy/src/cmd/mod.rs
+++ b/iggy/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod partitions;
+pub mod personal_access_tokens;
 pub mod streams;
 pub mod system;
 pub mod topics;

--- a/iggy/src/cmd/personal_access_tokens/create_personal_access_token.rs
+++ b/iggy/src/cmd/personal_access_tokens/create_personal_access_token.rs
@@ -1,0 +1,76 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::cmd::utils::personal_access_token_expiry::PersonalAccessTokenExpiry;
+use crate::personal_access_tokens::create_personal_access_token::CreatePersonalAccessToken;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct CreatePersonalAccessTokenCmd {
+    create_token: CreatePersonalAccessToken,
+    token_expiry: Option<PersonalAccessTokenExpiry>,
+    quiet_mode: bool,
+}
+
+impl CreatePersonalAccessTokenCmd {
+    pub fn new(
+        name: String,
+        pat_expiry: Option<PersonalAccessTokenExpiry>,
+        quiet_mode: bool,
+    ) -> Self {
+        Self {
+            create_token: CreatePersonalAccessToken {
+                name,
+                expiry: match &pat_expiry {
+                    None => None,
+                    Some(value) => value.into(),
+                },
+            },
+            token_expiry: pat_expiry,
+            quiet_mode,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for CreatePersonalAccessTokenCmd {
+    fn explain(&self) -> String {
+        let expiry_text = match &self.token_expiry {
+            Some(value) => format!("token expire time: {}", value),
+            None => String::from("without token expire time"),
+        };
+        format!(
+            "create personal access token with name: {} and {}",
+            self.create_token.name, expiry_text
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let token = client
+            .create_personal_access_token(&self.create_token)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem creating personal access token with name: {}",
+                    self.create_token.name
+                )
+            })?;
+
+        if self.quiet_mode {
+            println!("{}", token.token);
+        } else {
+            event!(target: PRINT_TARGET, Level::INFO,
+                "Personal access token with name: {} and {} created",
+                self.create_token.name,
+                match &self.token_expiry {
+                    Some(value) => format!("token expire time: {}", value),
+                    None => String::from("without token expire time"),
+                },
+            );
+            event!(target: PRINT_TARGET, Level::INFO,"Token: {}",
+                            token.token);
+        }
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/personal_access_tokens/delete_personal_access_tokens.rs
+++ b/iggy/src/cmd/personal_access_tokens/delete_personal_access_tokens.rs
@@ -1,0 +1,46 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::personal_access_tokens::delete_personal_access_token::DeletePersonalAccessToken;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct DeletePersonalAccessTokenCmd {
+    delete_token: DeletePersonalAccessToken,
+}
+
+impl DeletePersonalAccessTokenCmd {
+    pub fn new(name: String) -> Self {
+        Self {
+            delete_token: DeletePersonalAccessToken { name },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for DeletePersonalAccessTokenCmd {
+    fn explain(&self) -> String {
+        format!(
+            "delete personal access tokens with name: {}",
+            self.delete_token.name
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .delete_personal_access_token(&self.delete_token)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem deleting personal access tokens with name: {}",
+                    self.delete_token.name
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Personal access token with name: {} deleted", self.delete_token.name
+        );
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/personal_access_tokens/get_personal_access_tokens.rs
+++ b/iggy/src/cmd/personal_access_tokens/get_personal_access_tokens.rs
@@ -1,0 +1,79 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
+use crate::utils::timestamp::TimeStamp;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::Table;
+use tracing::{event, Level};
+
+pub enum GetPersonalAccessTokensOutput {
+    Table,
+    List,
+}
+
+pub struct GetPersonalAccessTokensCmd {
+    get_tokens: GetPersonalAccessTokens,
+    output: GetPersonalAccessTokensOutput,
+}
+
+impl GetPersonalAccessTokensCmd {
+    pub fn new(output: GetPersonalAccessTokensOutput) -> Self {
+        Self {
+            get_tokens: GetPersonalAccessTokens {},
+            output,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetPersonalAccessTokensCmd {
+    fn explain(&self) -> String {
+        let mode = match self.output {
+            GetPersonalAccessTokensOutput::Table => "table",
+            GetPersonalAccessTokensOutput::List => "list",
+        };
+        format!("list personal access tokens in {mode} mode")
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let tokens = client
+            .get_personal_access_tokens(&self.get_tokens)
+            .await
+            .with_context(|| String::from("Problem getting list of personal access tokens"))?;
+
+        match self.output {
+            GetPersonalAccessTokensOutput::Table => {
+                let mut table = Table::new();
+
+                table.set_header(vec!["Name", "Token Expiry Time"]);
+
+                tokens.iter().for_each(|token| {
+                    table.add_row(vec![
+                        format!("{}", token.name.clone()),
+                        match token.expiry {
+                            Some(value) => TimeStamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            None => String::from("None"),
+                        },
+                    ]);
+                });
+
+                event!(target: PRINT_TARGET, Level::INFO, "{table}");
+            }
+            GetPersonalAccessTokensOutput::List => {
+                tokens.iter().for_each(|token| {
+                    event!(target: PRINT_TARGET, Level::INFO,
+                        "{}|{}",
+                        token.name,
+                        match token.expiry {
+                            Some(value) => TimeStamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            None => String::from("None"),
+                        },
+                    );
+                });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/personal_access_tokens/mod.rs
+++ b/iggy/src/cmd/personal_access_tokens/mod.rs
@@ -1,0 +1,3 @@
+pub mod create_personal_access_token;
+pub mod delete_personal_access_tokens;
+pub mod get_personal_access_tokens;

--- a/iggy/src/cmd/utils/mod.rs
+++ b/iggy/src/cmd/utils/mod.rs
@@ -1,1 +1,2 @@
 pub mod message_expiry;
+pub mod personal_access_token_expiry;

--- a/iggy/src/cmd/utils/personal_access_token_expiry.rs
+++ b/iggy/src/cmd/utils/personal_access_token_expiry.rs
@@ -1,0 +1,3 @@
+use crate::cmd::utils::message_expiry::MessageExpiry;
+
+pub type PersonalAccessTokenExpiry = MessageExpiry;

--- a/iggy/src/utils/timestamp.rs
+++ b/iggy/src/utils/timestamp.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Local, Utc};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[derive(Debug)]
@@ -25,6 +25,10 @@ impl TimeStamp {
 
     pub fn to_string(&self, format: &str) -> String {
         DateTime::<Utc>::from(self.0).format(format).to_string()
+    }
+
+    pub fn to_local(&self, format: &str) -> String {
+        DateTime::<Local>::from(self.0).format(format).to_string()
     }
 }
 

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -21,6 +21,7 @@ Commands:
   ping       ping iggy server
   me         get current client info
   stats      get iggy server statistics
+  pat        personal access token operations
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cmd/mod.rs
+++ b/integration/tests/cmd/mod.rs
@@ -1,6 +1,7 @@
 mod common;
 mod general;
 mod partition;
+mod personal_access_token;
 mod stream;
 mod system;
 mod topic;

--- a/integration/tests/cmd/personal_access_token/mod.rs
+++ b/integration/tests/cmd/personal_access_token/mod.rs
@@ -1,0 +1,4 @@
+mod test_pat_create_command;
+mod test_pat_delete_command;
+mod test_pat_help_command;
+mod test_pat_list_command;

--- a/integration/tests/cmd/personal_access_token/test_pat_create_command.rs
+++ b/integration/tests/cmd/personal_access_token/test_pat_create_command.rs
@@ -1,0 +1,174 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use humantime::format_duration;
+use humantime::Duration as HumanDuration;
+use iggy::client::Client;
+use iggy::personal_access_tokens::{
+    delete_personal_access_token::DeletePersonalAccessToken,
+    get_personal_access_tokens::GetPersonalAccessTokens,
+};
+use predicates::str::starts_with;
+use serial_test::parallel;
+use std::time::Duration;
+
+struct TestPatCreateCmd {
+    name: String,
+    expiry: Option<Vec<String>>,
+}
+
+impl TestPatCreateCmd {
+    fn new(name: String, expiry: Option<Vec<String>>) -> Self {
+        Self { name, expiry }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut args = vec![self.name.clone()];
+        if let Some(expiry) = &self.expiry {
+            args.extend(expiry.clone());
+        }
+
+        args
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestPatCreateCmd {
+    async fn prepare_server_state(&self, _client: &dyn Client) {}
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("pat")
+            .arg("create")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let expiry = match &self.expiry {
+            Some(value) => {
+                let duration: Duration = *value.join(" ").parse::<HumanDuration>().unwrap();
+
+                format!("token expire time: {}", format_duration(duration))
+            }
+            None => String::from("without token expire time"),
+        };
+
+        let message = format!("Executing create personal access token with name: {} and {}\nPersonal access token with name: {} and {} created\nToken: ",
+                                self.name, expiry, self.name, expiry);
+
+        command_state.success().stdout(starts_with(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let tokens = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await;
+
+        assert!(tokens.is_ok());
+        let tokens = tokens.unwrap();
+        let token = tokens.into_iter().find(|t| t.name == self.name);
+        assert!(token.is_some());
+        let token = token.unwrap();
+        if self.expiry.is_none() {
+            assert!(token.expiry.is_none())
+        }
+
+        let delete = client
+            .delete_personal_access_token(&DeletePersonalAccessToken {
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(delete.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestPatCreateCmd::new(String::from("main"), None))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestPatCreateCmd::new(
+            String::from("client"),
+            Some(vec!["1day".to_owned()]),
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestPatCreateCmd::new(
+            String::from("sensor"),
+            Some(vec!["3weeks".to_owned()]),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "create", "--help"],
+            format!(
+                r#"Create personal access token
+
+Create personal access token which allow authenticating the clients using
+a token, instead of the regular credentials (username and password)
+In quiet mode only the personal access token name is printed
+
+Examples
+ iggy pat create name
+ iggy pat create client 1day
+ iggy pat create sensor 3weeks
+
+{USAGE_PREFIX} pat create <NAME> [EXPIRY]...
+
+Arguments:
+  <NAME>
+          Name of the personal access token
+
+  [EXPIRY]...
+          Personal access token expiry time in human readable format
+{CLAP_INDENT}
+          Expiry time must be expressed in human readable format like 15days 2min 2s ("none" or skipping parameter disables personal access token expiry)
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "create", "-h"],
+            format!(
+                r#"Create personal access token
+
+{USAGE_PREFIX} pat create <NAME> [EXPIRY]...
+
+Arguments:
+  <NAME>       Name of the personal access token
+  [EXPIRY]...  Personal access token expiry time in human readable format
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/personal_access_token/test_pat_delete_command.rs
+++ b/integration/tests/cmd/personal_access_token/test_pat_delete_command.rs
@@ -1,0 +1,130 @@
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, USAGE_PREFIX};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::personal_access_tokens::{
+    create_personal_access_token::CreatePersonalAccessToken,
+    get_personal_access_tokens::GetPersonalAccessTokens,
+};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestPatDeleteCmd {
+    name: String,
+}
+
+impl TestPatDeleteCmd {
+    fn new(name: String) -> Self {
+        Self { name }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        vec![self.name.clone()]
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestPatDeleteCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let pat = client
+            .create_personal_access_token(&CreatePersonalAccessToken {
+                name: self.name.clone(),
+                expiry: None,
+            })
+            .await;
+        assert!(pat.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("pat")
+            .arg("delete")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let message = format!("Executing delete personal access tokens with name: {}\nPersonal access token with name: {} deleted\n",
+                                self.name, self.name);
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let tokens = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await;
+
+        assert!(tokens.is_ok());
+        let tokens = tokens.unwrap();
+        assert!(tokens.is_empty());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestPatDeleteCmd::new(String::from("name")))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestPatDeleteCmd::new(String::from("client")))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "delete", "--help"],
+            format!(
+                r#"Delete personal access token
+
+Examples
+ iggy pat delete name
+ iggy pat delete client
+
+{USAGE_PREFIX} pat delete <NAME>
+
+Arguments:
+  <NAME>
+          Personal access token name to delete
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "delete", "-h"],
+            format!(
+                r#"Delete personal access token
+
+{USAGE_PREFIX} pat delete <NAME>
+
+Arguments:
+  <NAME>  Personal access token name to delete
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/personal_access_token/test_pat_help_command.rs
+++ b/integration/tests/cmd/personal_access_token/test_pat_help_command.rs
@@ -1,0 +1,29 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "help"],
+            format!(
+                r#"personal access token operations
+
+{USAGE_PREFIX} pat <COMMAND>
+
+Commands:
+  create  Create personal access token
+  delete  Delete personal access token
+  list    List all personal access tokens
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/personal_access_token/test_pat_list_command.rs
+++ b/integration/tests/cmd/personal_access_token/test_pat_list_command.rs
@@ -1,0 +1,151 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, OutputFormat, TestHelpCmd, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::personal_access_tokens::{
+    create_personal_access_token::CreatePersonalAccessToken,
+    delete_personal_access_token::DeletePersonalAccessToken,
+};
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+
+struct TestPatListCmd {
+    name: String,
+    output: OutputFormat,
+}
+
+impl TestPatListCmd {
+    fn new(name: String, output: OutputFormat) -> Self {
+        Self { name, output }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        self.output
+            .to_args()
+            .into_iter()
+            .map(String::from)
+            .collect()
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestPatListCmd {
+    async fn prepare_server_state(&self, client: &dyn Client) {
+        let pat = client
+            .create_personal_access_token(&CreatePersonalAccessToken {
+                name: self.name.clone(),
+                expiry: None,
+            })
+            .await;
+        assert!(pat.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("pat")
+            .arg("list")
+            .args(self.to_args())
+            .with_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with(format!(
+                "Executing list personal access tokens in {} mode",
+                self.output
+            )))
+            .stdout(contains(self.name.clone()));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let delete = client
+            .delete_personal_access_token(&DeletePersonalAccessToken {
+                name: self.name.clone(),
+            })
+            .await;
+        assert!(delete.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestPatListCmd::new(
+            String::from("name"),
+            OutputFormat::Default,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestPatListCmd::new(
+            String::from("client"),
+            OutputFormat::List,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestPatListCmd::new(
+            String::from("short"),
+            OutputFormat::Table,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "list", "--help"],
+            format!(
+                r#"List all personal access tokens
+
+Examples
+ iggy pat list
+
+{USAGE_PREFIX} pat list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>
+          List mode (table or list)
+{CLAP_INDENT}
+          [default: table]
+          [possible values: table, list]
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["pat", "list", "-h"],
+            format!(
+                r#"List all personal access tokens
+
+{USAGE_PREFIX} pat list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>  List mode (table or list) [default: table] [possible values: table, list]
+  -h, --help                   Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}


### PR DESCRIPTION
Add pat command with create, delete and list subcommands to iggy-cmd. Extend integration tests with cases which cover all new commands. This commit partially implements #182