### PR TITLE
Add overview to iggy-cmd by setting command as optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,11 +722,12 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "figlet-rs",
  "iggy",
  "keyring",
  "passterm",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "cmd"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
+homepage = "https://iggy.rs"
 
 [dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.68"
 clap = { version = "4.1.11", features = ["derive"] }
+figlet-rs = "0.1.5"
 iggy = { path = "../iggy", features = ["iggy-cmd"] }
 keyring = "2.0.5"
 passterm = "2.0.1"

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -12,13 +12,18 @@ use crate::args::{
     partition::PartitionAction, personal_access_token::PersonalAccessTokenAction,
     stream::StreamAction, system::PingArgs, topic::TopicAction,
 };
+use clap::{Args, Command as ClapCommand};
 use clap::{Parser, Subcommand};
+use figlet_rs::FIGfont;
 use iggy::args::Args as IggyArgs;
 use std::path::PathBuf;
 
 const QUIC_TRANSPORT: &str = "quic";
 const HTTP_TRANSPORT: &str = "http";
 const TCP_TRANSPORT: &str = "tcp";
+
+static CARGO_BIN_NAME: &str = env!("CARGO_BIN_NAME");
+static CARGO_PKG_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -27,7 +32,7 @@ pub(crate) struct IggyConsoleArgs {
     pub(crate) iggy: IggyArgs,
 
     #[clap(subcommand)]
-    pub(crate) command: Command,
+    pub(crate) command: Option<Command>,
 
     /// Quiet mode (disabled stdout printing)
     #[clap(short, long, default_value_t = false)]
@@ -58,7 +63,7 @@ pub(crate) struct IggyConsoleArgs {
     pub(crate) token_name: Option<String>,
 }
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum Command {
     /// stream operations
     #[clap(subcommand)]
@@ -123,5 +128,27 @@ impl IggyConsoleArgs {
             ),
             _ => None,
         }
+    }
+
+    pub(crate) fn print_overview() {
+        let mut cli = IggyConsoleArgs::augment_args_for_update(
+            ClapCommand::new(CARGO_BIN_NAME).bin_name(CARGO_BIN_NAME),
+        );
+
+        let full_help = cli.render_help().to_string();
+        let help = full_help.replace(
+            &full_help[full_help.find("Options:").unwrap()..full_help.len()],
+            "",
+        );
+
+        let standard_font = FIGfont::standard().unwrap();
+        let figure = standard_font.convert("Iggy CLI").unwrap();
+
+        println!("{figure}");
+        println!("{help}");
+        println!("Run '{CARGO_BIN_NAME} --help' for full help message.");
+        println!("Run '{CARGO_BIN_NAME} COMMAND --help' for more information on a command.");
+        println!();
+        println!("For more help on what's Iggy and how to use it, head to {CARGO_PKG_HOMEPAGE}");
     }
 }

