### PR TITLE
Add client get and client list commands with integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,7 +817,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/client.rs
+++ b/cmd/src/args/client.rs
@@ -1,0 +1,37 @@
+use crate::args::common::ListMode;
+use clap::{Args, Subcommand};
+
+#[derive(Debug, Clone, Subcommand)]
+pub(crate) enum ClientAction {
+    /// Get details of a single client with given ID
+    ///
+    /// Client ID is unique numerical identifier not to be confused with the user.
+    ///
+    /// Examples:
+    ///  iggy client get 42
+    #[clap(verbatim_doc_comment, visible_alias = "g")]
+    Get(ClientGetArgs),
+    /// List all currently connected clients to iggy server
+    ///
+    /// Clients shall not to be confused with the users
+    ///
+    /// Examples:
+    ///  iggy client list
+    ///  iggy client list --list-mode table
+    ///  iggy client list -l table
+    #[clap(verbatim_doc_comment, visible_alias = "l")]
+    List(ClientListArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ClientGetArgs {
+    /// Client ID to get
+    pub(crate) client_id: u32,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ClientListArgs {
+    /// List mode (table or list)
+    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
+    pub(crate) list_mode: ListMode,
+}

--- a/cmd/src/args/common.rs
+++ b/cmd/src/args/common.rs
@@ -1,4 +1,5 @@
 use clap::ValueEnum;
+use iggy::cmd::client::get_clients::GetClientsOutput;
 use iggy::cmd::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokensOutput;
 use iggy::cmd::streams::get_streams::GetStreamsOutput;
 use iggy::cmd::topics::get_topics::GetTopicsOutput;
@@ -42,6 +43,15 @@ impl From<ListMode> for GetUsersOutput {
         match mode {
             ListMode::Table => GetUsersOutput::Table,
             ListMode::List => GetUsersOutput::List,
+        }
+    }
+}
+
+impl From<ListMode> for GetClientsOutput {
+    fn from(mode: ListMode) -> Self {
+        match mode {
+            ListMode::Table => GetClientsOutput::Table,
+            ListMode::List => GetClientsOutput::List,
         }
     }
 }

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod partition;
 pub(crate) mod permissions;
@@ -9,8 +10,9 @@ pub(crate) mod user;
 
 use self::user::UserAction;
 use crate::args::{
-    partition::PartitionAction, personal_access_token::PersonalAccessTokenAction,
-    stream::StreamAction, system::PingArgs, topic::TopicAction,
+    client::ClientAction, partition::PartitionAction,
+    personal_access_token::PersonalAccessTokenAction, stream::StreamAction, system::PingArgs,
+    topic::TopicAction,
 };
 use clap::{Args, Command as ClapCommand};
 use clap::{Parser, Subcommand};
@@ -115,6 +117,9 @@ pub(crate) enum Command {
     /// user operations
     #[command(subcommand, visible_alias = "u")]
     User(UserAction),
+    /// client operations
+    #[command(subcommand, visible_alias = "c")]
+    Client(ClientAction),
 }
 
 impl IggyConsoleArgs {

--- a/cmd/src/main.rs
+++ b/cmd/src/main.rs
@@ -5,8 +5,8 @@ mod logging;
 
 use crate::args::permissions::PermissionsArgs;
 use crate::args::{
-    personal_access_token::PersonalAccessTokenAction, stream::StreamAction, topic::TopicAction,
-    Command, IggyConsoleArgs,
+    client::ClientAction, personal_access_token::PersonalAccessTokenAction, stream::StreamAction,
+    topic::TopicAction, Command, IggyConsoleArgs,
 };
 use crate::credentials::IggyCredentials;
 use crate::error::IggyCmdError;
@@ -22,6 +22,7 @@ use iggy::cmd::users::change_password::ChangePasswordCmd;
 use iggy::cmd::users::update_permissions::UpdatePermissionsCmd;
 use iggy::cmd::users::update_user::{UpdateUserCmd, UpdateUserType};
 use iggy::cmd::{
+    client::{get_client::GetClientCmd, get_clients::GetClientsCmd},
     partitions::{create_partitions::CreatePartitionsCmd, delete_partitions::DeletePartitionsCmd},
     personal_access_tokens::{
         create_personal_access_token::CreatePersonalAccessTokenCmd,
@@ -163,6 +164,12 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
                 )
                 .into(),
             )),
+        },
+        Command::Client(command) => match command {
+            ClientAction::Get(get_args) => Box::new(GetClientCmd::new(get_args.client_id)),
+            ClientAction::List(list_args) => {
+                Box::new(GetClientsCmd::new(list_args.list_mode.into()))
+            }
         },
     }
 }

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.1.1"
+version = "0.1.2"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/iggy/src/cmd/client/get_client.rs
+++ b/iggy/src/cmd/client/get_client.rs
@@ -1,0 +1,78 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::system::get_client::GetClient;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::{presets::ASCII_NO_BORDERS, Table};
+use tracing::{event, Level};
+
+pub struct GetClientCmd {
+    get_client: GetClient,
+}
+
+impl GetClientCmd {
+    pub fn new(client_id: u32) -> Self {
+        Self {
+            get_client: GetClient { client_id },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetClientCmd {
+    fn explain(&self) -> String {
+        format!("get client with ID: {}", self.get_client.client_id)
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let client_details = client.get_client(&self.get_client).await.with_context(|| {
+            format!(
+                "Problem getting client with ID: {}",
+                self.get_client.client_id
+            )
+        })?;
+
+        let mut table = Table::new();
+
+        table.set_header(vec!["Property", "Value"]);
+        table.add_row(vec![
+            "Client ID",
+            format!("{}", client_details.client_id).as_str(),
+        ]);
+
+        let user = match client_details.user_id {
+            Some(user_id) => format!("{}", user_id),
+            None => String::from("None"),
+        };
+        table.add_row(vec!["User ID", user.as_str()]);
+
+        table.add_row(vec!["Address", client_details.address.as_str()]);
+        table.add_row(vec!["Transport", client_details.transport.as_str()]);
+        table.add_row(vec![
+            "Consumer Groups Count",
+            format!("{}", client_details.consumer_groups_count).as_str(),
+        ]);
+
+        if client_details.consumer_groups_count > 0 {
+            let mut consumer_groups = Table::new();
+            consumer_groups.load_preset(ASCII_NO_BORDERS);
+            consumer_groups.set_header(vec!["Stream ID", "Topic ID", "Consumer Group ID"]);
+            for consumer_group in client_details.consumer_groups {
+                consumer_groups.add_row(vec![
+                    format!("{}", consumer_group.stream_id).as_str(),
+                    format!("{}", consumer_group.topic_id).as_str(),
+                    format!("{}", consumer_group.consumer_group_id).as_str(),
+                ]);
+            }
+
+            table.add_row(vec![
+                "Consumer Groups Details",
+                consumer_groups.to_string().as_str(),
+            ]);
+        }
+
+        event!(target: PRINT_TARGET, Level::INFO, "{table}");
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/client/get_clients.rs
+++ b/iggy/src/cmd/client/get_clients.rs
@@ -1,0 +1,104 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::system::get_clients::GetClients;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::Table;
+use tracing::{event, Level};
+
+pub enum GetClientsOutput {
+    Table,
+    List,
+}
+
+pub struct GetClientsCmd {
+    get_clients: GetClients,
+    output: GetClientsOutput,
+}
+
+impl GetClientsCmd {
+    pub fn new(output: GetClientsOutput) -> Self {
+        GetClientsCmd {
+            get_clients: GetClients {},
+            output,
+        }
+    }
+}
+
+impl Default for GetClientsCmd {
+    fn default() -> Self {
+        GetClientsCmd {
+            get_clients: GetClients {},
+            output: GetClientsOutput::Table,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetClientsCmd {
+    fn explain(&self) -> String {
+        let mode = match self.output {
+            GetClientsOutput::Table => "table",
+            GetClientsOutput::List => "list",
+        };
+        format!("list clients in {mode} mode")
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let clients = client
+            .get_clients(&self.get_clients)
+            .await
+            .with_context(|| String::from("Problem getting list of clients"))?;
+
+        if clients.is_empty() {
+            event!(target: PRINT_TARGET, Level::INFO, "No clients found!");
+            return Ok(());
+        }
+
+        match self.output {
+            GetClientsOutput::Table => {
+                let mut table = Table::new();
+
+                table.set_header(vec![
+                    "Client ID",
+                    "User ID",
+                    "Address",
+                    "Transport",
+                    "Consumer Groups",
+                ]);
+
+                clients.iter().for_each(|client_info| {
+                    table.add_row(vec![
+                        format!("{}", client_info.client_id),
+                        match client_info.user_id {
+                            Some(user_id) => format!("{}", user_id),
+                            None => String::from(""),
+                        },
+                        format!("{}", client_info.address),
+                        format!("{}", client_info.transport),
+                        format!("{}", client_info.consumer_groups_count),
+                    ]);
+                });
+
+                event!(target: PRINT_TARGET, Level::INFO, "{table}");
+            }
+            GetClientsOutput::List => {
+                clients.iter().for_each(|client_info| {
+                    event!(target: PRINT_TARGET, Level::INFO,
+                        "{}|{}|{}|{}|{}",
+                        client_info.client_id,
+                        match client_info.user_id {
+                            Some(user_id) => format!("{}", user_id),
+                            None => String::from(""),
+                        },
+                        client_info.address,
+                        client_info.transport,
+                        client_info.consumer_groups_count
+                    );
+                });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/client/mod.rs
+++ b/iggy/src/cmd/client/mod.rs
@@ -1,0 +1,2 @@
+pub mod get_client;
+pub mod get_clients;

--- a/iggy/src/cmd/mod.rs
+++ b/iggy/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub mod client;
 pub mod partitions;
 pub mod personal_access_tokens;
 pub mod streams;

--- a/integration/tests/cmd/client/mod.rs
+++ b/integration/tests/cmd/client/mod.rs
@@ -1,0 +1,3 @@
+mod test_client_get_command;
+mod test_client_help_command;
+mod test_client_list_command;

--- a/integration/tests/cmd/client/test_client_get_command.rs
+++ b/integration/tests/cmd/client/test_client_get_command.rs
@@ -1,0 +1,120 @@
+use crate::cmd::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, USAGE_PREFIX};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::{client::Client, system::get_me::GetMe};
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+
+struct TestClientGetCmd {
+    client_id: Option<u32>,
+}
+
+impl TestClientGetCmd {
+    fn new() -> Self {
+        Self { client_id: None }
+    }
+
+    fn get_client_id(&self) -> String {
+        match self.client_id {
+            None => String::from(""),
+            Some(client_id) => format!("{}", client_id),
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestClientGetCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let client_info = client.get_me(&GetMe {}).await;
+        assert!(client_info.is_ok());
+        self.client_id = Some(client_info.unwrap().client_id);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("client")
+            .arg("get")
+            .arg(self.get_client_id())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with(format!(
+                "Executing get client with ID: {}\n",
+                self.get_client_id()
+            )))
+            .stdout(contains(format!(
+                "Client ID             | {}",
+                self.get_client_id()
+            )))
+            .stdout(contains("User ID               | 1"));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test.execute_test(TestClientGetCmd::new()).await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["client", "get", "--help"],
+            format!(
+                r#"Get details of a single client with given ID
+
+Client ID is unique numerical identifier not to be confused with the user.
+
+Examples:
+ iggy client get 42
+
+{USAGE_PREFIX} client get <CLIENT_ID>
+
+Arguments:
+  <CLIENT_ID>
+          Client ID to get
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["client", "get", "-h"],
+            format!(
+                r#"Get details of a single client with given ID
+
+{USAGE_PREFIX} client get <CLIENT_ID>
+
+Arguments:
+  <CLIENT_ID>  Client ID to get
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/client/test_client_help_command.rs
+++ b/integration/tests/cmd/client/test_client_help_command.rs
@@ -1,0 +1,28 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["client", "help"],
+            format!(
+                r#"client operations
+
+{USAGE_PREFIX} client <COMMAND>
+
+Commands:
+  get   Get details of a single client with given ID [aliases: g]
+  list  List all currently connected clients to iggy server [aliases: l]
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/client/test_client_list_command.rs
+++ b/integration/tests/cmd/client/test_client_list_command.rs
@@ -1,0 +1,130 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, OutputFormat, TestHelpCmd, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::{client::Client, system::get_me::GetMe};
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+
+struct TestClientListCmd {
+    output: OutputFormat,
+    client_id: Option<u32>,
+}
+
+impl TestClientListCmd {
+    fn new(output: OutputFormat) -> Self {
+        Self {
+            output,
+            client_id: None,
+        }
+    }
+
+    fn to_args(&self) -> Vec<&str> {
+        self.output.to_args()
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestClientListCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let client_info = client.get_me(&GetMe {}).await;
+        assert!(client_info.is_ok());
+        self.client_id = Some(client_info.unwrap().client_id);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("client")
+            .arg("list")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state
+            .success()
+            .stdout(starts_with(format!(
+                "Executing list clients in {} mode",
+                self.output
+            )))
+            .stdout(contains(format!("{}", self.client_id.unwrap_or(0))));
+    }
+
+    async fn verify_server_state(&self, _client: &dyn Client) {}
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestClientListCmd::new(OutputFormat::Default))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestClientListCmd::new(OutputFormat::List))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestClientListCmd::new(OutputFormat::Table))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["client", "list", "--help"],
+            format!(
+                r#"List all currently connected clients to iggy server
+
+Clients shall not to be confused with the users
+
+Examples:
+ iggy client list
+ iggy client list --list-mode table
+ iggy client list -l table
+
+{USAGE_PREFIX} client list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>
+          List mode (table or list)
+{CLAP_INDENT}
+          [default: table]
+          [possible values: table, list]
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["client", "list", "-h"],
+            format!(
+                r#"List all currently connected clients to iggy server
+
+{USAGE_PREFIX} client list [OPTIONS]
+
+Options:
+  -l, --list-mode <LIST_MODE>  List mode (table or list) [default: table] [possible values: table, list]
+  -h, --help                   Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -23,6 +23,7 @@ Commands:
   stats      get iggy server statistics
   pat        personal access token operations
   user       user operations [aliases: u]
+  client     client operations [aliases: c]
   help       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cmd/general/test_overview_command.rs
+++ b/integration/tests/cmd/general/test_overview_command.rs
@@ -34,6 +34,7 @@ Commands:
   stats      get iggy server statistics
   pat        personal access token operations
   user       user operations [aliases: u]
+  client     client operations [aliases: c]
   help       Print this message or the help of the given subcommand(s)
 
 

--- a/integration/tests/cmd/mod.rs
+++ b/integration/tests/cmd/mod.rs
@@ -1,3 +1,4 @@
+mod client;
 mod common;
 mod general;
 mod partition;


### PR DESCRIPTION
Add two new commands to iggy command line client (cmd) for listing
clients connected to iggy server (client list) and getting detailed
information about particular client (client get).
