### PR TITLE
Add shell completion generator to iggy-cmd options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffe91f06a11b4b9420f62103854e90867812cd5d01557f853c5ee8e791b12ae"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,11 +731,12 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
  "clap",
+ "clap_complete",
  "figlet-rs",
  "iggy",
  "keyring",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -10,6 +10,7 @@ homepage = "https://iggy.rs"
 anyhow = "1.0.75"
 async-trait = "0.1.68"
 clap = { version = "4.1.11", features = ["derive"] }
+clap_complete = "4.4.4"
 figlet-rs = "0.1.5"
 iggy = { path = "../iggy", features = ["iggy-cmd"] }
 keyring = "2.0.5"

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -14,6 +14,7 @@ use crate::args::{
 };
 use clap::{Args, Command as ClapCommand};
 use clap::{Parser, Subcommand};
+use clap_complete::{generate, Generator, Shell};
 use figlet_rs::FIGfont;
 use iggy::args::Args as IggyArgs;
 use std::path::PathBuf;
@@ -61,6 +62,20 @@ pub(crate) struct IggyConsoleArgs {
     /// this option without revealing token value.
     #[clap(short = 'n', long, group = "credentials")]
     pub(crate) token_name: Option<String>,
+
+    /// Shell completion generator for iggy command
+    ///
+    /// Option prints shell completion code on standard output for selected shell.
+    /// Redirect standard output to file and follow and use selected shell means
+    /// to enable completion for iggy command.
+    /// Option cannot be combined with other options.
+    ///
+    /// Example:
+    ///  iggy --generate bash > iggy_completion.bash
+    ///  source iggy_completion.bash
+    #[clap(verbatim_doc_comment)]
+    #[clap(long = "generate", value_enum)]
+    pub(crate) generator: Option<Shell>,
 }
 
 #[derive(Debug, Clone, Subcommand)]
@@ -128,6 +143,17 @@ impl IggyConsoleArgs {
             ),
             _ => None,
         }
+    }
+
+    pub(crate) fn generate_completion<G: Generator>(&self, generator: G) {
+        generate(
+            generator,
+            &mut IggyConsoleArgs::augment_args_for_update(
+                ClapCommand::new(CARGO_BIN_NAME).bin_name(CARGO_BIN_NAME),
+            ),
+            CARGO_BIN_NAME,
+            &mut std::io::stdout(),
+        );
     }
 
     pub(crate) fn print_overview() {

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -142,9 +142,13 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
 async fn main() -> Result<(), IggyCmdError> {
     let args = IggyConsoleArgs::parse();
 
+    if let Some(generator) = args.generator {
+        args.generate_completion(generator);
+        return Ok(());
+    }
+
     if args.command.is_none() {
         IggyConsoleArgs::print_overview();
-
         return Ok(());
     }
 

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -157,6 +157,20 @@ Options:
 {CLAP_INDENT}
           When personal access token is created using command line tool and stored inside platform-specific secure storage its name can be used as an value for this option without revealing token value.
 
+      --generate <GENERATOR>
+          Shell completion generator for iggy command
+{CLAP_INDENT}
+          Option prints shell completion code on standard output for selected shell.
+          Redirect standard output to file and follow and use selected shell means
+          to enable completion for iggy command.
+          Option cannot be combined with other options.
+{CLAP_INDENT}
+          Example:
+           iggy --generate bash > iggy_completion.bash
+           source iggy_completion.bash
+{CLAP_INDENT}
+          [possible values: bash, elvish, fish, powershell, zsh]
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
Add an option which allows to generate shell completion code for selected shell.
