### PR TITLE
Add consumer group commands with integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "cmd"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cmd"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cmd/src/args/common.rs
+++ b/cmd/src/args/common.rs
@@ -1,5 +1,6 @@
 use clap::ValueEnum;
 use iggy::cmd::client::get_clients::GetClientsOutput;
+use iggy::cmd::consumer_group::get_consumer_groups::GetConsumerGroupsOutput;
 use iggy::cmd::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokensOutput;
 use iggy::cmd::streams::get_streams::GetStreamsOutput;
 use iggy::cmd::topics::get_topics::GetTopicsOutput;
@@ -52,6 +53,15 @@ impl From<ListMode> for GetClientsOutput {
         match mode {
             ListMode::Table => GetClientsOutput::Table,
             ListMode::List => GetClientsOutput::List,
+        }
+    }
+}
+
+impl From<ListMode> for GetConsumerGroupsOutput {
+    fn from(mode: ListMode) -> Self {
+        match mode {
+            ListMode::Table => GetConsumerGroupsOutput::Table,
+            ListMode::List => GetConsumerGroupsOutput::List,
         }
     }
 }

--- a/cmd/src/args/consumer_group.rs
+++ b/cmd/src/args/consumer_group.rs
@@ -1,0 +1,138 @@
+use crate::args::common::ListMode;
+use clap::{Args, Subcommand};
+use iggy::identifier::Identifier;
+
+#[derive(Debug, Clone, Subcommand)]
+pub(crate) enum ConsumerGroupAction {
+    /// Create consumer group with given ID and name for given stream ID and topic ID.
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-group create 1 1 1 prod
+    ///  iggy consumer-group create stream 2 2 test
+    ///  iggy consumer-group create 2 topic 3 receiver
+    ///  iggy consumer-group create stream topic 4 group
+    #[clap(verbatim_doc_comment, visible_alias = "c")]
+    Create(ConsumerGroupCreateArgs),
+    /// Delete consumer group with given ID for given stream ID and topic ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    /// Consumer group ID can be specified as a consumer group name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-group delete 1 2 3
+    ///  iggy consumer-group delete stream 2 3
+    ///  iggy consumer-group delete 1 topic 3
+    ///  iggy consumer-group delete 1 2 group
+    ///  iggy consumer-group delete stream topic 3
+    ///  iggy consumer-group delete 1 topic group
+    ///  iggy consumer-group delete stream 2 group
+    ///  iggy consumer-group delete stream topic group
+    #[clap(verbatim_doc_comment, visible_alias = "d")]
+    Delete(ConsumerGroupDeleteArgs),
+    /// Get details of a single consumer group with given ID for given stream ID and topic ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    /// Consumer group ID can be specified as a consumer group name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-group get 1 2 3
+    ///  iggy consumer-group get stream 2 3
+    ///  iggy consumer-group get 1 topic 3
+    ///  iggy consumer-group get 1 2 group
+    ///  iggy consumer-group get stream topic 3
+    ///  iggy consumer-group get 1 topic group
+    ///  iggy consumer-group get stream 2 group
+    ///  iggy consumer-group get stream topic group
+    #[clap(verbatim_doc_comment, visible_alias = "g")]
+    Get(ConsumerGroupGetArgs),
+    /// List all consumer groups for given stream ID and topic ID
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-group list 1 1
+    ///  iggy consumer-group list stream 2 --list-mode table
+    ///  iggy consumer-group list 3 topic -l table
+    ///  iggy consumer-group list production sensor -l table
+    #[clap(verbatim_doc_comment, visible_alias = "l")]
+    List(ConsumerGroupListArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerGroupCreateArgs {
+    /// Stream ID to create consumer group
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID to create consumer group
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Consumer group ID to create
+    pub(crate) consumer_group_id: u32,
+    /// Consumer group name to create
+    pub(crate) name: String,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerGroupDeleteArgs {
+    /// Stream ID to delete consumer group
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID to delete consumer group
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Consumer group ID to delete
+    ///
+    /// Consumer group ID can be specified as a consumer group name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) consumer_group_id: Identifier,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerGroupGetArgs {
+    /// Stream ID to get consumer group
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID to get consumer group
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Consumer group ID to get
+    ///
+    /// Consumer group ID can be specified as a consumer group name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) consumer_group_id: Identifier,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerGroupListArgs {
+    /// Stream ID to list consumer groups
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID to list consumer groups
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// List mode (table or list)
+    #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
+    pub(crate) list_mode: ListMode,
+}

--- a/cmd/src/args/mod.rs
+++ b/cmd/src/args/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod client;
 pub(crate) mod common;
+pub(crate) mod consumer_group;
 pub(crate) mod partition;
 pub(crate) mod permissions;
 pub(crate) mod personal_access_token;
@@ -10,7 +11,7 @@ pub(crate) mod user;
 
 use self::user::UserAction;
 use crate::args::{
-    client::ClientAction, partition::PartitionAction,
+    client::ClientAction, consumer_group::ConsumerGroupAction, partition::PartitionAction,
     personal_access_token::PersonalAccessTokenAction, stream::StreamAction, system::PingArgs,
     topic::TopicAction,
 };
@@ -120,6 +121,9 @@ pub(crate) enum Command {
     /// client operations
     #[command(subcommand, visible_alias = "c")]
     Client(ClientAction),
+    /// consumer group operations
+    #[command(subcommand, visible_alias = "g")]
+    ConsumerGroup(ConsumerGroupAction),
 }
 
 impl IggyConsoleArgs {

--- a/iggy/Cargo.toml
+++ b/iggy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.1.4"
+version = "0.1.5"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/iggy/src/cmd/consumer_group/create_consumer_group.rs
+++ b/iggy/src/cmd/consumer_group/create_consumer_group.rs
@@ -1,0 +1,64 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer_groups::create_consumer_group::CreateConsumerGroup;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct CreateConsumerGroupCmd {
+    create_consumer_group: CreateConsumerGroup,
+}
+
+impl CreateConsumerGroupCmd {
+    pub fn new(
+        stream_id: Identifier,
+        topic_id: Identifier,
+        consumer_group_id: u32,
+        name: String,
+    ) -> Self {
+        Self {
+            create_consumer_group: CreateConsumerGroup {
+                stream_id,
+                topic_id,
+                consumer_group_id,
+                name,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for CreateConsumerGroupCmd {
+    fn explain(&self) -> String {
+        format!(
+            "create consumer group with ID: {}, name: {} for topic with ID: {} and stream with ID: {}",
+            self.create_consumer_group.consumer_group_id,
+            self.create_consumer_group.name,
+            self.create_consumer_group.topic_id,
+            self.create_consumer_group.stream_id,
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .create_consumer_group(&self.create_consumer_group)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem creating consumer group (ID: {}, name: {}) for topic with ID: {} and stream with ID: {}",
+                    self.create_consumer_group.consumer_group_id, self.create_consumer_group.name, self.create_consumer_group.topic_id, self.create_consumer_group.stream_id
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Consumer group with ID: {}, name: {} created for topic with ID: {} and stream with ID: {}",
+            self.create_consumer_group.consumer_group_id,
+            self.create_consumer_group.name,
+            self.create_consumer_group.topic_id,
+            self.create_consumer_group.stream_id,
+        );
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/consumer_group/delete_consumer_group.rs
+++ b/iggy/src/cmd/consumer_group/delete_consumer_group.rs
@@ -1,0 +1,56 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer_groups::delete_consumer_group::DeleteConsumerGroup;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct DeleteConsumerGroupCmd {
+    delete_consumer_group: DeleteConsumerGroup,
+}
+
+impl DeleteConsumerGroupCmd {
+    pub fn new(stream_id: Identifier, topic_id: Identifier, consumer_group_id: Identifier) -> Self {
+        Self {
+            delete_consumer_group: DeleteConsumerGroup {
+                stream_id,
+                topic_id,
+                consumer_group_id,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for DeleteConsumerGroupCmd {
+    fn explain(&self) -> String {
+        format!(
+            "delete consumer group with ID: {} for topic with ID: {} and stream with ID: {}",
+            self.delete_consumer_group.consumer_group_id,
+            self.delete_consumer_group.topic_id,
+            self.delete_consumer_group.stream_id,
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .delete_consumer_group(&self.delete_consumer_group)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem deleting consumer group with ID: {} for topic with ID: {} and stream with ID: {}",
+                    self.delete_consumer_group.consumer_group_id, self.delete_consumer_group.topic_id, self.delete_consumer_group.stream_id
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Consumer group with ID: {} deleted for topic with ID: {} and stream with ID: {}",
+            self.delete_consumer_group.consumer_group_id,
+            self.delete_consumer_group.topic_id,
+            self.delete_consumer_group.stream_id,
+        );
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/consumer_group/get_consumer_group.rs
+++ b/iggy/src/cmd/consumer_group/get_consumer_group.rs
@@ -1,0 +1,89 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer_groups::get_consumer_group::GetConsumerGroup;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::{presets::ASCII_NO_BORDERS, Table};
+use tracing::{event, Level};
+
+pub struct GetConsumerGroupCmd {
+    get_consumer_group: GetConsumerGroup,
+}
+
+impl GetConsumerGroupCmd {
+    pub fn new(stream_id: Identifier, topic_id: Identifier, consumer_group_id: Identifier) -> Self {
+        Self {
+            get_consumer_group: GetConsumerGroup {
+                stream_id,
+                topic_id,
+                consumer_group_id,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetConsumerGroupCmd {
+    fn explain(&self) -> String {
+        format!(
+            "get consumer group with ID: {} for topic with ID: {} and stream with ID: {}",
+            self.get_consumer_group.consumer_group_id,
+            self.get_consumer_group.topic_id,
+            self.get_consumer_group.stream_id,
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let consumer_group = client
+            .get_consumer_group(&self.get_consumer_group)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem getting consumer group with ID: {} for topic with ID: {} and stream with ID: {}",
+                    self.get_consumer_group.consumer_group_id, self.get_consumer_group.topic_id, self.get_consumer_group.stream_id
+                )
+            })?;
+
+        let mut table = Table::new();
+
+        table.set_header(vec!["Property", "Value"]);
+        table.add_row(vec![
+            "Consumer group id",
+            format!("{}", consumer_group.id).as_str(),
+        ]);
+        table.add_row(vec!["Consumer group name", consumer_group.name.as_str()]);
+        table.add_row(vec![
+            "Partitions count",
+            format!("{}", consumer_group.partitions_count).as_str(),
+        ]);
+        table.add_row(vec![
+            "Members count",
+            format!("{}", consumer_group.members_count).as_str(),
+        ]);
+
+        if consumer_group.members_count > 0 {
+            let mut members_table = Table::new();
+            members_table.load_preset(ASCII_NO_BORDERS);
+            members_table.set_header(vec!["Member id", "Partitions count", "Partitions"]);
+            for member in consumer_group.members {
+                members_table.add_row(vec![
+                    format!("{}", member.id).as_str(),
+                    format!("{}", member.partitions_count).as_str(),
+                    member
+                        .partitions
+                        .iter()
+                        .map(|i| format!("{}", i))
+                        .collect::<Vec<String>>()
+                        .join(", ")
+                        .as_str(),
+                ]);
+            }
+            table.add_row(vec!["Members", members_table.to_string().as_str()]);
+        }
+
+        event!(target: PRINT_TARGET, Level::INFO,"{table}");
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/consumer_group/get_consumer_groups.rs
+++ b/iggy/src/cmd/consumer_group/get_consumer_groups.rs
@@ -1,0 +1,98 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer_groups::get_consumer_groups::GetConsumerGroups;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::Table;
+use std::fmt::{self, Display, Formatter};
+use tracing::{event, Level};
+
+pub enum GetConsumerGroupsOutput {
+    Table,
+    List,
+}
+
+impl Display for GetConsumerGroupsOutput {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            GetConsumerGroupsOutput::Table => write!(f, "table"),
+            GetConsumerGroupsOutput::List => write!(f, "list"),
+        }?;
+
+        Ok(())
+    }
+}
+
+pub struct GetConsumerGroupsCmd {
+    get_consumer_groups: GetConsumerGroups,
+    output: GetConsumerGroupsOutput,
+}
+
+impl GetConsumerGroupsCmd {
+    pub fn new(
+        stream_id: Identifier,
+        topic_id: Identifier,
+        output: GetConsumerGroupsOutput,
+    ) -> Self {
+        Self {
+            get_consumer_groups: GetConsumerGroups {
+                stream_id,
+                topic_id,
+            },
+            output,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetConsumerGroupsCmd {
+    fn explain(&self) -> String {
+        format!(
+            "list consumer groups for stream with ID: {} and topic with ID: {} in {} mode",
+            self.get_consumer_groups.stream_id, self.get_consumer_groups.topic_id, self.output
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let consumer_groups = client
+            .get_consumer_groups(&self.get_consumer_groups)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem getting consumer groups for stream with ID: {} and topic with ID: {}",
+                    self.get_consumer_groups.stream_id, self.get_consumer_groups.topic_id
+                )
+            })?;
+
+        match self.output {
+            GetConsumerGroupsOutput::Table => {
+                let mut table = Table::new();
+                table.set_header(vec!["ID", "Name", "Partitions Count", "Members Count"]);
+                consumer_groups.iter().for_each(|group| {
+                    table.add_row(vec![
+                        format!("{}", group.id),
+                        group.name.clone(),
+                        format!("{}", group.partitions_count),
+                        format!("{}", group.members_count),
+                    ]);
+                });
+
+                event!(target: PRINT_TARGET, Level::INFO, "{table}");
+            }
+            GetConsumerGroupsOutput::List => {
+                consumer_groups.iter().for_each(|group| {
+                    event!(target: PRINT_TARGET, Level::INFO,
+                        "{}|{}|{}|{}",
+                        group.id,
+                        group.name,
+                        group.partitions_count,
+                        group.members_count,
+                    );
+                });
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/iggy/src/cmd/consumer_group/mod.rs
+++ b/iggy/src/cmd/consumer_group/mod.rs
@@ -1,0 +1,4 @@
+pub mod create_consumer_group;
+pub mod delete_consumer_group;
+pub mod get_consumer_group;
+pub mod get_consumer_groups;

--- a/iggy/src/cmd/mod.rs
+++ b/iggy/src/cmd/mod.rs
@@ -1,4 +1,5 @@
 pub mod client;
+pub mod consumer_group;
 pub mod partitions;
 pub mod personal_access_tokens;
 pub mod streams;

--- a/integration/tests/cmd/common/mod.rs
+++ b/integration/tests/cmd/common/mod.rs
@@ -30,6 +30,8 @@ pub(crate) type TestTopicId = TestIdentifier;
 
 pub(crate) type TestUserId = TestIdentifier;
 
+pub(crate) type TestConsumerGroupId = TestIdentifier;
+
 pub(crate) enum OutputFormat {
     Default,
     List,

--- a/integration/tests/cmd/consumer_group/mod.rs
+++ b/integration/tests/cmd/consumer_group/mod.rs
@@ -1,0 +1,5 @@
+mod test_consumer_group_create_command;
+mod test_consumer_group_delete_command;
+mod test_consumer_group_get_command;
+mod test_consumer_group_help_command;
+mod test_consumer_group_list_command;

--- a/integration/tests/cmd/consumer_group/test_consumer_group_create_command.rs
+++ b/integration/tests/cmd/consumer_group/test_consumer_group_create_command.rs
@@ -1,0 +1,276 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, TestTopicId,
+    CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::consumer_groups::get_consumer_group::GetConsumerGroup;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestConsumerGroupCreateCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    consumer_group_id: u32,
+    consumer_group_name: String,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+}
+
+impl TestConsumerGroupCreateCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        consumer_group_id: u32,
+        consumer_group_name: String,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            consumer_group_id,
+            consumer_group_name,
+            using_stream_id,
+            using_topic_id,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        };
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(format!("{}", self.consumer_group_id));
+        command.push(self.consumer_group_name.clone());
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerGroupCreateCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: self.topic_id,
+                partitions_count: 0,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+            })
+            .await;
+        assert!(topic.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-group")
+            .arg("create")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let message = format!("Executing create consumer group with ID: {}, name: {} for topic with ID: {} and stream with ID: {}\nConsumer group with ID: {}, name: {} created for topic with ID: {} and stream with ID: {}\n",
+            self.consumer_group_id, self.consumer_group_name, topic_id, stream_id, self.consumer_group_id, self.consumer_group_name, topic_id, stream_id);
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let consumer_group = client
+            .get_consumer_group(&GetConsumerGroup {
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                consumer_group_id: Identifier::numeric(self.consumer_group_id).unwrap(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+        let consumer_group_details = consumer_group.unwrap();
+        assert_eq!(consumer_group_details.name, self.consumer_group_name);
+        assert_eq!(consumer_group_details.id, self.consumer_group_id);
+
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestConsumerGroupCreateCmd::new(
+            1,
+            String::from("main"),
+            1,
+            String::from("sync"),
+            1,
+            String::from("group1"),
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestConsumerGroupCreateCmd::new(
+            2,
+            String::from("stream"),
+            3,
+            String::from("topic"),
+            3,
+            String::from("group3"),
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestConsumerGroupCreateCmd::new(
+            4,
+            String::from("development"),
+            1,
+            String::from("probe"),
+            7,
+            String::from("group7"),
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestConsumerGroupCreateCmd::new(
+            2,
+            String::from("production"),
+            5,
+            String::from("test"),
+            4,
+            String::from("group4"),
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "create", "--help"],
+            format!(
+                r#"Create consumer group with given ID and name for given stream ID and topic ID.
+
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples:
+ iggy consumer-group create 1 1 1 prod
+ iggy consumer-group create stream 2 2 test
+ iggy consumer-group create 2 topic 3 receiver
+ iggy consumer-group create stream topic 4 group
+
+{USAGE_PREFIX} consumer-group create <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to create consumer group
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID to create consumer group
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <CONSUMER_GROUP_ID>
+          Consumer group ID to create
+
+  <NAME>
+          Consumer group name to create
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "create", "-h"],
+            format!(
+                r#"Create consumer group with given ID and name for given stream ID and topic ID.
+
+{USAGE_PREFIX} consumer-group create <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID> <NAME>
+
+Arguments:
+  <STREAM_ID>          Stream ID to create consumer group
+  <TOPIC_ID>           Topic ID to create consumer group
+  <CONSUMER_GROUP_ID>  Consumer group ID to create
+  <NAME>               Consumer group name to create
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/consumer_group/test_consumer_group_delete_command.rs
+++ b/integration/tests/cmd/consumer_group/test_consumer_group_delete_command.rs
@@ -1,0 +1,308 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestConsumerGroupId, TestHelpCmd, TestStreamId,
+    TestTopicId, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
+use iggy::consumer_groups::get_consumer_groups::GetConsumerGroups;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+
+struct TestConsumerGroupDeleteCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    consumer_group_id: u32,
+    consumer_group_name: String,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    using_consumer_group_id: TestConsumerGroupId,
+}
+
+impl TestConsumerGroupDeleteCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        consumer_group_id: u32,
+        consumer_group_name: String,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+        using_consumer_group_id: TestConsumerGroupId,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            consumer_group_id,
+            consumer_group_name,
+            using_stream_id,
+            using_topic_id,
+            using_consumer_group_id,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        };
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(match self.using_consumer_group_id {
+            TestConsumerGroupId::Numeric => format!("{}", self.consumer_group_id),
+            TestConsumerGroupId::Named => self.consumer_group_name.clone(),
+        });
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerGroupDeleteCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: self.topic_id,
+                partitions_count: 0,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let consumer_group = client
+            .create_consumer_group(&CreateConsumerGroup {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                consumer_group_id: self.consumer_group_id,
+                name: self.consumer_group_name.clone(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-group")
+            .arg("delete")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let consumer_group_id = match self.using_consumer_group_id {
+            TestConsumerGroupId::Numeric => format!("{}", self.consumer_group_id),
+            TestConsumerGroupId::Named => self.consumer_group_name.clone(),
+        };
+
+        let message = format!("Executing delete consumer group with ID: {} for topic with ID: {} and stream with ID: {}\nConsumer group with ID: {} deleted for topic with ID: {} and stream with ID: {}\n",
+            consumer_group_id, topic_id, stream_id, consumer_group_id, topic_id, stream_id);
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let consumer_groups = client
+            .get_consumer_groups(&GetConsumerGroups {
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(consumer_groups.is_ok());
+        let consumer_groups_details = consumer_groups.unwrap();
+        assert_eq!(consumer_groups_details.len(), 0);
+
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters = vec![
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Named,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Named,
+            TestConsumerGroupId::Named,
+        ),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, using_consumer_group_id) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestConsumerGroupDeleteCmd::new(
+                1,
+                String::from("stream"),
+                2,
+                String::from("topic"),
+                3,
+                String::from("consumer-group"),
+                using_stream_id,
+                using_topic_id,
+                using_consumer_group_id,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "delete", "--help"],
+            format!(
+                r#"Delete consumer group with given ID for given stream ID and topic ID
+
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+Consumer group ID can be specified as a consumer group name or ID
+
+Examples:
+ iggy consumer-group delete 1 2 3
+ iggy consumer-group delete stream 2 3
+ iggy consumer-group delete 1 topic 3
+ iggy consumer-group delete 1 2 group
+ iggy consumer-group delete stream topic 3
+ iggy consumer-group delete 1 topic group
+ iggy consumer-group delete stream 2 group
+ iggy consumer-group delete stream topic group
+
+{USAGE_PREFIX} consumer-group delete <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to delete consumer group
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID to delete consumer group
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <CONSUMER_GROUP_ID>
+          Consumer group ID to delete
+{CLAP_INDENT}
+          Consumer group ID can be specified as a consumer group name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "delete", "-h"],
+            format!(
+                r#"Delete consumer group with given ID for given stream ID and topic ID
+
+{USAGE_PREFIX} consumer-group delete <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID>
+
+Arguments:
+  <STREAM_ID>          Stream ID to delete consumer group
+  <TOPIC_ID>           Topic ID to delete consumer group
+  <CONSUMER_GROUP_ID>  Consumer group ID to delete
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/consumer_group/test_consumer_group_get_command.rs
+++ b/integration/tests/cmd/consumer_group/test_consumer_group_get_command.rs
@@ -1,0 +1,319 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestConsumerGroupId, TestHelpCmd, TestStreamId,
+    TestTopicId, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
+use iggy::consumer_groups::delete_consumer_group::DeleteConsumerGroup;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+
+struct TestConsumerGroupGetCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    consumer_group_id: u32,
+    consumer_group_name: String,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    using_consumer_group_id: TestConsumerGroupId,
+}
+
+impl TestConsumerGroupGetCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        consumer_group_id: u32,
+        consumer_group_name: String,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+        using_consumer_group_id: TestConsumerGroupId,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            consumer_group_id,
+            consumer_group_name,
+            using_stream_id,
+            using_topic_id,
+            using_consumer_group_id,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        };
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(match self.using_consumer_group_id {
+            TestConsumerGroupId::Numeric => format!("{}", self.consumer_group_id),
+            TestConsumerGroupId::Named => self.consumer_group_name.clone(),
+        });
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerGroupGetCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: self.topic_id,
+                partitions_count: 0,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let consumer_group = client
+            .create_consumer_group(&CreateConsumerGroup {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                consumer_group_id: self.consumer_group_id,
+                name: self.consumer_group_name.clone(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-group")
+            .arg("get")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let consumer_group_id = match self.using_consumer_group_id {
+            TestConsumerGroupId::Numeric => format!("{}", self.consumer_group_id),
+            TestConsumerGroupId::Named => self.consumer_group_name.clone(),
+        };
+
+        let start_message = format!(
+            "Executing get consumer group with ID: {} for topic with ID: {} and stream with ID: {}",
+            consumer_group_id, topic_id, stream_id
+        );
+
+        command_state
+            .success()
+            .stdout(starts_with(start_message))
+            .stdout(contains(format!(
+                "Consumer group id   | {}",
+                self.consumer_group_id
+            )))
+            .stdout(contains(format!(
+                "Consumer group name | {}",
+                self.consumer_group_name
+            )));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let consumer_group = client
+            .delete_consumer_group(&DeleteConsumerGroup {
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                consumer_group_id: Identifier::numeric(self.consumer_group_id).unwrap(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters = vec![
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            TestConsumerGroupId::Named,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Named,
+            TestConsumerGroupId::Numeric,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Named,
+            TestConsumerGroupId::Named,
+        ),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, using_consumer_group_id) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestConsumerGroupGetCmd::new(
+                1,
+                String::from("stream"),
+                2,
+                String::from("topic"),
+                3,
+                String::from("consumer-group"),
+                using_stream_id,
+                using_topic_id,
+                using_consumer_group_id,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "get", "--help"],
+            format!(
+                r#"Get details of a single consumer group with given ID for given stream ID and topic ID
+
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+Consumer group ID can be specified as a consumer group name or ID
+
+Examples:
+ iggy consumer-group get 1 2 3
+ iggy consumer-group get stream 2 3
+ iggy consumer-group get 1 topic 3
+ iggy consumer-group get 1 2 group
+ iggy consumer-group get stream topic 3
+ iggy consumer-group get 1 topic group
+ iggy consumer-group get stream 2 group
+ iggy consumer-group get stream topic group
+
+{USAGE_PREFIX} consumer-group get <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to get consumer group
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID to get consumer group
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <CONSUMER_GROUP_ID>
+          Consumer group ID to get
+{CLAP_INDENT}
+          Consumer group ID can be specified as a consumer group name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "get", "-h"],
+            format!(
+                r#"Get details of a single consumer group with given ID for given stream ID and topic ID
+
+{USAGE_PREFIX} consumer-group get <STREAM_ID> <TOPIC_ID> <CONSUMER_GROUP_ID>
+
+Arguments:
+  <STREAM_ID>          Stream ID to get consumer group
+  <TOPIC_ID>           Topic ID to get consumer group
+  <CONSUMER_GROUP_ID>  Consumer group ID to get
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/consumer_group/test_consumer_group_help_command.rs
+++ b/integration/tests/cmd/consumer_group/test_consumer_group_help_command.rs
@@ -1,0 +1,30 @@
+use crate::cmd::common::{help::TestHelpCmd, IggyCmdTest, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "help"],
+            format!(
+                r#"consumer group operations
+
+{USAGE_PREFIX} consumer-group <COMMAND>
+
+Commands:
+  create  Create consumer group with given ID and name for given stream ID and topic ID. [aliases: c]
+  delete  Delete consumer group with given ID for given stream ID and topic ID [aliases: d]
+  get     Get details of a single consumer group with given ID for given stream ID and topic ID [aliases: g]
+  list    List all consumer groups for given stream ID and topic ID [aliases: l]
+  help    Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help  Print help
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/consumer_group/test_consumer_group_list_command.rs
+++ b/integration/tests/cmd/consumer_group/test_consumer_group_list_command.rs
@@ -1,0 +1,312 @@
+use crate::cmd::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, OutputFormat, TestHelpCmd, TestStreamId,
+    TestTopicId, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
+use iggy::consumer_groups::delete_consumer_group::DeleteConsumerGroup;
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+
+struct TestConsumerGroupListCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    consumer_group_id: u32,
+    consumer_group_name: String,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    output: OutputFormat,
+}
+
+impl TestConsumerGroupListCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        consumer_group_id: u32,
+        consumer_group_name: String,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+        output: OutputFormat,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            consumer_group_id,
+            consumer_group_name,
+            using_stream_id,
+            using_topic_id,
+            output,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        };
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.extend(self.output.to_args().into_iter().map(String::from));
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerGroupListCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: self.stream_id,
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: self.topic_id,
+                partitions_count: 0,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let consumer_group = client
+            .create_consumer_group(&CreateConsumerGroup {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                consumer_group_id: self.consumer_group_id,
+                name: self.consumer_group_name.clone(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-group")
+            .arg("list")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let start_message = format!(
+            "Executing list consumer groups for stream with ID: {} and topic with ID: {} in {} mode",
+            stream_id, topic_id, self.output
+        );
+
+        command_state
+            .success()
+            .stdout(starts_with(start_message))
+            .stdout(contains(self.consumer_group_name.clone()));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let consumer_group = client
+            .delete_consumer_group(&DeleteConsumerGroup {
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                consumer_group_id: Identifier::numeric(self.consumer_group_id).unwrap(),
+            })
+            .await;
+        assert!(consumer_group.is_ok());
+
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters = vec![
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            OutputFormat::Default,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            OutputFormat::Default,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            OutputFormat::Default,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Named,
+            OutputFormat::Default,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            OutputFormat::List,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            OutputFormat::List,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            OutputFormat::List,
+        ),
+        (TestStreamId::Named, TestTopicId::Named, OutputFormat::List),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+            OutputFormat::Table,
+        ),
+        (
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+            OutputFormat::Table,
+        ),
+        (
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+            OutputFormat::Table,
+        ),
+        (TestStreamId::Named, TestTopicId::Named, OutputFormat::Table),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, output_format) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestConsumerGroupListCmd::new(
+                1,
+                String::from("stream"),
+                2,
+                String::from("topic"),
+                3,
+                String::from("consumer-group"),
+                using_stream_id,
+                using_topic_id,
+                output_format,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "list", "--help"],
+            format!(
+                r#"List all consumer groups for given stream ID and topic ID
+
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples:
+ iggy consumer-group list 1 1
+ iggy consumer-group list stream 2 --list-mode table
+ iggy consumer-group list 3 topic -l table
+ iggy consumer-group list production sensor -l table
+
+{USAGE_PREFIX} consumer-group list [OPTIONS] <STREAM_ID> <TOPIC_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to list consumer groups
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID to list consumer groups
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+Options:
+  -l, --list-mode <LIST_MODE>
+          List mode (table or list)
+{CLAP_INDENT}
+          [default: table]
+          [possible values: table, list]
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-group", "list", "-h"],
+            format!(
+                r#"List all consumer groups for given stream ID and topic ID
+
+{USAGE_PREFIX} consumer-group list [OPTIONS] <STREAM_ID> <TOPIC_ID>
+
+Arguments:
+  <STREAM_ID>  Stream ID to list consumer groups
+  <TOPIC_ID>   Topic ID to list consumer groups
+
+Options:
+  -l, --list-mode <LIST_MODE>  List mode (table or list) [default: table] [possible values: table, list]
+  -h, --help                   Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cmd/general/test_help_command.rs
+++ b/integration/tests/cmd/general/test_help_command.rs
@@ -15,16 +15,17 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} [OPTIONS] [COMMAND]
 
 Commands:
-  stream     stream operations [aliases: s]
-  topic      topic operations [aliases: t]
-  partition  partition operations [aliases: p]
-  ping       ping iggy server
-  me         get current client info
-  stats      get iggy server statistics
-  pat        personal access token operations
-  user       user operations [aliases: u]
-  client     client operations [aliases: c]
-  help       Print this message or the help of the given subcommand(s)
+  stream          stream operations [aliases: s]
+  topic           topic operations [aliases: t]
+  partition       partition operations [aliases: p]
+  ping            ping iggy server
+  me              get current client info
+  stats           get iggy server statistics
+  pat             personal access token operations
+  user            user operations [aliases: u]
+  client          client operations [aliases: c]
+  consumer-group  consumer group operations [aliases: g]
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
       --transport <TRANSPORT>

--- a/integration/tests/cmd/general/test_overview_command.rs
+++ b/integration/tests/cmd/general/test_overview_command.rs
@@ -26,16 +26,17 @@ Iggy is the persistent message streaming platform written in Rust, supporting QU
 Usage: iggy [OPTIONS] [COMMAND]
 
 Commands:
-  stream     stream operations [aliases: s]
-  topic      topic operations [aliases: t]
-  partition  partition operations [aliases: p]
-  ping       ping iggy server
-  me         get current client info
-  stats      get iggy server statistics
-  pat        personal access token operations
-  user       user operations [aliases: u]
-  client     client operations [aliases: c]
-  help       Print this message or the help of the given subcommand(s)
+  stream          stream operations [aliases: s]
+  topic           topic operations [aliases: t]
+  partition       partition operations [aliases: p]
+  ping            ping iggy server
+  me              get current client info
+  stats           get iggy server statistics
+  pat             personal access token operations
+  user            user operations [aliases: u]
+  client          client operations [aliases: c]
+  consumer-group  consumer group operations [aliases: g]
+  help            Print this message or the help of the given subcommand(s)
 
 
 Run 'iggy --help' for full help message.

--- a/integration/tests/cmd/mod.rs
+++ b/integration/tests/cmd/mod.rs
@@ -1,5 +1,6 @@
 mod client;
 mod common;
+mod consumer_group;
 mod general;
 mod partition;
 mod personal_access_token;


### PR DESCRIPTION
Add new commands to iggy command line client (cmd) for managing consumer
groups (create, delete, get, list).

Close #429
