### PR TITLE
Fix dependabot configuration and add dependencies badge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,49 +7,7 @@ updates:
     rebase-strategy: "disabled"
 
   - package-ecosystem: "cargo"
-    directory: "/bench"
+    directory: "/"
     schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/cli"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/cmd"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/iggy"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/integration"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/server"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/tools"
-    schedule:
-      interval: "weekly"
-    rebase-strategy: "disabled"
-
-  - package-ecosystem: "cargo"
-    directory: "/tpc"
-    schedule:
-      interval: "weekly"
+      interval: "daily"
     rebase-strategy: "disabled"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![docs](https://docs.rs/iggy/badge.svg)](https://docs.rs/iggy)
 [![workflow](https://github.com/iggy-rs/iggy/actions/workflows/test.yml/badge.svg)](https://github.com/iggy-rs/iggy/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/iggy-rs/iggy/graph/badge.svg?token=D9TIWPBWE2)](https://codecov.io/gh/iggy-rs/iggy)
+[![dependency](https://deps.rs/repo/github/iggy-rs/iggy/status.svg)](https://deps.rs/repo/github/iggy-rs/iggy)
 
 ---
 


### PR DESCRIPTION
Remove crates from dependabot.yml to let it use Cargo workspace settings
and check and update all creates instead of tpc only. Add dependencies
badge for which shows actual status of known security vulnerabilities.
Change dependabot schedule to daily for Rust crates checks.