--- a/cmd/src/args/partition.rs
+++ b/cmd/src/args/partition.rs
@@ -2,7 +2,7 @@ use clap::{Args, Subcommand};
 use iggy::identifier::Identifier;
 use std::convert::From;
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum PartitionAction {
     /// Create partitions for the specified topic ID
     /// and stream ID based on the given count.
@@ -32,7 +32,7 @@ pub(crate) enum PartitionAction {
     Delete(PartitionDeleteArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PartitionCreateArgs {
     /// Stream ID to create partitions
     ///
@@ -49,7 +49,7 @@ pub(crate) struct PartitionCreateArgs {
     pub(crate) partitions_count: u32,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PartitionDeleteArgs {
     /// Stream ID to delete partitions
     ///

--- a/cmd/src/args/personal_access_token.rs
+++ b/cmd/src/args/personal_access_token.rs
@@ -3,7 +3,7 @@ use clap::{Args, Subcommand};
 use iggy::cmd::utils::personal_access_token_expiry::PersonalAccessTokenExpiry;
 use std::convert::From;
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum PersonalAccessTokenAction {
     /// Create personal access token
     ///
@@ -32,7 +32,7 @@ pub(crate) enum PersonalAccessTokenAction {
     List(PersonalAccessTokenListArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PersonalAccessTokenCreateArgs {
     /// Name of the personal access token
     pub(crate) name: String,
@@ -53,13 +53,13 @@ pub(crate) struct PersonalAccessTokenCreateArgs {
     pub(crate) store_token: bool,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PersonalAccessTokenDeleteArgs {
     /// Personal access token name to delete
     pub(crate) name: String,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PersonalAccessTokenListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]

--- a/cmd/src/args/stream.rs
+++ b/cmd/src/args/stream.rs
@@ -2,7 +2,7 @@ use crate::args::common::ListMode;
 use clap::{Args, Subcommand};
 use iggy::identifier::Identifier;
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum StreamAction {
     /// Create stream with given ID and name
     ///
@@ -48,7 +48,7 @@ pub(crate) enum StreamAction {
     List(StreamListArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct StreamCreateArgs {
     /// Stream ID to create topic
     pub(crate) stream_id: u32,
@@ -56,7 +56,7 @@ pub(crate) struct StreamCreateArgs {
     pub(crate) name: String,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct StreamDeleteArgs {
     /// Stream ID to delete
     ///
@@ -64,7 +64,7 @@ pub(crate) struct StreamDeleteArgs {
     pub(crate) stream_id: Identifier,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct StreamUpdateArgs {
     /// Stream ID to update
     ///
@@ -74,7 +74,7 @@ pub(crate) struct StreamUpdateArgs {
     pub(crate) name: String,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct StreamGetArgs {
     /// Stream ID to get
     ///
@@ -82,7 +82,7 @@ pub(crate) struct StreamGetArgs {
     pub(crate) stream_id: Identifier,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct StreamListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]

--- a/cmd/src/args/system.rs
+++ b/cmd/src/args/system.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct PingArgs {
     /// Stop after sending count Ping packets
     #[arg(short, long, default_value_t = 1)]

--- a/cmd/src/args/topic.rs
+++ b/cmd/src/args/topic.rs
@@ -4,7 +4,7 @@ use iggy::cmd::utils::message_expiry::MessageExpiry;
 use iggy::identifier::Identifier;
 use std::convert::From;
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum TopicAction {
     /// Create topic with given ID, name, number of partitions
     /// and expiry time for given stream ID
@@ -65,7 +65,7 @@ pub(crate) enum TopicAction {
     List(TopicListArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct TopicCreateArgs {
     /// Stream ID to create topic
     ///
@@ -84,7 +84,7 @@ pub(crate) struct TopicCreateArgs {
     pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct TopicDeleteArgs {
     /// Stream ID to delete topic
     ///
@@ -98,7 +98,7 @@ pub(crate) struct TopicDeleteArgs {
     pub(crate) topic_id: Identifier,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct TopicUpdateArgs {
     /// Stream ID to update topic
     ///
@@ -118,7 +118,7 @@ pub(crate) struct TopicUpdateArgs {
     pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct TopicGetArgs {
     /// Stream ID to get topic
     ///
@@ -132,7 +132,7 @@ pub(crate) struct TopicGetArgs {
     pub(crate) topic_id: Identifier,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct TopicListArgs {
     /// Stream ID to list topics
     ///

--- a/cmd/src/args/user.rs
+++ b/cmd/src/args/user.rs
@@ -6,7 +6,7 @@ use std::convert::From;
 
 use super::permissions::global::GlobalPermissionsArg;
 
-#[derive(Debug, Subcommand)]
+#[derive(Debug, Clone, Subcommand)]
 pub(crate) enum UserAction {
     /// Create user with given username and password
     ///
@@ -28,7 +28,7 @@ pub(crate) enum UserAction {
     Delete(UserDeleteArgs),
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct UserCreateArgs {
     /// Username
     pub(crate) username: String,
@@ -92,7 +92,7 @@ pub(crate) struct UserCreateArgs {
     pub(crate) stream_permissions: Option<Vec<StreamPermissionsArg>>,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub(crate) struct UserDeleteArgs {
     /// User ID to delete
     ///

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -43,9 +43,9 @@ use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
 use std::sync::Arc;
 use tracing::{event, Level};
 
-fn get_command(args: &IggyConsoleArgs) -> Box<dyn CliCommand> {
+fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> {
     #[warn(clippy::let_and_return)]
-    match &args.command {
+    match command {
         Command::Stream(command) => match command {
             StreamAction::Create(args) => {
                 Box::new(CreateStreamCmd::new(args.stream_id, args.name.clone()))
@@ -142,11 +142,19 @@ fn get_command(args: &IggyConsoleArgs) -> Box<dyn CliCommand> {
 async fn main() -> Result<(), IggyCmdError> {
     let args = IggyConsoleArgs::parse();
 
+    if args.command.is_none() {
+        IggyConsoleArgs::print_overview();
+
+        return Ok(());
+    }
+
     let mut logging = Logging::new();
     logging.init(args.quiet, &args.debug);
 
+    let command = args.command.clone().unwrap();
+
     // Get command based on command line arguments
-    let mut command = get_command(&args);
+    let mut command = get_command(command, &args);
 
     // Create credentials based on command line arguments and command
     let mut credentials = IggyCredentials::new(&args, command.login_required())?;

--- a/integration/tests/cmd/general/mod.rs
+++ b/integration/tests/cmd/general/mod.rs
@@ -1,3 +1,4 @@
 mod test_help_command;
 mod test_missing_credentials;
+mod test_overview_command;
 mod test_quiet_mode;

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -12,7 +12,7 @@ pub async fn should_help_match() {
             format!(
                 r#"Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second.
 
-{USAGE_PREFIX} [OPTIONS] <COMMAND>
+{USAGE_PREFIX} [OPTIONS] [COMMAND]
 
 Commands:
   stream     stream operations

--- a/integration/tests/cmd/general/test_overview_command.rs
+++ b/integration/tests/cmd/general/test_overview_command.rs
@@ -1,0 +1,48 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest};
+use serial_test::parallel;
+
+const FIGLET_INDENT: &str = " ";
+const FIGLET_FILL: &str = "                         ";
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+    let no_arg: Vec<String> = vec![];
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            no_arg,
+            format!(
+                r#"  ___                              ____   _       ___{FIGLET_INDENT}
+ |_ _|   __ _    __ _   _   _     / ___| | |     |_ _|
+  | |   / _` |  / _` | | | | |   | |     | |      | |{FIGLET_INDENT}
+  | |  | (_| | | (_| | | |_| |   | |___  | |___   | |{FIGLET_INDENT}
+ |___|  \__, |  \__, |  \__, |    \____| |_____| |___|
+        |___/   |___/   |___/{FIGLET_FILL}
+
+Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second.
+
+Usage: iggy [OPTIONS] [COMMAND]
+
+Commands:
+  stream     stream operations
+  topic      topic operations
+  partition  partition operations
+  ping       ping iggy server
+  me         get current client info
+  stats      get iggy server statistics
+  pat        personal access token operations
+  user       user operations
+  help       Print this message or the help of the given subcommand(s)
+
+
+Run 'iggy --help' for full help message.
+Run 'iggy COMMAND --help' for more information on a command.
+
+For more help on what's Iggy and how to use it, head to https://iggy.rs
+"#,
+            ),
+        ))
+        .await;
+}


### PR DESCRIPTION
Set command as optional and handle missing command as proper action and print reduced help message with commands overview and general info about iggy.
