### PR TITLE
Add new user commands to iggy cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.0.120"
+version = "0.0.121"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1604,6 +1604,7 @@ dependencies = [
  "keyring",
  "lazy_static",
  "openssl",
+ "passterm",
  "quinn",
  "regex",
  "reqwest",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.9.2"
+version = "0.10.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -29,7 +29,7 @@ static CARGO_PKG_HOMEPAGE: &str = env!("CARGO_PKG_HOMEPAGE");
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 pub(crate) struct IggyConsoleArgs {
-    #[clap(flatten)]
+    #[clap(flatten, verbatim_doc_comment)]
     pub(crate) iggy: IggyArgs,
 
     #[clap(subcommand)]
@@ -48,7 +48,11 @@ pub(crate) struct IggyConsoleArgs {
     pub(crate) username: Option<String>,
 
     /// Iggy server password
-    #[clap(short, long)]
+    ///
+    /// An optional parameter to specify the password for authentication.
+    /// If not provided, user will be prompted interactively to enter the
+    /// password securely.
+    #[clap(short, long, verbatim_doc_comment)]
     pub(crate) password: Option<String>,
 
     /// Iggy server personal access token
@@ -58,9 +62,9 @@ pub(crate) struct IggyConsoleArgs {
     /// Iggy server personal access token name
     ///
     /// When personal access token is created using command line tool and stored
-    /// inside platform-specific secure storage its name can be used as an value for
-    /// this option without revealing token value.
-    #[clap(short = 'n', long, group = "credentials")]
+    /// inside platform-specific secure storage its name can be used as a value
+    /// for this option without revealing the token value.
+    #[clap(short = 'n', long, group = "credentials", verbatim_doc_comment)]
     pub(crate) token_name: Option<String>,
 
     /// Shell completion generator for iggy command

--- a/cmd/src/args/user.rs
+++ b/cmd/src/args/user.rs
@@ -11,8 +11,6 @@ use super::permissions::global::GlobalPermissionsArg;
 pub(crate) enum UserAction {
     /// Create user with given username and password
     ///
-    /// Stream ID can be specified as a stream name or ID
-    ///
     /// Examples
     ///  iggy user create testuser pass#1%X!
     ///  iggy user create guest guess --user-status inactive
@@ -44,13 +42,49 @@ pub(crate) enum UserAction {
     ///  iggy user list -l table
     #[clap(verbatim_doc_comment)]
     List(UserListArgs),
+    /// Change username for user with given ID
+    ///
+    /// User ID can be specified as a username or ID
+    ///
+    /// Examples:
+    ///  iggy user name 2 new_user_name
+    ///  iggy user name testuser test_user
+    #[clap(verbatim_doc_comment)]
+    Name(UserNameArgs),
+    /// Change status for user with given ID
+    ///
+    /// User ID can be specified as a username or ID
+    ///
+    /// Examples:
+    ///  iggy user status 2 active
+    ///  iggy user status testuser inactive
+    #[clap(verbatim_doc_comment)]
+    Status(UserStatusArgs),
+    /// Change password for user with given ID
+    ///
+    /// User ID can be specified as a username or ID
+    ///
+    /// Examples:
+    ///  iggy user password 2
+    ///  iggy user password client
+    ///  iggy user password 3 current_password new_password
+    ///  iggy user password testuser curpwd p@sswor4
+    #[clap(verbatim_doc_comment)]
+    Password(UserPasswordArgs),
 }
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct UserCreateArgs {
     /// Username
+    ///
+    /// Unique identifier for the user account on iggy server,
+    /// must be between 3 and 50 characters long.
+    #[clap(verbatim_doc_comment)]
     pub(crate) username: String,
     /// Password
+    ///
+    /// Password of the user, must be between 3 and 100 characters long.
+    #[clap(verbatim_doc_comment)]
     pub(crate) password: String,
     /// User status
     #[clap(short, long)]
@@ -131,4 +165,52 @@ pub(crate) struct UserListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
     pub(crate) list_mode: ListMode,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct UserNameArgs {
+    /// User ID to update
+    ///
+    /// User ID can be specified as a username or ID
+    pub(crate) user_id: Identifier,
+    /// New username
+    ///
+    /// New and unique identifier for the user account on iggy server,
+    /// must be between 3 and 50 characters long.
+    #[clap(verbatim_doc_comment)]
+    pub(crate) username: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct UserStatusArgs {
+    /// User ID to update
+    ///
+    /// User ID can be specified as a username or ID
+    pub(crate) user_id: Identifier,
+    /// New status
+    pub(crate) status: UserStatusArg,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct UserPasswordArgs {
+    /// User ID to update
+    ///
+    /// User ID can be specified as a username or ID
+    pub(crate) user_id: Identifier,
+    /// Current password
+    ///
+    /// Current password, must be between 3 and 100 characters long.
+    /// An optional parameter to specify the current password for the given user.
+    /// If not provided, the user will be prompted interactively to enter the
+    /// password securely, and the quiet mode option will not have any effect.
+    #[clap(verbatim_doc_comment)]
+    pub(crate) current_password: Option<String>,
+    /// New password
+    ///
+    /// New password, must be between 3 and 100 characters long.
+    /// An optional parameter to specify the new password for the given user.
+    /// If not provided, the user will be prompted interactively to enter the
+    /// password securely, and the quiet mode option will not have any effect.
+    #[clap(verbatim_doc_comment)]
+    pub(crate) new_password: Option<String>,
 }

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -18,6 +18,8 @@ use iggy::cli_command::{CliCommand, PRINT_TARGET};
 use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
 use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::cmd::users::change_password::ChangePasswordCmd;
+use iggy::cmd::users::update_user::{UpdateUserCmd, UpdateUserType};
 use iggy::cmd::{
     partitions::{create_partitions::CreatePartitionsCmd, delete_partitions::DeletePartitionsCmd},
     personal_access_tokens::{
@@ -124,25 +126,34 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
             ),
         },
         Command::User(command) => match command {
-            UserAction::Create(user_create_args) => Box::new(CreateUserCmd::new(
-                user_create_args.username.clone(),
-                user_create_args.password.clone(),
-                user_create_args.user_status.clone().into(),
+            UserAction::Create(create_args) => Box::new(CreateUserCmd::new(
+                create_args.username.clone(),
+                create_args.password.clone(),
+                create_args.user_status.clone().into(),
                 PermissionsArgs::new(
-                    user_create_args.global_permissions.clone(),
-                    user_create_args.stream_permissions.clone(),
+                    create_args.global_permissions.clone(),
+                    create_args.stream_permissions.clone(),
                 )
                 .into(),
             )),
-            UserAction::Delete(user_delete_args) => {
-                Box::new(DeleteUserCmd::new(user_delete_args.user_id.clone()))
+            UserAction::Delete(delete_args) => {
+                Box::new(DeleteUserCmd::new(delete_args.user_id.clone()))
             }
-            UserAction::Get(user_get_args) => {
-                Box::new(GetUserCmd::new(user_get_args.user_id.clone()))
-            }
-            UserAction::List(user_list_args) => {
-                Box::new(GetUsersCmd::new(user_list_args.list_mode.into()))
-            }
+            UserAction::Get(get_args) => Box::new(GetUserCmd::new(get_args.user_id.clone())),
+            UserAction::List(list_args) => Box::new(GetUsersCmd::new(list_args.list_mode.into())),
+            UserAction::Name(name_args) => Box::new(UpdateUserCmd::new(
+                name_args.user_id.clone(),
+                UpdateUserType::Name(name_args.username.clone()),
+            )),
+            UserAction::Status(status_args) => Box::new(UpdateUserCmd::new(
+                status_args.user_id.clone(),
+                UpdateUserType::Status(status_args.status.clone().into()),
+            )),
+            UserAction::Password(change_pwd_args) => Box::new(ChangePasswordCmd::new(
+                change_pwd_args.user_id,
+                change_pwd_args.current_password,
+                change_pwd_args.new_password,
+            )),
         },
     }
 }
@@ -186,7 +197,11 @@ async fn main() -> Result<(), IggyCmdError> {
     credentials.set_iggy_client(&client);
     credentials.login_user().await?;
 
-    event!(target: PRINT_TARGET, Level::INFO, "Executing {}", command.explain());
+    if command.use_tracing() {
+        event!(target: PRINT_TARGET, Level::INFO, "Executing {}", command.explain());
+    } else {
+        println!("Executing {}", command.explain());
+    }
     command.execute_cmd(&client).await?;
 
     credentials.logout_user().await?;

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.0.120"
+version = "0.0.121"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"
@@ -30,6 +30,7 @@ humantime = "2.1.0"
 keyring = { version = "2.0.5", optional = true }
 lazy_static = "1.4.0"
 openssl = { version = "0.10.*", features = ["vendored"] }
+passterm = { version = "2.0.1", optional = true }
 quinn = "0.10.2"
 regex = "1.10.2"
 reqwest = { version = "0.11.*", features = ["json"] }
@@ -52,4 +53,4 @@ serde_derive = "1.0.*"
 
 [features]
 default = []
-iggy-cmd = ["dep:comfy-table", "dep:byte-unit", "dep:keyring"]
+iggy-cmd = ["dep:comfy-table", "dep:byte-unit", "dep:keyring", "dep:passterm"]

--- a/iggy/src/cli_command.rs
+++ b/iggy/src/cli_command.rs
@@ -7,6 +7,9 @@ pub static PRINT_TARGET: &str = "iggy::cmd::output";
 #[async_trait]
 pub trait CliCommand {
     fn explain(&self) -> String;
+    fn use_tracing(&self) -> bool {
+        true
+    }
     fn login_required(&self) -> bool {
         true
     }

--- a/iggy/src/cmd/users/change_password.rs
+++ b/iggy/src/cmd/users/change_password.rs
@@ -1,0 +1,89 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use crate::users::change_password::ChangePassword;
+use anyhow::Context;
+use async_trait::async_trait;
+use passterm::{isatty, prompt_password_stdin, prompt_password_tty, Stream};
+use tracing::{event, Level};
+
+pub struct ChangePasswordCmd {
+    user_id: Identifier,
+    current_password: Option<String>,
+    new_password: Option<String>,
+}
+
+impl ChangePasswordCmd {
+    pub fn new(
+        user_id: Identifier,
+        current_password: Option<String>,
+        new_password: Option<String>,
+    ) -> Self {
+        Self {
+            user_id,
+            current_password,
+            new_password,
+        }
+    }
+
+    fn use_tracing(&self) -> bool {
+        self.current_password.is_some() || self.new_password.is_some()
+    }
+}
+
+#[async_trait]
+impl CliCommand for ChangePasswordCmd {
+    fn explain(&self) -> String {
+        format!("change password for user with ID: {}", self.user_id,)
+    }
+
+    fn use_tracing(&self) -> bool {
+        self.use_tracing()
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let current_password = match &self.current_password {
+            Some(password) => password.clone(),
+            None => {
+                if isatty(Stream::Stdin) {
+                    prompt_password_tty(Some("Current password: "))?
+                } else {
+                    prompt_password_stdin(None, Stream::Stdout)?
+                }
+            }
+        };
+
+        let new_password = match &self.new_password {
+            Some(password) => password.clone(),
+            None => {
+                if isatty(Stream::Stdin) {
+                    prompt_password_tty(Some("New password: "))?
+                } else {
+                    prompt_password_stdin(None, Stream::Stdout)?
+                }
+            }
+        };
+
+        client
+            .change_password(&ChangePassword {
+                user_id: self.user_id.clone(),
+                current_password,
+                new_password,
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem changing password for user with ID: {}",
+                    self.user_id,
+                )
+            })?;
+
+        if self.use_tracing() {
+            event!(target: PRINT_TARGET, Level::INFO, "Password for user with ID: {} changed", self.user_id);
+        } else {
+            println!("Password for user with ID: {} changed", self.user_id);
+        }
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/users/mod.rs
+++ b/iggy/src/cmd/users/mod.rs
@@ -1,4 +1,6 @@
+pub mod change_password;
 pub mod create_user;
 pub mod delete_user;
 pub mod get_user;
 pub mod get_users;
+pub mod update_user;

--- a/iggy/src/cmd/users/update_user.rs
+++ b/iggy/src/cmd/users/update_user.rs
@@ -1,0 +1,75 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use crate::models::user_status::UserStatus;
+use crate::users::update_user::UpdateUser;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+#[derive(Debug, Clone)]
+pub enum UpdateUserType {
+    Name(String),
+    Status(UserStatus),
+}
+
+pub struct UpdateUserCmd {
+    update_type: UpdateUserType,
+    update_user: UpdateUser,
+}
+
+impl UpdateUserCmd {
+    pub fn new(user_id: Identifier, update_type: UpdateUserType) -> Self {
+        let (username, status) = match update_type.clone() {
+            UpdateUserType::Name(username) => (Some(username), None),
+            UpdateUserType::Status(status) => (None, Some(status)),
+        };
+
+        UpdateUserCmd {
+            update_type,
+            update_user: UpdateUser {
+                user_id,
+                username,
+                status,
+            },
+        }
+    }
+
+    fn get_message(&self) -> String {
+        match &self.update_type {
+            UpdateUserType::Name(username) => format!("username: {}", username),
+            UpdateUserType::Status(status) => format!("status: {}", status),
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for UpdateUserCmd {
+    fn explain(&self) -> String {
+        format!(
+            "update user with ID: {} with {}",
+            self.update_user.user_id,
+            self.get_message()
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .update_user(&self.update_user)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem updating user with ID: {} with {}",
+                    self.update_user.user_id,
+                    self.get_message()
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "User with ID: {} updated with {}",
+            self.update_user.user_id, self.get_message()
+        );
+
+        Ok(())
+    }
+}

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -148,6 +148,10 @@ Options:
 
   -p, --password <PASSWORD>
           Iggy server password
+{CLAP_INDENT}
+          An optional parameter to specify the password for authentication.
+          If not provided, user will be prompted interactively to enter the
+          password securely.
 
   -t, --token <TOKEN>
           Iggy server personal access token
@@ -155,7 +159,9 @@ Options:
   -n, --token-name <TOKEN_NAME>
           Iggy server personal access token name
 {CLAP_INDENT}
-          When personal access token is created using command line tool and stored inside platform-specific secure storage its name can be used as an value for this option without revealing token value.
+          When personal access token is created using command line tool and stored
+          inside platform-specific secure storage its name can be used as a value
+          for this option without revealing the token value.
 
       --generate <GENERATOR>
           Shell completion generator for iggy command

--- a/integration/tests/cmd/user/mod.rs
+++ b/integration/tests/cmd/user/mod.rs
@@ -2,4 +2,8 @@ mod test_login_options;
 mod test_user_create_command;
 mod test_user_delete_command;
 mod test_user_get_command;
+mod test_user_help_command;
 mod test_user_list_command;
+mod test_user_name_command;
+mod test_user_password_command;
+mod test_user_status_command;

--- a/integration/tests/cmd/user/test_user_create_command.rs
+++ b/integration/tests/cmd/user/test_user_create_command.rs
@@ -301,8 +301,6 @@ pub async fn should_help_match() {
             format!(
                 r#"Create user with given username and password
 
-Stream ID can be specified as a stream name or ID
-
 Examples
  iggy user create testuser pass#1%X!
  iggy user create guest guess --user-status inactive
@@ -312,9 +310,14 @@ Examples
 Arguments:
   <USERNAME>
           Username
+{CLAP_INDENT}
+          Unique identifier for the user account on iggy server,
+          must be between 3 and 50 characters long.
 
   <PASSWORD>
           Password
+{CLAP_INDENT}
+          Password of the user, must be between 3 and 100 characters long.
 
 Options:
   -u, --user-status <USER_STATUS>

--- a/integration/tests/cmd/user/test_user_help_command.rs
+++ b/integration/tests/cmd/user/test_user_help_command.rs
@@ -1,0 +1,33 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "help"],
+            format!(
+                r#"user operations
+
+{USAGE_PREFIX} user <COMMAND>
+
+Commands:
+  create    Create user with given username and password
+  delete    Delete user with given ID
+  get       Get details of a single user with given ID
+  list      List all users
+  name      Change username for user with given ID
+  status    Change status for user with given ID
+  password  Change password for user with given ID
+  help      Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/user/test_user_name_command.rs
+++ b/integration/tests/cmd/user/test_user_name_command.rs
@@ -1,0 +1,192 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestUserId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::models::user_info::UserId;
+use iggy::users::create_user::CreateUser;
+use iggy::users::delete_user::DeleteUser;
+use iggy::users::get_user::GetUser;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestUserNameCmd {
+    username: String,
+    new_username: String,
+    using_identifier: TestUserId,
+    user_id: Option<UserId>,
+}
+
+impl TestUserNameCmd {
+    fn new(username: String, new_username: String, using_identifier: TestUserId) -> Self {
+        Self {
+            username,
+            new_username,
+            using_identifier,
+            user_id: None,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        match self.using_identifier {
+            TestUserId::Named => vec![self.username.clone(), self.new_username.clone()],
+            TestUserId::Numeric => {
+                vec![
+                    format!("{}", self.user_id.unwrap()),
+                    self.new_username.clone(),
+                ]
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestUserNameCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let create_user = client
+            .create_user(&CreateUser {
+                username: self.username.clone(),
+                ..Default::default()
+            })
+            .await;
+        assert!(create_user.is_ok());
+        let user = client
+            .get_user(&GetUser {
+                user_id: Identifier::from_str_value(self.username.as_str()).unwrap(),
+            })
+            .await;
+        assert!(user.is_ok());
+        self.user_id = Some(user.unwrap().id);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("user")
+            .arg("name")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let numeric_id = self.user_id.unwrap().to_string();
+        let identifier = match self.using_identifier {
+            TestUserId::Named => &self.username,
+            TestUserId::Numeric => &numeric_id,
+        };
+
+        let message = format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n",
+                                      identifier, self.new_username, identifier, self.new_username);
+
+        // let message = match self.using_identifier {
+        //     TestUserId::Named => format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n", self.username, self.new_username, self.username, self.new_username),
+        //     TestUserId::Numeric => format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n", self.user_id.unwrap(), self.new_username, self.user_id.unwrap(), self.new_username),
+        // };
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let deleted = client
+            .delete_user(&DeleteUser {
+                user_id: Identifier::numeric(self.user_id.unwrap()).unwrap(),
+            })
+            .await;
+        assert!(deleted.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestUserNameCmd::new(
+            String::from("tester"),
+            String::from("testing"),
+            TestUserId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserNameCmd::new(
+            String::from("user1"),
+            String::from("producer"),
+            TestUserId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserNameCmd::new(
+            String::from("same_name"),
+            String::from("same_name"),
+            TestUserId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "name", "--help"],
+            format!(
+                r#"Change username for user with given ID
+
+User ID can be specified as a username or ID
+
+Examples:
+ iggy user name 2 new_user_name
+ iggy user name testuser test_user
+
+{USAGE_PREFIX} user name <USER_ID> <USERNAME>
+
+Arguments:
+  <USER_ID>
+          User ID to update
+{CLAP_INDENT}
+          User ID can be specified as a username or ID
+
+  <USERNAME>
+          New username
+{CLAP_INDENT}
+          New and unique identifier for the user account on iggy server,
+          must be between 3 and 50 characters long.
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "name", "-h"],
+            format!(
+                r#"Change username for user with given ID
+
+{USAGE_PREFIX} user name <USER_ID> <USERNAME>
+
+Arguments:
+  <USER_ID>   User ID to update
+  <USERNAME>  New username
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/user/test_user_password_command.rs
+++ b/integration/tests/cmd/user/test_user_password_command.rs
@@ -1,0 +1,226 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestUserId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::models::user_info::UserId;
+use iggy::users::create_user::CreateUser;
+use iggy::users::delete_user::DeleteUser;
+use iggy::users::get_user::GetUser;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestUserPasswordCmd {
+    username: String,
+    password: String,
+    new_password: String,
+    using_identifier: TestUserId,
+    user_id: Option<UserId>,
+}
+
+impl TestUserPasswordCmd {
+    fn new(
+        username: String,
+        password: String,
+        new_password: String,
+        using_identifier: TestUserId,
+    ) -> Self {
+        Self {
+            username,
+            password,
+            new_password,
+            using_identifier,
+            user_id: None,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        match self.using_identifier {
+            TestUserId::Named => vec![
+                self.username.clone(),
+                self.password.clone(),
+                format!("{}", self.new_password.clone()),
+            ],
+            TestUserId::Numeric => {
+                vec![
+                    format!("{}", self.user_id.unwrap()),
+                    self.password.clone(),
+                    format!("{}", self.new_password.clone()),
+                ]
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestUserPasswordCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let create_user = client
+            .create_user(&CreateUser {
+                username: self.username.clone(),
+                password: self.password.clone(),
+                ..Default::default()
+            })
+            .await;
+        assert!(create_user.is_ok());
+        let user = client
+            .get_user(&GetUser {
+                user_id: Identifier::from_str_value(self.username.as_str()).unwrap(),
+            })
+            .await;
+        assert!(user.is_ok());
+        self.user_id = Some(user.unwrap().id);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("user")
+            .arg("password")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let message = match self.using_identifier {
+            TestUserId::Named => format!(
+                "Executing change password for user with ID: {}\nPassword for user with ID: {} changed\n",
+                self.username, self.username
+            ),
+            TestUserId::Numeric => format!(
+                "Executing change password for user with ID: {}\nPassword for user with ID: {} changed\n",
+                self.user_id.unwrap(), self.user_id.unwrap()
+            ),
+        };
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let deleted = client
+            .delete_user(&DeleteUser {
+                user_id: Identifier::numeric(self.user_id.unwrap()).unwrap(),
+            })
+            .await;
+        assert!(deleted.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestUserPasswordCmd::new(
+            String::from("user"),
+            String::from("password"),
+            String::from("new-password"),
+            TestUserId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserPasswordCmd::new(
+            String::from("admin"),
+            String::from("easy-pass"),
+            String::from("P@$$w0r4"),
+            TestUserId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserPasswordCmd::new(
+            String::from("easy_one"),
+            String::from("1234"),
+            String::from("4321"),
+            TestUserId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserPasswordCmd::new(
+            String::from("same_all_the_time"),
+            String::from("password"),
+            String::from("password"),
+            TestUserId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "password", "--help"],
+            format!(
+                r#"Change password for user with given ID
+
+User ID can be specified as a username or ID
+
+Examples:
+ iggy user password 2
+ iggy user password client
+ iggy user password 3 current_password new_password
+ iggy user password testuser curpwd p@sswor4
+
+{USAGE_PREFIX} user password <USER_ID> [CURRENT_PASSWORD] [NEW_PASSWORD]
+
+Arguments:
+  <USER_ID>
+          User ID to update
+{CLAP_INDENT}
+          User ID can be specified as a username or ID
+
+  [CURRENT_PASSWORD]
+          Current password
+{CLAP_INDENT}
+          Current password, must be between 3 and 100 characters long.
+          An optional parameter to specify the current password for the given user.
+          If not provided, the user will be prompted interactively to enter the
+          password securely, and the quiet mode option will not have any effect.
+
+  [NEW_PASSWORD]
+          New password
+{CLAP_INDENT}
+          New password, must be between 3 and 100 characters long.
+          An optional parameter to specify the new password for the given user.
+          If not provided, the user will be prompted interactively to enter the
+          password securely, and the quiet mode option will not have any effect.
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "password", "-h"],
+            format!(
+                r#"Change password for user with given ID
+
+{USAGE_PREFIX} user password <USER_ID> [CURRENT_PASSWORD] [NEW_PASSWORD]
+
+Arguments:
+  <USER_ID>           User ID to update
+  [CURRENT_PASSWORD]  Current password
+  [NEW_PASSWORD]      New password
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/user/test_user_status_command.rs
+++ b/integration/tests/cmd/user/test_user_status_command.rs
@@ -1,0 +1,205 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestUserId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::models::user_info::UserId;
+use iggy::models::user_status::UserStatus;
+use iggy::users::create_user::CreateUser;
+use iggy::users::delete_user::DeleteUser;
+use iggy::users::get_user::GetUser;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestUserStatusCmd {
+    username: String,
+    status: UserStatus,
+    new_status: UserStatus,
+    using_identifier: TestUserId,
+    user_id: Option<UserId>,
+}
+
+impl TestUserStatusCmd {
+    fn new(
+        username: String,
+        status: UserStatus,
+        new_status: UserStatus,
+        using_identifier: TestUserId,
+    ) -> Self {
+        Self {
+            username,
+            status,
+            new_status,
+            using_identifier,
+            user_id: None,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        match self.using_identifier {
+            TestUserId::Named => vec![
+                self.username.clone(),
+                format!("{}", self.new_status.clone()),
+            ],
+            TestUserId::Numeric => {
+                vec![
+                    format!("{}", self.user_id.unwrap()),
+                    format!("{}", self.new_status.clone()),
+                ]
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestUserStatusCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let create_user = client
+            .create_user(&CreateUser {
+                username: self.username.clone(),
+                status: self.status,
+                ..Default::default()
+            })
+            .await;
+        assert!(create_user.is_ok());
+        let user = client
+            .get_user(&GetUser {
+                user_id: Identifier::from_str_value(self.username.as_str()).unwrap(),
+            })
+            .await;
+        assert!(user.is_ok());
+        self.user_id = Some(user.unwrap().id);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("user")
+            .arg("status")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let message = match self.using_identifier {
+            TestUserId::Named => format!("Executing update user with ID: {} with status: {}\nUser with ID: {} updated with status: {}\n", self.username, self.new_status, self.username, self.new_status),
+            TestUserId::Numeric => format!("Executing update user with ID: {} with status: {}\nUser with ID: {} updated with status: {}\n", self.user_id.unwrap(), self.new_status, self.user_id.unwrap(), self.new_status),
+        };
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let deleted = client
+            .delete_user(&DeleteUser {
+                user_id: Identifier::numeric(self.user_id.unwrap()).unwrap(),
+            })
+            .await;
+        assert!(deleted.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestUserStatusCmd::new(
+            String::from("user"),
+            UserStatus::Active,
+            UserStatus::Inactive,
+            TestUserId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserStatusCmd::new(
+            String::from("admin"),
+            UserStatus::Inactive,
+            UserStatus::Active,
+            TestUserId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserStatusCmd::new(
+            String::from("inactive_user"),
+            UserStatus::Inactive,
+            UserStatus::Inactive,
+            TestUserId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestUserStatusCmd::new(
+            String::from("active_user"),
+            UserStatus::Active,
+            UserStatus::Active,
+            TestUserId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "status", "--help"],
+            format!(
+                r#"Change status for user with given ID
+
+User ID can be specified as a username or ID
+
+Examples:
+ iggy user status 2 active
+ iggy user status testuser inactive
+
+{USAGE_PREFIX} user status <USER_ID> <STATUS>
+
+Arguments:
+  <USER_ID>
+          User ID to update
+{CLAP_INDENT}
+          User ID can be specified as a username or ID
+
+  <STATUS>
+          New status
+{CLAP_INDENT}
+          [possible values: active, inactive]
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["user", "status", "-h"],
+            format!(
+                r#"Change status for user with given ID
+
+{USAGE_PREFIX} user status <USER_ID> <STATUS>
+
+Arguments:
+  <USER_ID>  User ID to update
+  <STATUS>   New status [possible values: active, inactive]
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}


### PR DESCRIPTION
Adding user name, status and password commands for changing given user
login / username, status (active / inactive) and password using iggy
command line tool. Adding integration tests for those commands.
Extend CliCommand trait with new method which allows particular commands
to use direct standard output for printing messages instead of tracing
events. Using new method for user password command which interactively
asks user in a secure way for current and new password.
