### PR TITLE
Fix logging when log level is selected from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3641,20 +3641,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -52,7 +52,7 @@ tower-layer = "0.3.2"
 tower-service = "0.3.2"
 tracing = { version = "0.1.*" }
 tracing-appender = "0.2.2"
-tracing-subscriber = { version = "0.3.17", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
 ulid = "1.1.0"
 uuid = { version = "1.5.0", features = ["v4", "fast-rng", "zerocopy"] }
 xxhash-rust = { version = "0.8.*", features = ["xxh32"] }


### PR DESCRIPTION
It turns out that both file layer and stdout layer need
it's own filters. Besides that, tracing-subscriber
is updated to 0.3.18.