### PR TITLE
Remove usage of human-time crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,25 +1490,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human-time"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259822ea527bd0d5ebf3108d84e98ac4f20769e2e8b2f3ab76e1dd6e21de7f3c"
-dependencies = [
- "human-time-macros",
-]
-
-[[package]]
-name = "human-time-macros"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a04129f85bfd960234ed3fa53212a4904881e024322e804ac5a48da239e44a09"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "human_bytes"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,7 +1600,6 @@ dependencies = [
  "convert_case 0.6.0",
  "crc32fast",
  "flume",
- "human-time",
  "humantime",
  "keyring",
  "lazy_static",

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -26,8 +26,7 @@ clap = { version = "4.4.7", features = ["derive"] }
 comfy-table = { version = "7.1.0", optional = true }
 crc32fast = "1.3.2"
 flume = "0.11.0"
-human-time = "0.1.6"
-humantime = { version = "2.1.0", optional = true }
+humantime = "2.1.0"
 keyring = { version = "2.0.5", optional = true }
 lazy_static = "1.4.0"
 openssl = { version = "0.10.*", features = ["vendored"] }
@@ -53,4 +52,4 @@ serde_derive = "1.0.*"
 
 [features]
 default = []
-iggy-cmd = ["dep:comfy-table", "dep:humantime", "dep:byte-unit", "dep:keyring"]
+iggy-cmd = ["dep:comfy-table", "dep:byte-unit", "dep:keyring"]

--- a/iggy/src/utils/duration.rs
+++ b/iggy/src/utils/duration.rs
@@ -1,4 +1,4 @@
-use human_time::ToHumanTimeString;
+use humantime::format_duration;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt::{Display, Formatter},
@@ -17,10 +17,7 @@ impl IggyDuration {
     }
 
     pub fn as_human_time_string(&self) -> String {
-        self.duration.to_human_time_string_with_format(
-            |n, unit| format!("{n}{unit}",),
-            |acc, item| format!("{} {}", acc, item),
-        )
+        format!("{}", format_duration(self.duration))
     }
 
     pub fn as_secs(&self) -> u32 {
@@ -67,6 +64,16 @@ mod tests {
         let duration = Duration::new(3661, 0); // 1 hour, 1 minute and 1 second
         let iggy_duration = IggyDuration::new(duration);
         assert_eq!(iggy_duration.as_human_time_string(), "1h 1m 1s");
+    }
+
+    #[test]
+    fn test_long_duration_as_human_time_string() {
+        let duration = Duration::new(36611233, 0); // 1year 1month 28days 1hour 13minutes 37seconds
+        let iggy_duration = IggyDuration::new(duration);
+        assert_eq!(
+            iggy_duration.as_human_time_string(),
+            "1year 1month 28days 1h 13m 37s"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Replace usage of human-time with format_duration from humantime crate
