### PR TITLE
Don't run sanity on test_nightly

### DIFF
--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -16,10 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  sanity:
-    uses: ./.github/workflows/sanity.yml
   build_and_test:
-    needs: sanity
     name: ${{ matrix.platform.skip_tests == true && 'build' || 'build and test' }} ${{ matrix.platform.os_name }}
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 45
@@ -95,9 +92,7 @@ jobs:
         if: runner.os != 'Windows'
   finalize:
     runs-on: ubuntu-latest
-    needs:
-      - sanity
-      - build_and_test
+    needs: build_and_test
     if: always()
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
No sense in running it, since it's required to every
PR. This fixes #306.
