### PR TITLE
Add user permissions command to iggy cmd

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1585,7 +1585,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.0.121"
+version = "0.0.122"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/user.rs
+++ b/cmd/src/args/user.rs
@@ -18,7 +18,7 @@ pub(crate) enum UserAction {
     Create(UserCreateArgs),
     /// Delete user with given ID
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     ///
     /// Examples:
     ///  iggy user delete 2
@@ -27,7 +27,7 @@ pub(crate) enum UserAction {
     Delete(UserDeleteArgs),
     /// Get details of a single user with given ID
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     ///
     /// Examples:
     ///  iggy user get 2
@@ -44,7 +44,7 @@ pub(crate) enum UserAction {
     List(UserListArgs),
     /// Change username for user with given ID
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     ///
     /// Examples:
     ///  iggy user name 2 new_user_name
@@ -53,7 +53,7 @@ pub(crate) enum UserAction {
     Name(UserNameArgs),
     /// Change status for user with given ID
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     ///
     /// Examples:
     ///  iggy user status 2 active
@@ -62,7 +62,7 @@ pub(crate) enum UserAction {
     Status(UserStatusArgs),
     /// Change password for user with given ID
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     ///
     /// Examples:
     ///  iggy user password 2
@@ -71,6 +71,18 @@ pub(crate) enum UserAction {
     ///  iggy user password testuser curpwd p@sswor4
     #[clap(verbatim_doc_comment)]
     Password(UserPasswordArgs),
+    /// Set permissions for user with given ID
+    ///
+    /// The user ID can be specified as either a username or an ID. Permissions
+    /// are configured based on the options provided with this command. If no
+    /// options are set, the default behavior is to remove permissions for the
+    /// specified user.
+    ///
+    /// Examples:
+    ///  iggy user permissions 2
+    ///  iggy user permissions client
+    #[clap(verbatim_doc_comment)]
+    Permissions(UserPermissionsArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -148,7 +160,7 @@ pub(crate) struct UserCreateArgs {
 pub(crate) struct UserDeleteArgs {
     /// User ID to delete
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     pub(crate) user_id: Identifier,
 }
 
@@ -156,7 +168,7 @@ pub(crate) struct UserDeleteArgs {
 pub(crate) struct UserGetArgs {
     /// User ID to get
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     pub(crate) user_id: Identifier,
 }
 
@@ -171,7 +183,7 @@ pub(crate) struct UserListArgs {
 pub(crate) struct UserNameArgs {
     /// User ID to update
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     pub(crate) user_id: Identifier,
     /// New username
     ///
@@ -185,7 +197,7 @@ pub(crate) struct UserNameArgs {
 pub(crate) struct UserStatusArgs {
     /// User ID to update
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     pub(crate) user_id: Identifier,
     /// New status
     pub(crate) status: UserStatusArg,
@@ -195,7 +207,7 @@ pub(crate) struct UserStatusArgs {
 pub(crate) struct UserPasswordArgs {
     /// User ID to update
     ///
-    /// User ID can be specified as a username or ID
+    /// The user ID can be specified as either a username or an ID
     pub(crate) user_id: Identifier,
     /// Current password
     ///
@@ -213,4 +225,64 @@ pub(crate) struct UserPasswordArgs {
     /// password securely, and the quiet mode option will not have any effect.
     #[clap(verbatim_doc_comment)]
     pub(crate) new_password: Option<String>,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct UserPermissionsArgs {
+    /// User ID to update
+    ///
+    /// The user ID can be specified as either a username or an ID
+    pub(crate) user_id: Identifier,
+    /// Set global permissions for created user
+    ///
+    /// All global permissions by default are set to false and this command line option
+    /// allows to set each permission individually. Permissions are separated
+    /// by comma and each permission is identified by the same name as in the iggy
+    /// SDK in iggy::models::permissions::GlobalPermissions struct. For each permission
+    /// there's long variant (same as in SDK) and short variant.
+    ///
+    /// Available permissions (long and short versions):  manage_servers / m_srv,
+    /// read_servers / r_srv, manage_users / m_usr, read_users / r_usr,
+    /// manage_streams / m_str, read_streams / r_str, manage_topics / m_top,
+    /// read_topics / r_top, poll_messages / p_msg, send_messages / s_msg
+    ///
+    /// Examples:
+    ///  iggy user create guest guess --global-permissions p_msg,s_msg
+    ///  iggy user create admin pass#1%X! -g m_srv,r_srv,m_usr,r_usr,m_str,r_str,m_top,r_top,p_msg,s_msg
+    #[clap(short, long, verbatim_doc_comment)]
+    #[arg(value_parser = clap::value_parser!(GlobalPermissionsArg))]
+    pub(crate) global_permissions: Option<GlobalPermissionsArg>,
+    /// Set stream permissions for created user
+    ///
+    /// Stream permissions are defined by each stream separately. Setting permission for stream
+    /// allows to set each permission individually, by default, if no permission is provided
+    /// (only stream ID is provided) all are set fo false. Stream permission format consists
+    /// of stream ID followed by colon (:) and list of permissions separated by comma (,).
+    /// For each stream permission there's long variant (same as in SDK in
+    /// iggy::models::permissions::StreamPermissions) and short variant.
+    ///
+    /// Available stream permissions: manage_stream / m_str, read_stream / r_str, manage_topics / m_top,
+    /// read_topics / r_top, poll_messages / p_msg, send_messages / s_msg.
+    ///
+    /// For each stream one can set permissions for each topic separately. Topic permissions
+    /// are defined for each topic separately. Setting permission for topic allows to set each
+    /// permission individually, by default, if no permission is provided (only topic ID is provided)
+    /// all are set fo false. Topic permission format consists of topic ID followed by colon (:)
+    /// and list of permissions separated by comma (,). For each topic permission there's long
+    /// variant (same as in SDK in iggy::models::permissions::TopicPermissions) and short variant.
+    /// Topic permissions are separated by hash (#) after stream permissions.
+    ///
+    /// Available topic permissions: manage_topic / m_top, read_topic / r_top, poll_messages / p_msg,
+    /// send_messages / s_msg.
+    ///
+    /// Permissions format: STREAM_ID[:STREAM_PERMISSIONS][#TOPIC_ID[:TOPIC_PERMISSIONS]]
+    ///
+    /// Examples:
+    ///  iggy user create guest guest -s 1:manage_topics,read_topics
+    ///  iggy user create admin p@Ss! --stream-permissions 2:m_str,r_str,m_top,r_top,p_msg,s_msg
+    ///  iggy user create sender s3n43r -s 3#1:s_msg#2:s_msg
+    ///  iggy user create user1 test12 -s 4:manage_stream,r_top#1:s_msg,p_msg#2:manage_topic
+    #[clap(short, long, verbatim_doc_comment)]
+    #[arg(value_parser = clap::value_parser!(StreamPermissionsArg))]
+    pub(crate) stream_permissions: Option<Vec<StreamPermissionsArg>>,
 }

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -19,6 +19,7 @@ use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
 use iggy::clients::client::{IggyClient, IggyClientConfig};
 use iggy::cmd::users::change_password::ChangePasswordCmd;
+use iggy::cmd::users::update_permissions::UpdatePermissionsCmd;
 use iggy::cmd::users::update_user::{UpdateUserCmd, UpdateUserType};
 use iggy::cmd::{
     partitions::{create_partitions::CreatePartitionsCmd, delete_partitions::DeletePartitionsCmd},
@@ -153,6 +154,14 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
                 change_pwd_args.user_id,
                 change_pwd_args.current_password,
                 change_pwd_args.new_password,
+            )),
+            UserAction::Permissions(permissions_args) => Box::new(UpdatePermissionsCmd::new(
+                permissions_args.user_id.clone(),
+                PermissionsArgs::new(
+                    permissions_args.global_permissions.clone(),
+                    permissions_args.stream_permissions.clone(),
+                )
+                .into(),
             )),
         },
     }

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.0.121"
+version = "0.0.122"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/iggy/src/cmd/users/mod.rs
+++ b/iggy/src/cmd/users/mod.rs
@@ -3,4 +3,5 @@ pub mod create_user;
 pub mod delete_user;
 pub mod get_user;
 pub mod get_users;
+pub mod update_permissions;
 pub mod update_user;

--- a/iggy/src/cmd/users/update_permissions.rs
+++ b/iggy/src/cmd/users/update_permissions.rs
@@ -1,0 +1,52 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use crate::models::permissions::Permissions;
+use crate::users::update_permissions::UpdatePermissions;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct UpdatePermissionsCmd {
+    update_permissions: UpdatePermissions,
+}
+
+impl UpdatePermissionsCmd {
+    pub fn new(user_id: Identifier, permissions: Option<Permissions>) -> Self {
+        Self {
+            update_permissions: UpdatePermissions {
+                user_id,
+                permissions,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for UpdatePermissionsCmd {
+    fn explain(&self) -> String {
+        format!(
+            "update permissions for user with ID: {}",
+            self.update_permissions.user_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .update_permissions(&self.update_permissions)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem updating permissions for user with ID: {}",
+                    self.update_permissions.user_id
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Permissions for user with ID: {} updated",
+            self.update_permissions.user_id
+        );
+
+        Ok(())
+    }
+}

--- a/integration/tests/cmd/user/common.rs
+++ b/integration/tests/cmd/user/common.rs
@@ -1,0 +1,38 @@
+use iggy::models::permissions::Permissions;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PermissionsTestArgs {
+    pub(crate) global_permissions: Option<String>,
+    pub(crate) stream_permissions: Vec<String>,
+    pub(crate) expected_permissions: Option<Permissions>,
+}
+
+impl PermissionsTestArgs {
+    pub(crate) fn new(
+        global_permissions: Option<String>,
+        stream_permissions: Vec<String>,
+        expected_permissions: Option<Permissions>,
+    ) -> Self {
+        Self {
+            global_permissions,
+            stream_permissions,
+            expected_permissions,
+        }
+    }
+
+    pub(crate) fn as_arg(&self) -> Vec<String> {
+        let mut args = vec![];
+        if let Some(global_permissions) = &self.global_permissions {
+            args.push(String::from("--global-permissions"));
+            args.push(global_permissions.clone());
+        }
+
+        args.extend(
+            self.stream_permissions
+                .iter()
+                .flat_map(|i| vec![String::from("--stream-permissions"), i.clone()])
+                .collect::<Vec<String>>(),
+        );
+        args
+    }
+}

--- a/integration/tests/cmd/user/mod.rs
+++ b/integration/tests/cmd/user/mod.rs
@@ -1,3 +1,4 @@
+mod common;
 mod test_login_options;
 mod test_user_create_command;
 mod test_user_delete_command;
@@ -6,4 +7,5 @@ mod test_user_help_command;
 mod test_user_list_command;
 mod test_user_name_command;
 mod test_user_password_command;
+mod test_user_permissions_command;
 mod test_user_status_command;

--- a/integration/tests/cmd/user/test_user_delete_command.rs
+++ b/integration/tests/cmd/user/test_user_delete_command.rs
@@ -126,7 +126,7 @@ pub async fn should_help_match() {
             format!(
                 r"Delete user with given ID
 
-User ID can be specified as a username or ID
+The user ID can be specified as either a username or an ID
 
 Examples:
  iggy user delete 2
@@ -138,7 +138,7 @@ Arguments:
   <USER_ID>
           User ID to delete
 {CLAP_INDENT}
-          User ID can be specified as a username or ID
+          The user ID can be specified as either a username or an ID
 
 Options:
   -h, --help

--- a/integration/tests/cmd/user/test_user_get_command.rs
+++ b/integration/tests/cmd/user/test_user_get_command.rs
@@ -242,7 +242,7 @@ pub async fn should_help_match() {
             format!(
                 r#"Get details of a single user with given ID
 
-User ID can be specified as a username or ID
+The user ID can be specified as either a username or an ID
 
 Examples:
  iggy user get 2
@@ -254,7 +254,7 @@ Arguments:
   <USER_ID>
           User ID to get
 {CLAP_INDENT}
-          User ID can be specified as a username or ID
+          The user ID can be specified as either a username or an ID
 
 Options:
   -h, --help

--- a/integration/tests/cmd/user/test_user_help_command.rs
+++ b/integration/tests/cmd/user/test_user_help_command.rs
@@ -15,14 +15,15 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} user <COMMAND>
 
 Commands:
-  create    Create user with given username and password
-  delete    Delete user with given ID
-  get       Get details of a single user with given ID
-  list      List all users
-  name      Change username for user with given ID
-  status    Change status for user with given ID
-  password  Change password for user with given ID
-  help      Print this message or the help of the given subcommand(s)
+  create       Create user with given username and password
+  delete       Delete user with given ID
+  get          Get details of a single user with given ID
+  list         List all users
+  name         Change username for user with given ID
+  status       Change status for user with given ID
+  password     Change password for user with given ID
+  permissions  Set permissions for user with given ID
+  help         Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/integration/tests/cmd/user/test_user_name_command.rs
+++ b/integration/tests/cmd/user/test_user_name_command.rs
@@ -79,11 +79,6 @@ impl IggyCmdTestCase for TestUserNameCmd {
         let message = format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n",
                                       identifier, self.new_username, identifier, self.new_username);
 
-        // let message = match self.using_identifier {
-        //     TestUserId::Named => format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n", self.username, self.new_username, self.username, self.new_username),
-        //     TestUserId::Numeric => format!("Executing update user with ID: {} with username: {}\nUser with ID: {} updated with username: {}\n", self.user_id.unwrap(), self.new_username, self.user_id.unwrap(), self.new_username),
-        // };
-
         command_state.success().stdout(diff(message));
     }
 
@@ -137,7 +132,7 @@ pub async fn should_help_match() {
             format!(
                 r#"Change username for user with given ID
 
-User ID can be specified as a username or ID
+The user ID can be specified as either a username or an ID
 
 Examples:
  iggy user name 2 new_user_name
@@ -149,7 +144,7 @@ Arguments:
   <USER_ID>
           User ID to update
 {CLAP_INDENT}
-          User ID can be specified as a username or ID
+          The user ID can be specified as either a username or an ID
 
   <USERNAME>
           New username

--- a/integration/tests/cmd/user/test_user_password_command.rs
+++ b/integration/tests/cmd/user/test_user_password_command.rs
@@ -158,7 +158,7 @@ pub async fn should_help_match() {
             format!(
                 r#"Change password for user with given ID
 
-User ID can be specified as a username or ID
+The user ID can be specified as either a username or an ID
 
 Examples:
  iggy user password 2
@@ -172,7 +172,7 @@ Arguments:
   <USER_ID>
           User ID to update
 {CLAP_INDENT}
-          User ID can be specified as a username or ID
+          The user ID can be specified as either a username or an ID
 
   [CURRENT_PASSWORD]
           Current password

--- a/integration/tests/cmd/user/test_user_status_command.rs
+++ b/integration/tests/cmd/user/test_user_status_command.rs
@@ -151,7 +151,7 @@ pub async fn should_help_match() {
             format!(
                 r#"Change status for user with given ID
 
-User ID can be specified as a username or ID
+The user ID can be specified as either a username or an ID
 
 Examples:
  iggy user status 2 active
@@ -163,7 +163,7 @@ Arguments:
   <USER_ID>
           User ID to update
 {CLAP_INDENT}
-          User ID can be specified as a username or ID
+          The user ID can be specified as either a username or an ID
 
   <STATUS>
           New status


### PR DESCRIPTION
Add command user permissions which allows to set permissions for given user. Command has same set of permissions related parameters as user create command. Add integration test for checking user permissions command. Improved help message for user commands where user ID is used.