### PR TITLE
use `keepcalm` instead of `Arc<RwLock<System>>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1958,6 +1958,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keepcalm"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031ddc7e27bbb011c78958881a3723873608397b8b10e146717fc05cf3364d78"
+dependencies = [
+ "once_cell",
+ "parking_lot 0.12.1",
+]
+
+[[package]]
 name = "keyring"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3376,6 +3386,7 @@ dependencies = [
  "futures",
  "iggy",
  "jsonwebtoken",
+ "keepcalm",
  "libc",
  "moka",
  "prometheus-client",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,6 +25,7 @@ flume = "0.11.0"
 futures = "0.3.30"
 iggy = { path = "../iggy" }
 jsonwebtoken = "9.*"
+keepcalm = "0.3.5"
 moka = { version = "0.12.1", features = ["future"] }
 prometheus-client = "0.22.0"
 quinn = { version = "0.10.2" }

--- a/server/src/binary/handlers/consumer_groups/create_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/create_consumer_group_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .create_consumer_group(
             session,

--- a/server/src/binary/handlers/consumer_groups/delete_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/delete_consumer_group_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .delete_consumer_group(
             session,

--- a/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let consumer_group = system.get_consumer_group(
         session,
         &command.stream_id,

--- a/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let consumer_groups =
         system.get_consumer_groups(session, &command.stream_id, &command.topic_id)?;
     let consumer_groups = mapper::map_consumer_groups(&consumer_groups).await;

--- a/server/src/binary/handlers/consumer_groups/join_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/join_consumer_group_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .join_consumer_group(
             session,

--- a/server/src/binary/handlers/consumer_groups/leave_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/leave_consumer_group_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .leave_consumer_group(
             session,

--- a/server/src/binary/handlers/consumer_offsets/get_consumer_offset_handler.rs
+++ b/server/src/binary/handlers/consumer_offsets/get_consumer_offset_handler.rs
@@ -15,7 +15,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let consumer =
         PollingConsumer::from_consumer(&command.consumer, session.client_id, command.partition_id);
     let offset = system

--- a/server/src/binary/handlers/consumer_offsets/store_consumer_offset_handler.rs
+++ b/server/src/binary/handlers/consumer_offsets/store_consumer_offset_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let consumer =
         PollingConsumer::from_consumer(&command.consumer, session.client_id, command.partition_id);
     system

--- a/server/src/binary/handlers/messages/poll_messages_handler.rs
+++ b/server/src/binary/handlers/messages/poll_messages_handler.rs
@@ -18,7 +18,7 @@ pub async fn handle(
     debug!("session: {session}, command: {command}");
     let consumer =
         PollingConsumer::from_consumer(&command.consumer, session.client_id, command.partition_id);
-    let system = system.read().await;
+    let system = system.read();
     let messages = system
         .poll_messages(
             session,

--- a/server/src/binary/handlers/messages/send_messages_handler.rs
+++ b/server/src/binary/handlers/messages/send_messages_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .append_messages(
             session,

--- a/server/src/binary/handlers/partitions/create_partitions_handler.rs
+++ b/server/src/binary/handlers/partitions/create_partitions_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .create_partitions(
             session,

--- a/server/src/binary/handlers/partitions/delete_partitions_handler.rs
+++ b/server/src/binary/handlers/partitions/delete_partitions_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .delete_partitions(
             session,

--- a/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let token = system
         .create_personal_access_token(session, &command.name, command.expiry)
         .await?;

--- a/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .delete_personal_access_token(session, &command.name)
         .await?;

--- a/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let personal_access_tokens = system.get_personal_access_tokens(session).await?;
     let personal_access_tokens = mapper::map_personal_access_tokens(&personal_access_tokens);
     sender

--- a/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let user = system
         .login_with_personal_access_token(&command.token, Some(session))
         .await?;

--- a/server/src/binary/handlers/streams/create_stream_handler.rs
+++ b/server/src/binary/handlers/streams/create_stream_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .create_stream(session, command.stream_id, &command.name)
         .await?;

--- a/server/src/binary/handlers/streams/delete_stream_handler.rs
+++ b/server/src/binary/handlers/streams/delete_stream_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system.delete_stream(session, &command.stream_id).await?;
     sender.send_empty_ok_response().await?;
     Ok(())

--- a/server/src/binary/handlers/streams/get_stream_handler.rs
+++ b/server/src/binary/handlers/streams/get_stream_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let stream = system.find_stream(session, &command.stream_id)?;
     let stream = mapper::map_stream(stream).await;
     sender.send_ok_response(&stream).await?;

--- a/server/src/binary/handlers/streams/get_streams_handler.rs
+++ b/server/src/binary/handlers/streams/get_streams_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let streams = system.find_streams(session)?;
     let streams = mapper::map_streams(&streams).await;
     sender.send_ok_response(streams.as_slice()).await?;

--- a/server/src/binary/handlers/streams/update_stream_handler.rs
+++ b/server/src/binary/handlers/streams/update_stream_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .update_stream(session, &command.stream_id, &command.name)
         .await?;

--- a/server/src/binary/handlers/system/get_client_handler.rs
+++ b/server/src/binary/handlers/system/get_client_handler.rs
@@ -15,7 +15,7 @@ pub async fn handle(
     debug!("session: {session}, command: {command}");
     let bytes;
     {
-        let system = system.read().await;
+        let system = system.read();
         let client = system.get_client(session, command.client_id).await?;
         {
             let client = client.read().await;

--- a/server/src/binary/handlers/system/get_clients_handler.rs
+++ b/server/src/binary/handlers/system/get_clients_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let clients = system.get_clients(session).await?;
     let clients = mapper::map_clients(&clients).await;
     sender.send_ok_response(clients.as_slice()).await?;

--- a/server/src/binary/handlers/system/get_me_handler.rs
+++ b/server/src/binary/handlers/system/get_me_handler.rs
@@ -15,7 +15,7 @@ pub async fn handle(
     debug!("session: {session}, command: {command}");
     let bytes;
     {
-        let system = system.read().await;
+        let system = system.read();
         let client = system.get_client(session, session.client_id).await?;
         {
             let client = client.read().await;

--- a/server/src/binary/handlers/system/get_stats_handler.rs
+++ b/server/src/binary/handlers/system/get_stats_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let stats = system.get_stats(session).await?;
     let bytes = mapper::map_stats(&stats);
     sender.send_ok_response(bytes.as_slice()).await?;

--- a/server/src/binary/handlers/topics/create_topic_handler.rs
+++ b/server/src/binary/handlers/topics/create_topic_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .create_topic(
             session,

--- a/server/src/binary/handlers/topics/delete_topic_handler.rs
+++ b/server/src/binary/handlers/topics/delete_topic_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .delete_topic(session, &command.stream_id, &command.topic_id)
         .await?;

--- a/server/src/binary/handlers/topics/get_topic_handler.rs
+++ b/server/src/binary/handlers/topics/get_topic_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let topic = system.find_topic(session, &command.stream_id, &command.topic_id)?;
     let topic = mapper::map_topic(topic).await;
     sender.send_ok_response(&topic).await?;

--- a/server/src/binary/handlers/topics/get_topics_handler.rs
+++ b/server/src/binary/handlers/topics/get_topics_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let topics = system.find_topics(session, &command.stream_id)?;
     let topics = mapper::map_topics(&topics).await;
     sender.send_ok_response(&topics).await?;

--- a/server/src/binary/handlers/topics/update_topic_handler.rs
+++ b/server/src/binary/handlers/topics/update_topic_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .update_topic(
             session,

--- a/server/src/binary/handlers/users/change_password_handler.rs
+++ b/server/src/binary/handlers/users/change_password_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .change_password(
             session,

--- a/server/src/binary/handlers/users/create_user_handler.rs
+++ b/server/src/binary/handlers/users/create_user_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .create_user(
             session,

--- a/server/src/binary/handlers/users/delete_user_handler.rs
+++ b/server/src/binary/handlers/users/delete_user_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system.delete_user(session, &command.user_id).await?;
     sender.send_empty_ok_response().await?;
     Ok(())

--- a/server/src/binary/handlers/users/get_user_handler.rs
+++ b/server/src/binary/handlers/users/get_user_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let user = system.find_user(session, &command.user_id).await?;
     let bytes = mapper::map_user(&user);
     sender.send_ok_response(bytes.as_slice()).await?;

--- a/server/src/binary/handlers/users/get_users_handler.rs
+++ b/server/src/binary/handlers/users/get_users_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let users = system.get_users(session).await?;
     let users = mapper::map_users(&users);
     sender.send_ok_response(users.as_slice()).await?;

--- a/server/src/binary/handlers/users/login_user_handler.rs
+++ b/server/src/binary/handlers/users/login_user_handler.rs
@@ -14,7 +14,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     let user = system
         .login_user(&command.username, &command.password, Some(session))
         .await?;

--- a/server/src/binary/handlers/users/logout_user_handler.rs
+++ b/server/src/binary/handlers/users/logout_user_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system.logout_user(session).await?;
     session.clear_user_id();
     sender.send_empty_ok_response().await?;

--- a/server/src/binary/handlers/users/update_permissions_handler.rs
+++ b/server/src/binary/handlers/users/update_permissions_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let mut system = system.write().await;
+    let mut system = system.write();
     system
         .update_permissions(session, &command.user_id, command.permissions.clone())
         .await?;

--- a/server/src/binary/handlers/users/update_user_handler.rs
+++ b/server/src/binary/handlers/users/update_user_handler.rs
@@ -13,7 +13,7 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");
-    let system = system.read().await;
+    let system = system.read();
     system
         .update_user(
             session,

--- a/server/src/channels/commands/clean_messages.rs
+++ b/server/src/channels/commands/clean_messages.rs
@@ -64,7 +64,7 @@ impl MessagesCleaner {
 impl ServerCommand<CleanMessagesCommand> for CleanMessagesExecutor {
     async fn execute(&mut self, system: &SharedSystem, _command: CleanMessagesCommand) {
         let now = TimeStamp::now().to_micros();
-        let system_read = system.read().await;
+        let system_read = system.read();
         let streams = system_read.get_streams();
         for stream in streams {
             let topics = stream.get_topics();
@@ -81,12 +81,10 @@ impl ServerCommand<CleanMessagesCommand> for CleanMessagesExecutor {
 
                     system
                         .write()
-                        .await
                         .metrics
                         .decrement_segments(deleted_segments.segments_count);
                     system
                         .write()
-                        .await
                         .metrics
                         .decrement_messages(deleted_segments.messages_count);
                 }

--- a/server/src/channels/commands/clean_personal_access_tokens.rs
+++ b/server/src/channels/commands/clean_personal_access_tokens.rs
@@ -65,7 +65,7 @@ impl PersonalAccessTokenCleaner {
 #[async_trait]
 impl ServerCommand<CleanPersonalAccessTokensCommand> for CleanPersonalAccessTokensExecutor {
     async fn execute(&mut self, system: &SharedSystem, _command: CleanPersonalAccessTokensCommand) {
-        let system = system.read().await;
+        let system = system.read();
         let tokens = system.storage.personal_access_token.load_all().await;
         if tokens.is_err() {
             error!("Failed to load personal access tokens: {:?}", tokens);

--- a/server/src/channels/commands/save_messages.rs
+++ b/server/src/channels/commands/save_messages.rs
@@ -73,7 +73,6 @@ impl ServerCommand<SaveMessagesCommand> for SaveMessagesExecutor {
         let storage = Arc::new(FileSegmentStorage::new(persister));
         system
             .write()
-            .await
             .persist_messages(storage)
             .await
             .unwrap_or_else(|error| {

--- a/server/src/http/consumer_groups.rs
+++ b/server/src/http/consumer_groups.rs
@@ -34,7 +34,7 @@ async fn get_consumer_group(
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
     let consumer_group_id = Identifier::from_str_value(&consumer_group_id)?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let consumer_group = system.get_consumer_group(
         &Session::stateless(identity.user_id, identity.ip_address),
         &stream_id,
@@ -53,7 +53,7 @@ async fn get_consumer_groups(
 ) -> Result<Json<Vec<ConsumerGroup>>, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let consumer_groups = system.get_consumer_groups(
         &Session::stateless(identity.user_id, identity.ip_address),
         &stream_id,
@@ -72,7 +72,7 @@ async fn create_consumer_group(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .create_consumer_group(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -93,7 +93,7 @@ async fn delete_consumer_group(
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
     let consumer_group_id = Identifier::from_str_value(&consumer_group_id)?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .delete_consumer_group(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/consumer_offsets.rs
+++ b/server/src/http/consumer_offsets.rs
@@ -34,7 +34,7 @@ async fn get_consumer_offset(
     query.validate()?;
     let consumer_id = PollingConsumer::resolve_consumer_id(&query.consumer.id);
     let consumer = PollingConsumer::Consumer(consumer_id, query.partition_id.unwrap_or(0));
-    let system = state.system.read().await;
+    let system = state.system.read();
     let offset = system
         .get_consumer_offset(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -57,7 +57,7 @@ async fn store_consumer_offset(
     command.validate()?;
     let consumer_id = PollingConsumer::resolve_consumer_id(&command.consumer.id);
     let consumer = PollingConsumer::Consumer(consumer_id, command.partition_id.unwrap_or(0));
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .store_consumer_offset(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/http_server.rs
+++ b/server/src/http/http_server.rs
@@ -98,7 +98,7 @@ pub async fn start(config: HttpConfig, system: SharedSystem) -> SocketAddr {
 async fn build_app_state(config: &HttpConfig, system: SharedSystem) -> Arc<AppState> {
     let db;
     {
-        let system_read = system.read().await;
+        let system_read = system.read();
         db = system_read
             .db
             .as_ref()

--- a/server/src/http/messages.rs
+++ b/server/src/http/messages.rs
@@ -37,7 +37,7 @@ async fn poll_messages(
     let partition_id = query.partition_id.unwrap_or(0);
     let consumer_id = PollingConsumer::resolve_consumer_id(&query.consumer.id);
     let consumer = PollingConsumer::Consumer(consumer_id, partition_id);
-    let system = state.system.read().await;
+    let system = state.system.read();
     let polled_messages = system
         .poll_messages(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -61,7 +61,7 @@ async fn send_messages(
     command.partitioning.length = command.partitioning.value.len() as u8;
     command.validate()?;
 
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .append_messages(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/metrics.rs
+++ b/server/src/http/metrics.rs
@@ -13,6 +13,6 @@ pub async fn metrics(
     request: Request<Body>,
     next: Next,
 ) -> Result<Response, StatusCode> {
-    state.system.read().await.metrics.increment_http_requests();
+    state.system.read().metrics.increment_http_requests();
     Ok(next.run(request).await)
 }

--- a/server/src/http/partitions.rs
+++ b/server/src/http/partitions.rs
@@ -30,7 +30,7 @@ async fn create_partitions(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .create_partitions(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -51,7 +51,7 @@ async fn delete_partitions(
     query.stream_id = Identifier::from_str_value(&stream_id)?;
     query.topic_id = Identifier::from_str_value(&topic_id)?;
     query.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .delete_partitions(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/personal_access_tokens.rs
+++ b/server/src/http/personal_access_tokens.rs
@@ -36,7 +36,7 @@ async fn get_personal_access_tokens(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<PersonalAccessTokenInfo>>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let personal_access_tokens = system
         .get_personal_access_tokens(&Session::stateless(identity.user_id, identity.ip_address))
         .await?;
@@ -50,7 +50,7 @@ async fn create_personal_access_token(
     Json(command): Json<CreatePersonalAccessToken>,
 ) -> Result<Json<RawPersonalAccessToken>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let token = system
         .create_personal_access_token(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -66,7 +66,7 @@ async fn delete_personal_access_token(
     Extension(identity): Extension<Identity>,
     Path(name): Path<String>,
 ) -> Result<StatusCode, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .delete_personal_access_token(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -81,7 +81,7 @@ async fn login_with_personal_access_token(
     Json(command): Json<LoginWithPersonalAccessToken>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let user = system
         .login_with_personal_access_token(&command.token, None)
         .await?;

--- a/server/src/http/streams.rs
+++ b/server/src/http/streams.rs
@@ -29,7 +29,7 @@ async fn get_stream(
     Extension(identity): Extension<Identity>,
     Path(stream_id): Path<String>,
 ) -> Result<Json<StreamDetails>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let stream = system.find_stream(
         &Session::stateless(identity.user_id, identity.ip_address),
@@ -43,7 +43,7 @@ async fn get_streams(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<Stream>>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let streams =
         system.find_streams(&Session::stateless(identity.user_id, identity.ip_address))?;
     let streams = mapper::map_streams(&streams).await;
@@ -56,7 +56,7 @@ async fn create_stream(
     Json(command): Json<CreateStream>,
 ) -> Result<StatusCode, CustomError> {
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .create_stream(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -75,7 +75,7 @@ async fn update_stream(
 ) -> Result<StatusCode, CustomError> {
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .update_stream(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -92,7 +92,7 @@ async fn delete_stream(
     Path(stream_id): Path<String>,
 ) -> Result<StatusCode, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .delete_stream(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/system.rs
+++ b/server/src/http/system.rs
@@ -29,7 +29,7 @@ pub fn router(state: Arc<AppState>, metrics_config: &HttpMetricsConfig) -> Route
 }
 
 async fn get_metrics(State(state): State<Arc<AppState>>) -> Result<String, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     Ok(system.metrics.get_formatted_output())
 }
 
@@ -37,7 +37,7 @@ async fn get_stats(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Stats>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let stats = system
         .get_stats(&Session::stateless(identity.user_id, identity.ip_address))
         .await?;
@@ -49,7 +49,7 @@ async fn get_client(
     Extension(identity): Extension<Identity>,
     Path(client_id): Path<u32>,
 ) -> Result<Json<ClientInfoDetails>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let client = system
         .get_client(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -65,7 +65,7 @@ async fn get_clients(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<ClientInfo>>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let clients = system
         .get_clients(&Session::stateless(identity.user_id, identity.ip_address))
         .await?;

--- a/server/src/http/topics.rs
+++ b/server/src/http/topics.rs
@@ -32,7 +32,7 @@ async fn get_topic(
     Extension(identity): Extension<Identity>,
     Path((stream_id, topic_id)): Path<(String, String)>,
 ) -> Result<Json<TopicDetails>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
     let topic = system.find_topic(
@@ -50,7 +50,7 @@ async fn get_topics(
     Path(stream_id): Path<String>,
 ) -> Result<Json<Vec<Topic>>, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let topics = system.find_topics(
         &Session::stateless(identity.user_id, identity.ip_address),
         &stream_id,
@@ -67,7 +67,7 @@ async fn create_topic(
 ) -> Result<StatusCode, CustomError> {
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .create_topic(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -90,7 +90,7 @@ async fn update_topic(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .update_topic(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -110,7 +110,7 @@ async fn delete_topic(
 ) -> Result<StatusCode, CustomError> {
     let stream_id = Identifier::from_str_value(&stream_id)?;
     let topic_id = Identifier::from_str_value(&topic_id)?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .delete_topic(
             &Session::stateless(identity.user_id, identity.ip_address),

--- a/server/src/http/users.rs
+++ b/server/src/http/users.rs
@@ -42,7 +42,7 @@ async fn get_user(
     Path(user_id): Path<String>,
 ) -> Result<Json<UserInfoDetails>, CustomError> {
     let user_id = Identifier::from_str_value(&user_id)?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let user = system
         .find_user(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -57,7 +57,7 @@ async fn get_users(
     State(state): State<Arc<AppState>>,
     Extension(identity): Extension<Identity>,
 ) -> Result<Json<Vec<UserInfo>>, CustomError> {
-    let system = state.system.read().await;
+    let system = state.system.read();
     let users = system
         .get_users(&Session::stateless(identity.user_id, identity.ip_address))
         .await?;
@@ -71,7 +71,7 @@ async fn create_user(
     Json(command): Json<CreateUser>,
 ) -> Result<StatusCode, CustomError> {
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .create_user(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -92,7 +92,7 @@ async fn update_user(
 ) -> Result<StatusCode, CustomError> {
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .update_user(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -112,7 +112,7 @@ async fn update_permissions(
 ) -> Result<StatusCode, CustomError> {
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .update_permissions(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -131,7 +131,7 @@ async fn change_password(
 ) -> Result<StatusCode, CustomError> {
     command.user_id = Identifier::from_str_value(&user_id)?;
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .change_password(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -149,7 +149,7 @@ async fn delete_user(
     Path(user_id): Path<String>,
 ) -> Result<StatusCode, CustomError> {
     let user_id = Identifier::from_str_value(&user_id)?;
-    let mut system = state.system.write().await;
+    let mut system = state.system.write();
     system
         .delete_user(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -164,7 +164,7 @@ async fn login_user(
     Json(command): Json<LoginUser>,
 ) -> Result<Json<IdentityInfo>, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     let user = system
         .login_user(&command.username, &command.password, None)
         .await?;
@@ -178,7 +178,7 @@ async fn logout_user(
     Json(command): Json<LogoutUser>,
 ) -> Result<StatusCode, CustomError> {
     command.validate()?;
-    let system = state.system.read().await;
+    let system = state.system.read();
     system
         .logout_user(&Session::stateless(identity.user_id, identity.ip_address))
         .await?;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<(), ServerError> {
     }
 
     let shutdown_timestamp = Instant::now();
-    let mut system = system.write().await;
+    let mut system = system.write();
     let persister = Arc::new(FileWithSyncPersister);
     let storage = Arc::new(FileSegmentStorage::new(persister));
     system.shutdown(storage).await?;

--- a/server/src/quic/listener.rs
+++ b/server/src/quic/listener.rs
@@ -43,7 +43,6 @@ async fn handle_connection(
         info!("Client has connected: {address}");
         let client_id = system
             .read()
-            .await
             .add_client(&address, Transport::Quic)
             .await;
         let mut session = Session::from_client_id(client_id, address);
@@ -52,12 +51,12 @@ async fn handle_connection(
             let mut stream = match stream {
                 Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
                     info!("Connection closed");
-                    system.read().await.delete_client(&address).await;
+                    system.read().delete_client(&address).await;
                     return Ok(());
                 }
                 Err(error) => {
                     error!("Error when handling QUIC stream: {:?}", error);
-                    system.read().await.delete_client(&address).await;
+                    system.read().delete_client(&address).await;
                     return Err(error);
                 }
                 Ok(stream) => stream,

--- a/server/src/streaming/systems/system.rs
+++ b/server/src/streaming/systems/system.rs
@@ -19,24 +19,26 @@ use tokio::sync::RwLock;
 use tokio::time::Instant;
 use tracing::{info, trace};
 
+use keepcalm::{SharedMut, SharedReadLock, SharedWriteLock};
+
 #[derive(Debug)]
 pub struct SharedSystem {
-    system: Arc<RwLock<System>>,
+    system: SharedMut<System>,
 }
 
 impl SharedSystem {
     pub fn new(system: System) -> SharedSystem {
         SharedSystem {
-            system: Arc::new(RwLock::new(system)),
+            system: SharedMut::new(system),
         }
     }
 
-    pub async fn read(&self) -> tokio::sync::RwLockReadGuard<'_, System> {
-        self.system.read().await
+    pub fn read(&self) -> SharedReadLock<System> {
+        self.system.read()
     }
 
-    pub async fn write(&self) -> tokio::sync::RwLockWriteGuard<'_, System> {
-        self.system.write().await
+    pub fn write(&self) -> SharedWriteLock<System> {
+        self.system.write()
     }
 }
 

--- a/server/src/tcp/connection_handler.rs
+++ b/server/src/tcp/connection_handler.rs
@@ -17,11 +17,7 @@ pub(crate) async fn handle_connection(
     sender: &mut dyn Sender,
     system: SharedSystem,
 ) -> Result<(), ServerError> {
-    let client_id = system
-        .read()
-        .await
-        .add_client(&address, Transport::Tcp)
-        .await;
+    let client_id = system.read().add_client(&address, Transport::Tcp).await;
 
     let mut session = Session::from_client_id(client_id, address);
     let mut initial_buffer = [0u8; INITIAL_BYTES_LENGTH];

--- a/server/src/tcp/tcp_listener.rs
+++ b/server/src/tcp/tcp_listener.rs
@@ -36,7 +36,7 @@ pub async fn start(address: &str, system: SharedSystem) -> SocketAddr {
                             handle_connection(address, &mut sender, system.clone()).await
                         {
                             handle_error(error);
-                            system.read().await.delete_client(&address).await;
+                            system.read().delete_client(&address).await;
                         }
                     });
                 }

--- a/server/src/tcp/tcp_tls_listener.rs
+++ b/server/src/tcp/tcp_tls_listener.rs
@@ -58,7 +58,7 @@ pub(crate) async fn start(address: &str, config: TcpTlsConfig, system: SharedSys
                             handle_connection(address, &mut sender, system.clone()).await
                         {
                             handle_error(error);
-                            system.read().await.delete_client(&address).await;
+                            system.read().delete_client(&address).await;
                         }
                     });
                 }


### PR DESCRIPTION
- Uses keepcalms `SharedMut` which is equivalent to `Arc<RwLock<T>>`.
- acquiring the lock is now sync so this PR mainly consisted of removing the `await` calls.
- Can likely be done for more usages of `Arc<RwLock<T>>` (or any `Arc<T>` in general) if that is desired.
- Closes #123 Although it might be good to use this in more locations.
