### PR TITLE
Add mechanism to test iggy cmd by providing data to stdin

### DIFF
--- a/integration/tests/cmd/user/test_login_options.rs
+++ b/integration/tests/cmd/user/test_login_options.rs
@@ -2,18 +2,47 @@ use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
+use iggy::users::defaults::{DEFAULT_ROOT_PASSWORD, DEFAULT_ROOT_USERNAME};
 use predicates::str::{contains, starts_with};
 use serial_test::parallel;
 
 #[derive(Debug, Default)]
-struct TestLoginOptions {}
+enum UseCredentials {
+    #[default]
+    CliOptions,
+    StdinInput,
+}
+
+#[derive(Debug, Default)]
+struct TestLoginOptions {
+    use_credentials: UseCredentials,
+}
+
+impl TestLoginOptions {
+    fn new(use_credentials: UseCredentials) -> Self {
+        Self { use_credentials }
+    }
+}
 
 #[async_trait]
 impl IggyCmdTestCase for TestLoginOptions {
     async fn prepare_server_state(&mut self, _client: &dyn Client) {}
 
     fn get_command(&self) -> IggyCmdCommand {
-        IggyCmdCommand::new().with_cli_credentials().arg("me")
+        match self.use_credentials {
+            UseCredentials::CliOptions => IggyCmdCommand::new().with_cli_credentials().arg("me"),
+            UseCredentials::StdinInput => IggyCmdCommand::new()
+                .opt("--username")
+                .opt(DEFAULT_ROOT_USERNAME)
+                .arg("me"),
+        }
+    }
+
+    fn provide_stdin_input(&self) -> Option<Vec<String>> {
+        match self.use_credentials {
+            UseCredentials::StdinInput => Some(vec![DEFAULT_ROOT_PASSWORD.to_string()]),
+            _ => None,
+        }
     }
 
     fn verify_command(&self, command_state: Assert) {
@@ -33,6 +62,9 @@ pub async fn should_be_successful() {
 
     iggy_cmd_test.setup().await;
     iggy_cmd_test
-        .execute_test(TestLoginOptions::default())
+        .execute_test(TestLoginOptions::new(UseCredentials::CliOptions))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestLoginOptions::new(UseCredentials::StdinInput))
         .await;
 }


### PR DESCRIPTION
Extend test case trait with method which allows test to send strings to
iggy cmd stdin. By default method returns None. Extending tests for
server authentication and user password command with new mechanism
in order to provide passwords from standard input of iggy command.
