### PR TITLE
Fix serialization of created_at for User objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3055,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.49"
+version = "0.0.50"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.0.49"
+version = "0.0.50"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -252,7 +252,7 @@ fn extend_client(client: &Client, bytes: &mut Vec<u8>) {
 
 fn extend_user(user: &User, bytes: &mut Vec<u8>) {
     bytes.put_u32_le(user.id);
-    bytes.put_u64(user.created_at);
+    bytes.put_u64_le(user.created_at);
     bytes.put_u8(user.status.as_code());
     bytes.put_u8(user.username.len() as u8);
     bytes.extend(user.username.as_bytes());


### PR DESCRIPTION
Replaced put_u64 with put_u64_le in order to serialize data in little-endian byte order.
