### PR TITLE
Test automatic release of iggy-server to dockerhub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.0.52"
+version = "0.0.53"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.0.52"
+version = "0.0.53"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Upon merge of this commit, new tag shall be created, eg. iggy-0.0.123 and SDK 'iggy' shall be updated to 0.0.123 on crates.io.
