### PR TITLE
Add suffix to artifact name for digest upload and download

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests
+          name: digests-${{ matrix.platform.os_name }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -212,7 +212,7 @@ jobs:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
-          name: digests
+          pattern: 'digests-*'
           path: /tmp/digests
 
       - name: Login to Docker Hub


### PR DESCRIPTION
Due to restriction in upload-artifact@v4+ there's no possibility
to use the same name for several artifacts uploaded to the registry.
Setting suffix for digest artifact and download it during merge
using pattern.

This fix #399 #400 #401 #402 #403 #404
