### PR TITLE
Add missing condition to creat gh release only if tag was created

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,7 @@ jobs:
 
   create_github_release:
     runs-on: ubuntu-latest
+    if: ${{ needs.tag.outputs.tag_created == 'true' }}
     needs:
       - release_and_publish
       - tag


### PR DESCRIPTION
This fixes #366.
