### PR TITLE
Download artifacts to the same directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,6 +213,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: 'digests-*'
+          merge-multiple: true
           path: /tmp/digests
 
       - name: Login to Docker Hub


### PR DESCRIPTION
With this setting all digest artifacts will be placed in /tmp/digests
instead of subfolders.

This fix #406
