### PR TITLE
Change test condition and add missing SW for CI

### DIFF
--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -99,8 +99,11 @@ jobs:
         run: export QEMU_RUNNER=${{ matrix.platform.qemu_runner }}
         if: ${{ matrix.platform.cross }}
 
-      - name: Install musl-tools on Linux
-        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
+      - name: Install musl-tools, gnome-keyring and keyutils on Linux
+        run: |
+          sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
+          rm -f $HOME/.local/share/keyrings/*
+          echo -n "test" | gnome-keyring-daemon --unlock
         if: contains(matrix.platform.name, 'musl')
 
       - name: Build binary

--- a/integration/tests/cmd/general/test_missing_credentials.rs
+++ b/integration/tests/cmd/general/test_missing_credentials.rs
@@ -2,7 +2,7 @@ use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::client::Client;
-use predicates::str::diff;
+use predicates::str::starts_with;
 use serial_test::parallel;
 
 struct TestNoCredentialsCmd {}
@@ -16,10 +16,12 @@ impl IggyCmdTestCase for TestNoCredentialsCmd {
     }
 
     fn verify_command(&self, command_state: Assert) {
+        // Use starts_with without closing bracket (CI tests run with RUST_BACKTRACE which causes rust to emit
+        // longer message with full stack trace at the end of which closing bracket is located).
         command_state
             .failure()
-            .stderr(diff(
-                "Error: CommandError(Iggy command line tool error\n\nCaused by:\n    Missing iggy server credentials)\n",
+            .stderr(starts_with(
+                "Error: CommandError(Iggy command line tool error\n\nCaused by:\n    Missing iggy server credentials",
             ));
     }
 


### PR DESCRIPTION
Change how test_missing_credentials test validates correctness of iggy cmd output. Add gnome-keyring keyutils to list of installed SW for CI machines in nightly run.

This fix #354
