### PR TITLE
Change CreateTopic and UpdateTopic API

### DIFF
--- a/bench/src/benchmarks/benchmark.rs
+++ b/bench/src/benchmarks/benchmark.rs
@@ -85,6 +85,8 @@ pub trait Benchmarkable {
                         partitions_count,
                         name,
                         message_expiry: None,
+                        max_topic_size: None,
+                        replication_factor: 1,
                     })
                     .await?;
             }

--- a/cli/src/args/topic.rs
+++ b/cli/src/args/topic.rs
@@ -2,6 +2,7 @@ use crate::args::common::ListMode;
 use clap::{Args, Subcommand};
 use iggy::cli::utils::message_expiry::MessageExpiry;
 use iggy::identifier::Identifier;
+use iggy::utils::byte_size::IggyByteSize;
 use std::convert::From;
 
 #[derive(Debug, Clone, Subcommand)]
@@ -78,10 +79,20 @@ pub(crate) struct TopicCreateArgs {
     pub(crate) partitions_count: u32,
     /// Name of the topic
     pub(crate) name: String,
+    /// Max topic size
+    ///
+    /// ("unlimited" or skipping parameter disables max topic size functionality in topic)
+    /// Can't be lower than segment size in the config.
+    #[arg(short, long, default_value = "unlimited", verbatim_doc_comment)]
+    pub(crate) max_topic_size: IggyByteSize,
+    /// Replication factor for the topic
+    #[arg(short, long, default_value = "1")]
+    pub(crate) replication_factor: u8,
     /// Message expiry time in human readable format like 15days 2min 2s
-    /// ("none" or skipping parameter disables message expiry functionality in topic)
-    #[arg(value_parser = clap::value_parser!(MessageExpiry))]
-    pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
+    ///
+    /// ("unlimited" or skipping parameter disables message expiry functionality in topic)
+    #[arg(value_parser = clap::value_parser!(MessageExpiry), verbatim_doc_comment)]
+    pub(crate) message_expiry: Vec<MessageExpiry>,
 }
 
 #[derive(Debug, Clone, Args)]
@@ -112,10 +123,20 @@ pub(crate) struct TopicUpdateArgs {
     pub(crate) topic_id: Identifier,
     /// New name for the topic
     pub(crate) name: String,
+    /// New max topic size
+    ///
+    /// ("unlimited" or skipping parameter causes removal of max topic size parameter in topic)
+    /// Can't be lower than segment size in the config.
+    #[arg(short, long, default_value = "unlimited", verbatim_doc_comment)]
+    pub(crate) max_topic_size: IggyByteSize,
+    #[arg(short, long, default_value = "1")]
+    /// New replication factor for the topic
+    pub(crate) replication_factor: u8,
     /// New message expiry time in human readable format like 15days 2min 2s
-    /// ("none" or skipping parameter causes removal of expiry parameter in topic)
-    #[arg(value_parser = clap::value_parser!(MessageExpiry))]
-    pub(crate) message_expiry: Option<Vec<MessageExpiry>>,
+    ///
+    /// ("unlimited" or skipping parameter causes removal of expiry parameter in topic)
+    #[arg(value_parser = clap::value_parser!(MessageExpiry), verbatim_doc_comment)]
+    pub(crate) message_expiry: Vec<MessageExpiry>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -47,9 +47,7 @@ use iggy::cli::{
         update_permissions::UpdatePermissionsCmd,
         update_user::{UpdateUserCmd, UpdateUserType},
     },
-    utils::{
-        message_expiry::MessageExpiry, personal_access_token_expiry::PersonalAccessTokenExpiry,
-    },
+    utils::personal_access_token_expiry::PersonalAccessTokenExpiry,
 };
 use iggy::cli_command::{CliCommand, PRINT_TARGET};
 use iggy::client_provider::{self, ClientProviderConfig};
@@ -79,7 +77,9 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
                 args.topic_id,
                 args.partitions_count,
                 args.name.clone(),
-                MessageExpiry::new(args.message_expiry.clone()),
+                args.message_expiry.clone().into(),
+                args.max_topic_size,
+                args.replication_factor,
             )),
             TopicAction::Delete(args) => Box::new(DeleteTopicCmd::new(
                 args.stream_id.clone(),
@@ -89,7 +89,9 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
                 args.stream_id.clone(),
                 args.topic_id.clone(),
                 args.name.clone(),
-                MessageExpiry::new(args.message_expiry.clone()),
+                args.message_expiry.clone().into(),
+                args.max_topic_size,
+                args.replication_factor,
             )),
             TopicAction::Get(args) => Box::new(GetTopicCmd::new(
                 args.stream_id.clone(),

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -258,13 +258,20 @@ size = "4GB"
 
 # Data retention policy configuration.
 [system.retention_policy]
-# Configures the message expiry setting.
+# Configures the message time-based expiry setting.
 # "disabled" means messages are kept indefinitely.
 # A time value in human-readable format determines the lifespan of messages.
 # Example: `message_expiry = "2 days 4 hours 15 minutes"` means messages will expire after that duration.
 message_expiry = "disabled"
 
-# Maximum size of a topic, e.g., "10 GB".
+# Configures the topic size-based expiry setting.
+# "unlimited" or "0" means topics are kept indefinitely.
+# A size value in human-readable format determines the maximum size of a topic.
+# When a topic reaches this size, the oldest messages are deleted to make room for new ones.
+# Messages are removed in full segments, so if segment size is 1 GB and the topic size is 10 GB,
+# the oldest segment will be deleted upon reaching 10 GB.
+# Example: `max_topic_size = "10 GB"` means oldest messages in topics will be deleted when they reach 10 GB.
+# Note: this setting can be overwritten with CreateTopic and UpdateTopic requests.
 max_topic_size = "10 GB"
 
 # Encryption configuration
@@ -350,5 +357,3 @@ enabled = false
 max_entries = 1000
 # Maximum age of ID entries in the deduplication cache in human-readable format.
 expiry = "1m"
-
-

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -66,6 +66,8 @@ async fn init_system(client: &IggyClient) {
             partitions_count: 1,
             name: "sample-topic".to_string(),
             message_expiry: None,
+            max_topic_size: None,
+            replication_factor: 1,
         })
         .await
     {

--- a/examples/src/shared/system.rs
+++ b/examples/src/shared/system.rs
@@ -90,6 +90,8 @@ pub async fn init_by_producer(args: &Args, client: &dyn Client) -> Result<(), Er
             partitions_count: args.partitions_count,
             name: "orders".to_string(),
             message_expiry: None,
+            max_topic_size: None,
+            replication_factor: 1,
         })
         .await?;
     Ok(())

--- a/iggy/errors_repository.rs
+++ b/iggy/errors_repository.rs
@@ -813,6 +813,14 @@ pub fn load_errors() -> Vec<ErrorRepositoryEntry> {
             template: "Cannot read topics for stream with ID: {0}".to_string(),
         },
         ErrorRepositoryEntry {
+            snake_case_name: "invalid_replication_factor".to_string(),
+            code: 2018,
+            signature: "".to_string(),
+            converts_from: "".to_string(),
+            source: "".to_string(),
+            template: "Invalid replication factor".to_string(),
+        },
+        ErrorRepositoryEntry {
             snake_case_name: "cannot_create_partition".to_string(),
             code: 3000,
             signature: "u32, u32, u32".to_string(),

--- a/iggy/src/binary/topics.rs
+++ b/iggy/src/binary/topics.rs
@@ -18,6 +18,7 @@ pub async fn get_topic(
     client: &dyn BinaryClient,
     command: &GetTopic,
 ) -> Result<TopicDetails, Error> {
+    fail_if_not_authenticated(client).await?;
     let response = client
         .send_with_response(GET_TOPIC_CODE, &command.as_bytes())
         .await?;

--- a/iggy/src/cli/message/poll_messages.rs
+++ b/iggy/src/cli/message/poll_messages.rs
@@ -3,7 +3,7 @@ use crate::client::Client;
 use crate::consumer::Consumer;
 use crate::identifier::Identifier;
 use crate::messages::poll_messages::{PollMessages, PollingStrategy};
-use crate::utils::{byte_size::IggyByteSize, duration::IggyDuration, timestamp::TimeStamp};
+use crate::utils::{byte_size::IggyByteSize, duration::IggyDuration, timestamp::IggyTimestamp};
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -94,7 +94,7 @@ impl CliCommand for PollMessagesCmd {
         messages.messages.iter().for_each(|message| {
             table.add_row(vec![
                 format!("{}", message.offset),
-                TimeStamp::from(message.timestamp).to_local("%Y-%m-%d %H:%M:%S%.6f"),
+                IggyTimestamp::from(message.timestamp).to_local("%Y-%m-%d %H:%M:%S%.6f"),
                 format!("{}", message.id),
                 format!("{}", message.payload.len()),
                 String::from_utf8_lossy(&message.payload).to_string(),

--- a/iggy/src/cli/personal_access_tokens/get_personal_access_tokens.rs
+++ b/iggy/src/cli/personal_access_tokens/get_personal_access_tokens.rs
@@ -1,7 +1,7 @@
 use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -52,8 +52,8 @@ impl CliCommand for GetPersonalAccessTokensCmd {
                     table.add_row(vec![
                         format!("{}", token.name.clone()),
                         match token.expiry {
-                            Some(value) => TimeStamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
-                            None => String::from("None"),
+                            Some(value) => IggyTimestamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            None => String::from("unlimited"),
                         },
                     ]);
                 });
@@ -66,8 +66,8 @@ impl CliCommand for GetPersonalAccessTokensCmd {
                         "{}|{}",
                         token.name,
                         match token.expiry {
-                            Some(value) => TimeStamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
-                            None => String::from("None"),
+                            Some(value) => IggyTimestamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            None => String::from("unlimited"),
                         },
                     );
                 });

--- a/iggy/src/cli/streams/get_stream.rs
+++ b/iggy/src/cli/streams/get_stream.rs
@@ -2,7 +2,7 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::streams::get_stream::GetStream;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -40,7 +40,7 @@ impl CliCommand for GetStreamCmd {
         table.add_row(vec!["Stream ID", format!("{}", stream.id).as_str()]);
         table.add_row(vec![
             "Created",
-            TimeStamp::from(stream.created_at)
+            IggyTimestamp::from(stream.created_at)
                 .to_string("%Y-%m-%d %H:%M:%S")
                 .as_str(),
         ]);

--- a/iggy/src/cli/streams/get_streams.rs
+++ b/iggy/src/cli/streams/get_streams.rs
@@ -1,7 +1,7 @@
 use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::streams::get_streams::GetStreams;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -67,7 +67,7 @@ impl CliCommand for GetStreamsCmd {
                 streams.iter().for_each(|stream| {
                     table.add_row(vec![
                         format!("{}", stream.id),
-                        TimeStamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
                         stream.name.clone(),
                         format!("{}", stream.size_bytes),
                         format!("{}", stream.messages_count),
@@ -82,7 +82,7 @@ impl CliCommand for GetStreamsCmd {
                     event!(target: PRINT_TARGET, Level::INFO,
                         "{}|{}|{}|{}|{}|{}",
                         stream.id,
-                        TimeStamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
                         stream.name,
                         stream.size_bytes,
                         stream.messages_count,

--- a/iggy/src/cli/topics/get_topic.rs
+++ b/iggy/src/cli/topics/get_topic.rs
@@ -2,7 +2,7 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::topics::get_topic::GetTopic;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -46,7 +46,7 @@ impl CliCommand for GetTopicCmd {
         table.add_row(vec!["Topic id", format!("{}", topic.id).as_str()]);
         table.add_row(vec![
             "Created",
-            TimeStamp::from(topic.created_at)
+            IggyTimestamp::from(topic.created_at)
                 .to_string("%Y-%m-%d %H:%M:%S")
                 .as_str(),
         ]);
@@ -56,7 +56,15 @@ impl CliCommand for GetTopicCmd {
             "Message expiry",
             match topic.message_expiry {
                 Some(value) => format!("{}", value),
-                None => String::from("None"),
+                None => String::from("unlimited"),
+            }
+            .as_str(),
+        ]);
+        table.add_row(vec![
+            "Max topic size",
+            match topic.max_topic_size {
+                Some(value) => format!("{}", value),
+                None => String::from("unlimited"),
             }
             .as_str(),
         ]);

--- a/iggy/src/cli/topics/get_topics.rs
+++ b/iggy/src/cli/topics/get_topics.rs
@@ -2,7 +2,7 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::topics::get_topics::GetTopics;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -65,6 +65,7 @@ impl CliCommand for GetTopicsCmd {
                     "Created",
                     "Name",
                     "Size (B)",
+                    "Max Topic Size (B)",
                     "Message Expiry (s)",
                     "Messages Count",
                     "Partitions Count",
@@ -73,12 +74,16 @@ impl CliCommand for GetTopicsCmd {
                 topics.iter().for_each(|topic| {
                     table.add_row(vec![
                         format!("{}", topic.id),
-                        TimeStamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
                         topic.name.clone(),
-                        format!("{}", topic.size_bytes),
+                        format!("{}", topic.size),
+                        match topic.max_topic_size {
+                            Some(value) => format!("{}", value),
+                            None => String::from("unlimited"),
+                        },
                         match topic.message_expiry {
                             Some(value) => format!("{}", value),
-                            None => String::from("None"),
+                            None => String::from("unlimited"),
                         },
                         format!("{}", topic.messages_count),
                         format!("{}", topic.partitions_count),
@@ -90,14 +95,18 @@ impl CliCommand for GetTopicsCmd {
             GetTopicsOutput::List => {
                 topics.iter().for_each(|topic| {
                     event!(target: PRINT_TARGET, Level::INFO,
-                        "{}|{}|{}|{}|{}|{}|{}",
+                        "{}|{}|{}|{}|{}|{}|{}|{}",
                         topic.id,
-                        TimeStamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
                         topic.name,
-                        topic.size_bytes,
+                        topic.size,
+                        match topic.max_topic_size {
+                            Some(value) => format!("{}", value),
+                            None => String::from("unlimited"),
+                        },
                         match topic.message_expiry {
                             Some(value) => format!("{}", value),
-                            None => String::from("None"),
+                            None => String::from("unlimited"),
                         },
                         topic.messages_count,
                         topic.partitions_count

--- a/iggy/src/cli/topics/update_topic.rs
+++ b/iggy/src/cli/topics/update_topic.rs
@@ -3,13 +3,17 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::topics::update_topic::UpdateTopic;
+use crate::utils::byte_size::IggyByteSize;
 use anyhow::Context;
 use async_trait::async_trait;
+use core::fmt;
 use tracing::{event, Level};
 
 pub struct UpdateTopicCmd {
     update_topic: UpdateTopic,
-    message_expiry: Option<MessageExpiry>,
+    message_expiry: MessageExpiry,
+    max_topic_size: IggyByteSize,
+    replication_factor: u8,
 }
 
 impl UpdateTopicCmd {
@@ -17,19 +21,22 @@ impl UpdateTopicCmd {
         stream_id: Identifier,
         topic_id: Identifier,
         name: String,
-        message_expiry: Option<MessageExpiry>,
+        message_expiry: MessageExpiry,
+        max_topic_size: IggyByteSize,
+        replication_factor: u8,
     ) -> Self {
         Self {
             update_topic: UpdateTopic {
                 stream_id,
                 topic_id,
                 name,
-                message_expiry: match &message_expiry {
-                    None => None,
-                    Some(value) => value.into(),
-                },
+                message_expiry: message_expiry.clone().into(),
+                max_topic_size: Some(max_topic_size),
+                replication_factor,
             },
             message_expiry,
+            max_topic_size,
+            replication_factor,
         }
     }
 }
@@ -37,17 +44,7 @@ impl UpdateTopicCmd {
 #[async_trait]
 impl CliCommand for UpdateTopicCmd {
     fn explain(&self) -> String {
-        let expiry_text = match &self.message_expiry {
-            Some(value) => format!(" and message expire time: {}", value),
-            None => String::from(""),
-        };
-        format!(
-            "update topic with ID: {}, name: {}{} in stream with ID: {}",
-            self.update_topic.topic_id,
-            self.update_topic.name,
-            expiry_text,
-            self.update_topic.stream_id
-        )
+        format!("{}", self)
     }
 
     async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
@@ -56,28 +53,40 @@ impl CliCommand for UpdateTopicCmd {
             .await
             .with_context(|| {
                 format!(
-                    "Problem updating topic (ID: {}, name: {}{}) in stream with ID: {}",
+                    "Problem updating topic (ID: {}, name: {}, message expiry: {}) in stream with ID: {}",
                     self.update_topic.topic_id,
                     self.update_topic.name,
-                    match &self.message_expiry {
-                        Some(value) => format!(" and message expire time: {}", value),
-                        None => String::from(""),
-                    },
+                    self.message_expiry,
                     self.update_topic.stream_id
                 )
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
-            "Topic with ID: {} updated name: {}{} in stream with ID: {}",
+            "Topic with ID: {} updated name: {}, updated message expiry: {} in stream with ID: {}",
             self.update_topic.topic_id,
             self.update_topic.name,
-            match &self.message_expiry {
-                Some(value) => format!(" and message expire time: {}", value),
-                None => String::from(""),
-            },
+            self.message_expiry,
             self.update_topic.stream_id,
         );
 
         Ok(())
+    }
+}
+
+impl fmt::Display for UpdateTopicCmd {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        let topic_id = &self.update_topic.topic_id;
+        let topic_name = &self.update_topic.name;
+        let message_expiry = &self.message_expiry;
+        let max_topic_size = &self.max_topic_size.as_human_string_with_zero_as_unlimited();
+        let replication_factor = self.replication_factor;
+        let stream_id = &self.update_topic.stream_id;
+
+        write!(
+            f,
+            "update topic with ID: {topic_id}, name: {topic_name}, message expiry: \
+            {message_expiry}, max topic size: {max_topic_size}, replication \
+            factor: {replication_factor}, in stream with ID: {stream_id}",
+        )
     }
 }

--- a/iggy/src/cli/users/get_user.rs
+++ b/iggy/src/cli/users/get_user.rs
@@ -3,7 +3,7 @@ use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::models::permissions::{GlobalPermissions, StreamPermissions, TopicPermissions};
 use crate::users::get_user::GetUser;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::presets::ASCII_NO_BORDERS;
@@ -148,7 +148,7 @@ impl CliCommand for GetUserCmd {
         table.add_row(vec!["User ID", format!("{}", user.id).as_str()]);
         table.add_row(vec![
             "Created",
-            TimeStamp::from(user.created_at)
+            IggyTimestamp::from(user.created_at)
                 .to_local("%Y-%m-%d %H:%M:%S")
                 .as_str(),
         ]);

--- a/iggy/src/cli/users/get_users.rs
+++ b/iggy/src/cli/users/get_users.rs
@@ -1,7 +1,7 @@
 use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::users::get_users::GetUsers;
-use crate::utils::timestamp::TimeStamp;
+use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -65,7 +65,7 @@ impl CliCommand for GetUsersCmd {
                 users.iter().for_each(|user| {
                     table.add_row(vec![
                         format!("{}", user.id),
-                        TimeStamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
                         user.status.clone().to_string(),
                         user.username.clone(),
                     ]);
@@ -78,7 +78,7 @@ impl CliCommand for GetUsersCmd {
                     event!(target: PRINT_TARGET, Level::INFO,
                         "{}|{}|{}|{}",
                         user.id,
-                        TimeStamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
                         user.status.clone().to_string(),
                         user.username.clone(),
                     );

--- a/iggy/src/cli/utils/message_expiry.rs
+++ b/iggy/src/cli/utils/message_expiry.rs
@@ -66,7 +66,7 @@ impl FromStr for MessageExpiry {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let result = match s {
-            "none" => MessageExpiry::NeverExpire,
+            "unlimited" | "none" | "None" | "Unlimited" => MessageExpiry::NeverExpire,
             value => {
                 let duration = value.parse::<HumanDuration>().map_err(|e| format!("{e}"))?;
 
@@ -82,6 +82,25 @@ impl FromStr for MessageExpiry {
         };
 
         Ok(result)
+    }
+}
+
+impl From<MessageExpiry> for Option<u32> {
+    fn from(val: MessageExpiry) -> Self {
+        match val {
+            MessageExpiry::ExpireDuration(value) => Some(value.as_secs() as u32),
+            MessageExpiry::NeverExpire => None,
+        }
+    }
+}
+
+impl From<Vec<MessageExpiry>> for MessageExpiry {
+    fn from(values: Vec<MessageExpiry>) -> Self {
+        let mut result = MessageExpiry::NeverExpire;
+        for value in values {
+            result = result + value;
+        }
+        result
     }
 }
 

--- a/iggy/src/models/messages.rs
+++ b/iggy/src/models/messages.rs
@@ -4,7 +4,7 @@ use crate::messages::send_messages;
 use crate::models::header;
 use crate::models::header::{HeaderKey, HeaderValue};
 use crate::sizeable::Sizeable;
-use crate::utils::{checksum, timestamp::TimeStamp};
+use crate::utils::{checksum, timestamp::IggyTimestamp};
 use bytes::{BufMut, Bytes};
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
@@ -132,7 +132,7 @@ impl Sizeable for Arc<Message> {
 impl Message {
     /// Creates a new message from the `Message` struct being part of `SendMessages` command.
     pub fn from_message(message: &send_messages::Message) -> Self {
-        let timestamp = TimeStamp::now().to_micros();
+        let timestamp = IggyTimestamp::now().to_micros();
         let checksum = checksum::calculate(&message.payload);
         let headers = message.headers.as_ref().cloned();
 

--- a/iggy/src/models/topic.rs
+++ b/iggy/src/models/topic.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 /// - `created_at`: the timestamp when the topic was created.
 /// - `name`: the unique name of the topic.
 /// - `size`: the total size of the topic in bytes.
-/// - `message_expiry`: the optional expiry of the messages in the topic.
+/// - `message_expiry`: the optional expiry of the messages in the topic in seconds.
+/// - `max_topic_size`: the optional maximum size of the topic in bytes.
+/// - `replication_factor`: replication factor for the topic.
 /// - `messages_count`: the total number of messages in the topic.
 /// - `partitions_count`: the total number of partitions in the topic.
 #[derive(Debug, Serialize, Deserialize)]
@@ -19,9 +21,14 @@ pub struct Topic {
     /// The unique name of the topic.
     pub name: String,
     /// The total size of the topic in bytes.
-    pub size_bytes: IggyByteSize,
-    /// The optional expiry of the messages in the topic.
+    pub size: IggyByteSize,
+    /// The optional expiry of the messages in the topic in seconds.
     pub message_expiry: Option<u32>,
+    /// The optional maximum size of the topic.
+    /// Can't be lower than segment size in the config.
+    pub max_topic_size: Option<IggyByteSize>,
+    /// Replication factor for the topic.
+    pub replication_factor: u8,
     /// The total number of messages in the topic.
     pub messages_count: u64,
     /// The total number of partitions in the topic.
@@ -33,8 +40,10 @@ pub struct Topic {
 /// - `id`: the unique identifier (numeric) of the topic.
 /// - `created_at`: the timestamp when the topic was created.
 /// - `name`: the unique name of the topic.
-/// - `size`: the total size of the topic in bytes.
-/// - `message_expiry`: the optional expiry of the messages in the topic.
+/// - `size`: the total size of the topic.
+/// - `message_expiry`: the optional expiry of the messages in the topic in seconds.
+/// - `max_topic_size`: the optional maximum size of the topic.
+/// - `replication_factor`: replication factor for the topic.
 /// - `messages_count`: the total number of messages in the topic.
 /// - `partitions_count`: the total number of partitions in the topic.
 /// - `partitions`: the collection of partitions in the topic.
@@ -46,10 +55,15 @@ pub struct TopicDetails {
     pub created_at: u64,
     /// The unique name of the topic.
     pub name: String,
-    /// The total size of the topic in bytes.
+    /// The total size of the topic.
     pub size: IggyByteSize,
     /// The optional expiry of the messages in the topic.
     pub message_expiry: Option<u32>,
+    /// The optional maximum size of the topic.
+    /// Can't be lower than segment size in the config.
+    pub max_topic_size: Option<IggyByteSize>,
+    /// Replication factor for the topic.
+    pub replication_factor: u8,
     /// The total number of messages in the topic.
     pub messages_count: u64,
     /// The total number of partitions in the topic.

--- a/iggy/src/utils/byte_size.rs
+++ b/iggy/src/utils/byte_size.rs
@@ -8,17 +8,29 @@ use super::duration::IggyDuration;
 
 /// A struct for representing byte sizes with various utility functions.
 ///
-/// This struct is part of the `crate` module and uses `Byte` from `byte_unit` crate.
+/// This struct uses `Byte` from `byte_unit` crate.
 /// It also implements serialization and deserialization via the `serde` crate.
 ///
-/// # Examples
+/// # Example
 ///
 /// ```
 /// use iggy::utils::byte_size::IggyByteSize;
+/// use std::str::FromStr;
 ///
-/// let size = IggyByteSize::from(1024_u64);
-/// println!("Size in bytes: {}", size.as_bytes_u64());
-/// println!("Human-readable size: {}", size.to_human_string());
+/// let size = IggyByteSize::from(568_000_000_u64);
+/// assert_eq!(568_000_000, size.as_bytes_u64());
+/// assert_eq!("568 MB", size.as_human_string());
+/// assert_eq!("568 MB", format!("{}", size));
+///
+/// let size = IggyByteSize::from(0_u64);
+/// assert_eq!("unlimited", size.as_human_string_with_zero_as_unlimited());
+/// assert_eq!("0 B", size.as_human_string());
+/// assert_eq!(0, size.as_bytes_u64());
+///
+/// let size = IggyByteSize::from_str("1 GB").unwrap();
+/// assert_eq!(1_000_000_000, size.as_bytes_u64());
+/// assert_eq!("1 GB", size.as_human_string());
+/// assert_eq!("1 GB", format!("{}", size));
 /// ```
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
 pub struct IggyByteSize(Byte);
@@ -36,13 +48,13 @@ impl IggyByteSize {
     }
 
     /// Returns a human-readable string representation of the byte size using decimal units.
-    pub fn to_human_string(&self) -> String {
+    pub fn as_human_string(&self) -> String {
         self.0.get_appropriate_unit(UnitType::Decimal).to_string()
     }
 
     /// Returns a human-readable string representation of the byte size.
     /// Returns "unlimited" if the size is zero.
-    pub fn to_human_string_with_special_zero(&self) -> String {
+    pub fn as_human_string_with_zero_as_unlimited(&self) -> String {
         if self.as_bytes_u64() == 0 {
             return "unlimited".to_string();
         }
@@ -50,23 +62,30 @@ impl IggyByteSize {
     }
 
     /// Calculates the throughput based on the provided duration and returns a human-readable string.
-    ///
-    /// # Arguments
-    ///
-    /// * `duration` - A reference to `IggyDuration`.
-    pub fn to_human_throughput_string(&self, duration: &IggyDuration) -> String {
-        if duration.as_secs() == 0 {
+    pub(crate) fn _as_human_throughput_string(&self, duration: &IggyDuration) -> String {
+        if duration.is_zero() {
             return "0 B/s".to_string();
         }
-
-        let bytes_per_second = Self::from(self.0.as_u64() / duration.as_secs() as u64);
-        format!("{}/s", bytes_per_second)
+        let seconds = duration.as_secs_f64();
+        let normalized_bytes_per_second = Self::from((self.as_bytes_u64() as f64 / seconds) as u64);
+        format!("{}/s", normalized_bytes_per_second)
     }
 }
 
+/// Converts a `u64` bytes to `IggyByteSize`.
 impl From<u64> for IggyByteSize {
     fn from(byte_size: u64) -> Self {
         IggyByteSize(Byte::from_u64(byte_size))
+    }
+}
+
+/// Converts an `Option<u64>` bytes to `IggyByteSize`.
+impl From<Option<u64>> for IggyByteSize {
+    fn from(byte_size: Option<u64>) -> Self {
+        match byte_size {
+            Some(value) => IggyByteSize(Byte::from_u64(value)),
+            None => IggyByteSize(Byte::from_u64(0)),
+        }
     }
 }
 
@@ -74,13 +93,11 @@ impl FromStr for IggyByteSize {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(IggyByteSize(Byte::from_str(s)?))
-    }
-}
-
-impl fmt::Display for IggyByteSize {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_human_string())
+        if matches!(s, "0" | "unlimited" | "Unlimited" | "none" | "None") {
+            Ok(IggyByteSize(Byte::from_u64(0)))
+        } else {
+            Ok(IggyByteSize(Byte::from_str(s)?))
+        }
     }
 }
 
@@ -93,6 +110,12 @@ impl PartialEq<u64> for IggyByteSize {
 impl PartialOrd<u64> for IggyByteSize {
     fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
         self.as_bytes_u64().partial_cmp(other)
+    }
+}
+
+impl fmt::Display for IggyByteSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_human_string())
     }
 }
 
@@ -131,33 +154,42 @@ mod tests {
     }
 
     #[test]
-    fn test_from_str_gigabytes() {
-        let byte_size = IggyByteSize::from_str("1.073 GB").unwrap();
-        assert_eq!(byte_size.as_bytes_u64(), 1_073_000_000);
+    fn test_from_str_gigabyte() {
+        let byte_size = IggyByteSize::from_str("1 GiB").unwrap();
+        assert_eq!(byte_size.as_bytes_u64(), 1024 * 1024 * 1024);
+
+        let byte_size = IggyByteSize::from_str("1 GB").unwrap();
+        assert_eq!(byte_size.as_bytes_u64(), 1000 * 1000 * 1000);
     }
 
     #[test]
-    fn test_from_str_megabytes() {
+    fn test_from_str_megabyte() {
+        let byte_size = IggyByteSize::from_str("1 MiB").unwrap();
+        assert_eq!(byte_size.as_bytes_u64(), 1024 * 1024);
+
         let byte_size = IggyByteSize::from_str("1 MB").unwrap();
-        assert_eq!(byte_size.as_bytes_u64(), 1_000_000);
+        assert_eq!(byte_size.as_bytes_u64(), 1000 * 1000);
     }
 
     #[test]
     fn test_to_human_string_ok() {
         let byte_size = IggyByteSize::from(1_073_000_000);
-        assert_eq!(byte_size.to_string(), "1.073 GB");
+        assert_eq!(byte_size.as_human_string(), "1.073 GB");
     }
 
     #[test]
     fn test_to_human_string_zero() {
         let byte_size = IggyByteSize::from(0);
-        assert_eq!(byte_size.to_human_string(), "0 B");
+        assert_eq!(byte_size.as_human_string(), "0 B");
     }
 
     #[test]
     fn test_to_human_string_special_zero() {
         let byte_size = IggyByteSize::from(0);
-        assert_eq!(byte_size.to_human_string_with_special_zero(), "unlimited");
+        assert_eq!(
+            byte_size.as_human_string_with_zero_as_unlimited(),
+            "unlimited"
+        );
     }
 
     #[test]
@@ -165,7 +197,7 @@ mod tests {
         let byte_size = IggyByteSize::from(1_073_000_000);
         let duration = IggyDuration::from_str("10s").unwrap();
         assert_eq!(
-            byte_size.to_human_throughput_string(&duration),
+            byte_size._as_human_throughput_string(&duration),
             "107.3 MB/s"
         );
     }
@@ -174,21 +206,21 @@ mod tests {
     fn test_throughput_zero_size() {
         let byte_size = IggyByteSize::from(0);
         let duration = IggyDuration::from_str("10s").unwrap();
-        assert_eq!(byte_size.to_human_throughput_string(&duration), "0 B/s");
+        assert_eq!(byte_size._as_human_throughput_string(&duration), "0 B/s");
     }
 
     #[test]
     fn test_throughput_zero_duration() {
         let byte_size = IggyByteSize::from(1_073_000_000);
         let duration = IggyDuration::from_str("0s").unwrap();
-        assert_eq!(byte_size.to_human_throughput_string(&duration), "0 B/s");
+        assert_eq!(byte_size._as_human_throughput_string(&duration), "0 B/s");
     }
 
     #[test]
     fn test_throughput_very_low() {
         let byte_size = IggyByteSize::from(8);
         let duration = IggyDuration::from_str("1s").unwrap();
-        assert_eq!(byte_size.to_human_throughput_string(&duration), "8 B/s");
+        assert_eq!(byte_size._as_human_throughput_string(&duration), "8 B/s");
     }
 
     #[test]
@@ -196,7 +228,7 @@ mod tests {
         let byte_size = IggyByteSize::from(u64::MAX);
         let duration = IggyDuration::from_str("1s").unwrap();
         assert_eq!(
-            byte_size.to_human_throughput_string(&duration),
+            byte_size._as_human_throughput_string(&duration),
             "18.446744073709553 EB/s"
         );
     }

--- a/iggy/src/utils/duration.rs
+++ b/iggy/src/utils/duration.rs
@@ -24,6 +24,14 @@ impl IggyDuration {
         self.duration.as_secs() as u32
     }
 
+    pub fn as_secs_f64(&self) -> f64 {
+        self.duration.as_secs_f64()
+    }
+
+    pub fn as_micros(&self) -> u64 {
+        self.duration.as_micros() as u64
+    }
+
     pub fn get_duration(&self) -> Duration {
         self.duration
     }
@@ -37,7 +45,8 @@ impl FromStr for IggyDuration {
     type Err = humantime::DurationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "0" || s == "unlimited" || s == "disabled" || s == "None" || s == "none" {
+        let s = &s.to_lowercase();
+        if s == "0" || s == "unlimited" || s == "disabled" || s == "none" {
             Ok(IggyDuration {
                 duration: Duration::new(0, 0),
             })

--- a/iggy/src/utils/timestamp.rs
+++ b/iggy/src/utils/timestamp.rs
@@ -1,18 +1,31 @@
 use chrono::{DateTime, Local, Utc};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+/// A struct that represents a timestamp.
+///
+/// This struct uses `SystemTime` from `std::time` crate.
+///
+/// # Example
+///
+/// ```
+/// use iggy::utils::timestamp::IggyTimestamp;
+///
+/// let timestamp = IggyTimestamp::from(1694968446131680);
+/// assert_eq!(timestamp.to_string("%Y-%m-%d %H:%M:%S"), "2023-09-17 16:34:06");
+/// assert_eq!(timestamp.to_micros(), 1694968446131680);
+/// ```
 #[derive(Debug)]
-pub struct TimeStamp(SystemTime);
+pub struct IggyTimestamp(SystemTime);
 
-impl Default for TimeStamp {
+impl Default for IggyTimestamp {
     fn default() -> Self {
         Self(SystemTime::now())
     }
 }
 
-impl TimeStamp {
+impl IggyTimestamp {
     pub fn now() -> Self {
-        TimeStamp::default()
+        IggyTimestamp::default()
     }
 
     pub fn to_secs(&self) -> u64 {
@@ -32,9 +45,9 @@ impl TimeStamp {
     }
 }
 
-impl From<u64> for TimeStamp {
+impl From<u64> for IggyTimestamp {
     fn from(timestamp: u64) -> Self {
-        TimeStamp(UNIX_EPOCH + Duration::from_micros(timestamp))
+        IggyTimestamp(UNIX_EPOCH + Duration::from_micros(timestamp))
     }
 }
 
@@ -44,19 +57,19 @@ mod tests {
 
     #[test]
     fn test_timestamp_get() {
-        let timestamp = TimeStamp::now();
+        let timestamp = IggyTimestamp::now();
         assert!(timestamp.to_micros() > 0);
     }
 
     #[test]
     fn test_timestamp_to_micros() {
-        let timestamp = TimeStamp::from(1663472051111);
+        let timestamp = IggyTimestamp::from(1663472051111);
         assert_eq!(timestamp.to_micros(), 1663472051111);
     }
 
     #[test]
     fn test_timestamp_to_string() {
-        let timestamp = TimeStamp::from(1694968446131680);
+        let timestamp = IggyTimestamp::from(1694968446131680);
         assert_eq!(
             timestamp.to_string("%Y-%m-%d %H:%M:%S"),
             "2023-09-17 16:34:06"
@@ -65,7 +78,7 @@ mod tests {
 
     #[test]
     fn test_timestamp_from_u64() {
-        let timestamp = TimeStamp::from(1663472051111);
+        let timestamp = IggyTimestamp::from(1663472051111);
         assert_eq!(timestamp.to_micros(), 1663472051111);
     }
 }

--- a/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
@@ -84,6 +84,8 @@ impl IggyCmdTestCase for TestConsumerGroupCreateCmd {
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
@@ -90,6 +90,8 @@ impl IggyCmdTestCase for TestConsumerGroupDeleteCmd {
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
@@ -90,6 +90,8 @@ impl IggyCmdTestCase for TestConsumerGroupGetCmd {
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
@@ -87,6 +87,8 @@ impl IggyCmdTestCase for TestConsumerGroupListCmd {
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/message/test_message_poll_command.rs
+++ b/integration/tests/cli/message/test_message_poll_command.rs
@@ -112,6 +112,8 @@ impl IggyCmdTestCase for TestMessagePollCmd {
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/message/test_message_send_command.rs
+++ b/integration/tests/cli/message/test_message_send_command.rs
@@ -141,6 +141,8 @@ impl IggyCmdTestCase for TestMessageSendCmd {
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/partition/test_partition_create_command.rs
+++ b/integration/tests/cli/partition/test_partition_create_command.rs
@@ -83,6 +83,8 @@ impl IggyCmdTestCase for TestPartitionCreateCmd {
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/partition/test_partition_delete_command.rs
+++ b/integration/tests/cli/partition/test_partition_delete_command.rs
@@ -83,6 +83,8 @@ impl IggyCmdTestCase for TestPartitionDeleteCmd {
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/system/test_stats_command.rs
+++ b/integration/tests/cli/system/test_stats_command.rs
@@ -27,6 +27,8 @@ impl IggyCmdTestCase for TestStatsCmd {
                 stream_id,
                 partitions_count: 5,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
                 name: String::from("topic"),
             })
             .await;

--- a/integration/tests/cli/topic/test_topic_delete_command.rs
+++ b/integration/tests/cli/topic/test_topic_delete_command.rs
@@ -72,6 +72,8 @@ impl IggyCmdTestCase for TestTopicDeleteCmd {
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/topic/test_topic_get_command.rs
+++ b/integration/tests/cli/topic/test_topic_get_command.rs
@@ -73,6 +73,8 @@ impl IggyCmdTestCase for TestTopicGetCmd {
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());
@@ -111,7 +113,8 @@ impl IggyCmdTestCase for TestTopicGetCmd {
                 self.topic_name
             )))
             .stdout(contains("Topic size          | 0"))
-            .stdout(contains("Message expiry      | None"))
+            .stdout(contains("Message expiry      | unlimited"))
+            .stdout(contains("Max topic size      | unlimited"))
             .stdout(contains("Topic message count | 0"))
             .stdout(contains("Partitions count    | 1"));
     }

--- a/integration/tests/cli/topic/test_topic_list_command.rs
+++ b/integration/tests/cli/topic/test_topic_list_command.rs
@@ -70,6 +70,8 @@ impl IggyCmdTestCase for TestTopicListCmd {
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await;
         assert!(topic.is_ok());

--- a/integration/tests/cli/topic/test_topic_update_command.rs
+++ b/integration/tests/cli/topic/test_topic_update_command.rs
@@ -4,13 +4,14 @@ use crate::cli::common::{
 };
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
-use humantime::format_duration;
 use humantime::Duration as HumanDuration;
+use iggy::cli::utils::message_expiry::MessageExpiry;
 use iggy::streams::create_stream::CreateStream;
 use iggy::streams::delete_stream::DeleteStream;
 use iggy::topics::create_topic::CreateTopic;
 use iggy::topics::delete_topic::DeleteTopic;
 use iggy::topics::get_topic::GetTopic;
+use iggy::utils::byte_size::IggyByteSize;
 use iggy::{client::Client, identifier::Identifier};
 use predicates::str::diff;
 use serial_test::parallel;
@@ -22,8 +23,12 @@ struct TestTopicUpdateCmd {
     topic_id: u32,
     topic_name: String,
     message_expiry: Option<Vec<String>>,
+    max_topic_size: Option<IggyByteSize>,
+    replication_factor: u8,
     topic_new_name: String,
     topic_new_message_expiry: Option<Vec<String>>,
+    topic_new_max_size: Option<IggyByteSize>,
+    topic_new_replication_factor: u8,
     using_stream_id: TestStreamId,
     using_topic_id: TestTopicId,
 }
@@ -36,8 +41,12 @@ impl TestTopicUpdateCmd {
         topic_id: u32,
         topic_name: String,
         message_expiry: Option<Vec<String>>,
+        max_topic_size: Option<IggyByteSize>,
+        replication_factor: u8,
         topic_new_name: String,
         topic_new_message_expiry: Option<Vec<String>>,
+        topic_new_max_size: Option<IggyByteSize>,
+        topic_new_replication_factor: u8,
         using_stream_id: TestStreamId,
         using_topic_id: TestTopicId,
     ) -> Self {
@@ -47,8 +56,12 @@ impl TestTopicUpdateCmd {
             topic_id,
             topic_name,
             message_expiry,
+            max_topic_size,
+            replication_factor,
             topic_new_name,
             topic_new_message_expiry,
+            topic_new_max_size,
+            topic_new_replication_factor,
             using_stream_id,
             using_topic_id,
         }
@@ -66,6 +79,17 @@ impl TestTopicUpdateCmd {
         });
 
         command.push(self.topic_new_name.clone());
+
+        if let Some(max_size_bytes) = &self.topic_new_max_size {
+            command.push(format!("--max-size-bytes={}", max_size_bytes));
+        }
+
+        if self.topic_new_replication_factor != 1 {
+            command.push(format!(
+                "--replication-factor={}",
+                self.topic_new_replication_factor
+            ));
+        }
 
         if let Some(message_expiry) = &self.topic_new_message_expiry {
             command.extend(message_expiry.clone());
@@ -96,6 +120,8 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
             }
         };
 
+        let max_topic_size = self.max_topic_size;
+
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
@@ -103,6 +129,8 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry,
+                max_topic_size,
+                replication_factor: self.replication_factor,
             })
             .await;
         assert!(topic.is_ok());
@@ -127,20 +155,26 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
             TestTopicId::Named => self.topic_name.clone(),
         };
 
-        let message_expiry = match &self.topic_new_message_expiry {
-            None => String::new(),
-            Some(message_expiry) => {
-                let duration: Duration =
-                    *message_expiry.join(" ").parse::<HumanDuration>().unwrap();
+        let message_expiry = (match &self.topic_new_message_expiry {
+            Some(value) => value.join(" "),
+            None => MessageExpiry::NeverExpire.to_string(),
+        })
+        .to_string();
 
-                format!(" and message expire time: {}", format_duration(duration))
-            }
-        };
+        let max_topic_size = (match &self.topic_new_max_size {
+            Some(value) => value.as_human_string_with_zero_as_unlimited(),
+            None => IggyByteSize::default().as_human_string_with_zero_as_unlimited(),
+        })
+        .to_string();
 
-        let expected_message = format!(
-            "Executing update topic with ID: {}, name: {}{} in stream with ID: {}\nTopic with ID: {} updated name: {}{} in stream with ID: {}\n",
-            topic_id, self.topic_new_name, message_expiry, stream_id, topic_id, self.topic_new_name, message_expiry, stream_id
-        );
+        let replication_factor = self.replication_factor;
+        let new_topic_name = &self.topic_new_name;
+
+        let expected_message = format!("Executing update topic with ID: {topic_id}, name: {new_topic_name}, \
+                                message expiry: {message_expiry}, max topic size: {max_topic_size}, \
+                                replication factor: {replication_factor}, in stream with ID: {stream_id}\n\
+                                Topic with ID: {topic_id} updated name: {new_topic_name}, updated message expiry: {message_expiry} \
+                                in stream with ID: {stream_id}\n");
 
         command_state.success().stdout(diff(expected_message));
     }
@@ -193,7 +227,6 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
 #[parallel]
 pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
-
     iggy_cmd_test.setup().await;
     iggy_cmd_test
         .execute_test(TestTopicUpdateCmd::new(
@@ -202,8 +235,12 @@ pub async fn should_be_successful() {
             1,
             String::from("sync"),
             None,
+            None,
+            1,
             String::from("new_name"),
             None,
+            None,
+            1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
         ))
@@ -215,8 +252,12 @@ pub async fn should_be_successful() {
             3,
             String::from("topic"),
             None,
+            None,
+            1,
             String::from("testing"),
             None,
+            None,
+            1,
             TestStreamId::Named,
             TestTopicId::Numeric,
         ))
@@ -228,8 +269,12 @@ pub async fn should_be_successful() {
             5,
             String::from("development"),
             None,
+            None,
+            1,
             String::from("development"),
             None,
+            None,
+            1,
             TestStreamId::Numeric,
             TestTopicId::Named,
         ))
@@ -241,13 +286,17 @@ pub async fn should_be_successful() {
             2,
             String::from("probe"),
             None,
+            None,
+            1,
             String::from("development"),
             Some(vec![
                 String::from("1day"),
-                String::from("1hour"),
-                String::from("1min"),
-                String::from("1sec"),
+                String::from("1h"),
+                String::from("1m"),
+                String::from("1s"),
             ]),
+            None,
+            1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
         ))
@@ -259,8 +308,12 @@ pub async fn should_be_successful() {
             1,
             String::from("testing"),
             Some(vec![String::from("1s")]),
+            None,
+            1,
             String::from("testing"),
-            Some(vec![String::from("66sec")]),
+            Some(vec![String::from("1m 6s")]),
+            None,
+            1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
         ))
@@ -276,8 +329,12 @@ pub async fn should_be_successful() {
                 String::from("1m"),
                 String::from("1h"),
             ]),
+            None,
+            1,
             String::from("testing"),
             None,
+            None,
+            1,
             TestStreamId::Numeric,
             TestTopicId::Named,
         ))
@@ -305,7 +362,7 @@ Examples
  iggy update 1 1 new-name
  iggy update 1 2 new-name 1day 1hour 1min 1sec
 
-{USAGE_PREFIX} topic update <STREAM_ID> <TOPIC_ID> <NAME> [MESSAGE_EXPIRY]...
+{USAGE_PREFIX} topic update [OPTIONS] <STREAM_ID> <TOPIC_ID> <NAME> [MESSAGE_EXPIRY]...
 
 Arguments:
   <STREAM_ID>
@@ -322,9 +379,24 @@ Arguments:
           New name for the topic
 
   [MESSAGE_EXPIRY]...
-          New message expiry time in human readable format like 15days 2min 2s ("none" or skipping parameter causes removal of expiry parameter in topic)
+          New message expiry time in human readable format like 15days 2min 2s
+{CLAP_INDENT}
+          ("unlimited" or skipping parameter causes removal of expiry parameter in topic)
 
 Options:
+  -m, --max-topic-size <MAX_TOPIC_SIZE>
+          New max topic size
+{CLAP_INDENT}
+          ("unlimited" or skipping parameter causes removal of max topic size parameter in topic)
+          Can't be lower than segment size in the config.
+{CLAP_INDENT}
+          [default: unlimited]
+
+  -r, --replication-factor <REPLICATION_FACTOR>
+          New replication factor for the topic
+{CLAP_INDENT}
+          [default: 1]
+
   -h, --help
           Print help (see a summary with '-h')
 "#,
@@ -344,16 +416,18 @@ pub async fn should_short_help_match() {
             format!(
                 r#"Update topic name an message expiry time for given topic ID in given stream ID
 
-{USAGE_PREFIX} topic update <STREAM_ID> <TOPIC_ID> <NAME> [MESSAGE_EXPIRY]...
+{USAGE_PREFIX} topic update [OPTIONS] <STREAM_ID> <TOPIC_ID> <NAME> [MESSAGE_EXPIRY]...
 
 Arguments:
   <STREAM_ID>          Stream ID to update topic
   <TOPIC_ID>           Topic ID to update
   <NAME>               New name for the topic
-  [MESSAGE_EXPIRY]...  New message expiry time in human readable format like 15days 2min 2s ("none" or skipping parameter causes removal of expiry parameter in topic)
+  [MESSAGE_EXPIRY]...  New message expiry time in human readable format like 15days 2min 2s
 
 Options:
-  -h, --help  Print help (see more with '--help')
+  -m, --max-topic-size <MAX_TOPIC_SIZE>          New max topic size [default: unlimited]
+  -r, --replication-factor <REPLICATION_FACTOR>  New replication factor for the topic [default: 1]
+  -h, --help                                     Print help (see more with '--help')
 "#,
             ),
         ))

--- a/integration/tests/examples/mod.rs
+++ b/integration/tests/examples/mod.rs
@@ -134,6 +134,8 @@ impl<'a> IggyExampleTest<'a> {
                     partitions_count: 1,
                     name: "sample-topic".to_string(),
                     message_expiry: None,
+                    max_topic_size: None,
+                    replication_factor: 1,
                 })
                 .await
                 .unwrap();

--- a/integration/tests/server/scenarios/consumer_group_join_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_join_scenario.rs
@@ -46,6 +46,8 @@ pub async fn run(client_factory: &dyn ClientFactory) {
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
     };
     system_client.create_topic(&create_topic).await.unwrap();
 

--- a/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
@@ -70,6 +70,8 @@ async fn init_system(
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
     };
     system_client.create_topic(&create_topic).await.unwrap();
 

--- a/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
@@ -57,6 +57,8 @@ async fn init_system(client: &IggyClient) {
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
     };
     client.create_topic(&create_topic).await.unwrap();
 

--- a/integration/tests/server/scenarios/message_headers_scenario.rs
+++ b/integration/tests/server/scenarios/message_headers_scenario.rs
@@ -109,6 +109,8 @@ async fn init_system(client: &IggyClient) {
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
     };
     client.create_topic(&create_topic).await.unwrap();
 }

--- a/integration/tests/streaming/consumer_group.rs
+++ b/integration/tests/streaming/consumer_group.rs
@@ -81,6 +81,8 @@ async fn init_topic(setup: &TestSetup) -> Topic {
         setup.config.clone(),
         setup.storage.clone(),
         None,
+        None,
+        1,
     )
     .unwrap();
     topic.persist().await.unwrap();

--- a/integration/tests/streaming/messages.rs
+++ b/integration/tests/streaming/messages.rs
@@ -2,7 +2,7 @@ use crate::streaming::common::test_setup::TestSetup;
 use bytes::Bytes;
 use iggy::models::header::{HeaderKey, HeaderValue};
 use iggy::models::messages::{Message, MessageState};
-use iggy::utils::{checksum, timestamp::TimeStamp};
+use iggy::utils::{checksum, timestamp::IggyTimestamp};
 use server::configs::system::{PartitionConfig, SystemConfig};
 use server::streaming::partitions::partition::Partition;
 use std::collections::HashMap;
@@ -39,7 +39,7 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
     for i in 1..=messages_count {
         let offset = (i - 1) as u64;
         let state = MessageState::Available;
-        let timestamp = TimeStamp::now().to_micros();
+        let timestamp = IggyTimestamp::now().to_micros();
         let id = i as u128;
         let payload = Bytes::from(format!("message {}", i));
         let checksum = checksum::calculate(&payload);

--- a/integration/tests/streaming/personal_access_token.rs
+++ b/integration/tests/streaming/personal_access_token.rs
@@ -1,11 +1,11 @@
 use crate::streaming::common::test_setup::TestSetup;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use server::streaming::personal_access_tokens::personal_access_token::PersonalAccessToken;
 
 #[tokio::test]
 async fn many_personal_access_tokens_should_be_saved_and_loaded() {
     let setup = TestSetup::init().await;
-    let now = TimeStamp::now().to_micros();
+    let now = IggyTimestamp::now().to_micros();
     let (pat1, raw_token1) = PersonalAccessToken::new(1, "test1", now, None);
     let (pat2, raw_token2) = PersonalAccessToken::new(2, "test2", now, Some(1000));
     let (pat3, raw_token3) = PersonalAccessToken::new(3, "test3", now, Some(100_000));
@@ -101,7 +101,7 @@ fn assert_pat(personal_access_token: &PersonalAccessToken, loaded_pat: &Personal
 async fn personal_access_token_should_be_deleted() {
     let setup = TestSetup::init().await;
     let user_id = 1;
-    let now = TimeStamp::now().to_micros();
+    let now = IggyTimestamp::now().to_micros();
     let (personal_access_token, _) = PersonalAccessToken::new(user_id, "test", now, None);
     setup
         .storage

--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -1,7 +1,7 @@
 use crate::streaming::common::test_setup::TestSetup;
 use bytes::Bytes;
 use iggy::models::messages::{Message, MessageState};
-use iggy::utils::{checksum, timestamp::TimeStamp};
+use iggy::utils::{checksum, timestamp::IggyTimestamp};
 use server::streaming::segments::segment;
 use server::streaming::segments::segment::{INDEX_EXTENSION, LOG_EXTENSION, TIME_INDEX_EXTENSION};
 use std::sync::Arc;
@@ -126,7 +126,7 @@ async fn should_persist_and_load_segment_with_messages() {
     .await;
     let messages_count = 10;
     for i in 0..messages_count {
-        let message = create_message(i, "test", TimeStamp::now().to_micros());
+        let message = create_message(i, "test", IggyTimestamp::now().to_micros());
         segment.append_messages(&[Arc::new(message)]).await.unwrap();
     }
 
@@ -179,7 +179,7 @@ async fn given_all_expired_messages_segment_should_be_expired() {
     )
     .await;
     let messages_count = 10;
-    let now = TimeStamp::now().to_micros();
+    let now = IggyTimestamp::now().to_micros();
     let message_expiry = message_expiry as u64;
     let mut expired_timestamp = now - (1000 * 2 * message_expiry);
     for i in 0..messages_count {
@@ -223,7 +223,7 @@ async fn given_at_least_one_not_expired_message_segment_should_not_be_expired() 
         start_offset,
     )
     .await;
-    let now = TimeStamp::now().to_micros();
+    let now = IggyTimestamp::now().to_micros();
     let message_expiry = message_expiry as u64;
     let expired_timestamp = now - (1000 * 2 * message_expiry);
     let not_expired_timestamp = now - (1000 * message_expiry) + 1;

--- a/integration/tests/streaming/stream.rs
+++ b/integration/tests/streaming/stream.rs
@@ -94,7 +94,7 @@ async fn should_purge_existing_stream_on_disk() {
 
         let topic_id = 1;
         stream
-            .create_topic(topic_id, "test", 1, None)
+            .create_topic(topic_id, "test", 1, None, None, 1)
             .await
             .unwrap();
 

--- a/integration/tests/streaming/topic.rs
+++ b/integration/tests/streaming/topic.rs
@@ -23,6 +23,8 @@ async fn should_persist_topics_with_partitions_directories_and_info_file() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            None,
+            1,
         )
         .unwrap();
 
@@ -54,6 +56,8 @@ async fn should_load_existing_topic_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            None,
+            1,
         )
         .unwrap();
         topic.persist().await.unwrap();
@@ -97,6 +101,8 @@ async fn should_delete_existing_topic_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            None,
+            1,
         )
         .unwrap();
         topic.persist().await.unwrap();
@@ -130,6 +136,8 @@ async fn should_purge_existing_topic_on_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            None,
+            1,
         )
         .unwrap();
         topic.persist().await.unwrap();

--- a/integration/tests/streaming/topic_messages.rs
+++ b/integration/tests/streaming/topic_messages.rs
@@ -204,6 +204,8 @@ async fn init_topic(setup: &TestSetup, partitions_count: u32) -> Topic {
         setup.config.clone(),
         setup.storage.clone(),
         None,
+        None,
+        1,
     )
     .unwrap();
     topic.persist().await.unwrap();

--- a/integration/tests/streaming/user.rs
+++ b/integration/tests/streaming/user.rs
@@ -3,7 +3,7 @@ use iggy::models::permissions::{
     GlobalPermissions, Permissions, StreamPermissions, TopicPermissions,
 };
 use iggy::models::user_status::UserStatus;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use server::streaming::users::user::User;
 use std::collections::HashMap;
 
@@ -158,7 +158,7 @@ fn create_user(id: u32) -> User {
         id,
         username: format!("user{}", id),
         password: "secret".to_string(),
-        created_at: TimeStamp::now().to_micros(),
+        created_at: IggyTimestamp::now().to_micros(),
         status: UserStatus::Active,
         permissions: Some(Permissions {
             global: GlobalPermissions {

--- a/server/src/binary/handlers/topics/create_topic_handler.rs
+++ b/server/src/binary/handlers/topics/create_topic_handler.rs
@@ -22,6 +22,8 @@ pub async fn handle(
             &command.name,
             command.partitions_count,
             command.message_expiry,
+            command.max_topic_size,
+            command.replication_factor,
         )
         .await?;
     sender.send_empty_ok_response().await?;

--- a/server/src/binary/handlers/topics/update_topic_handler.rs
+++ b/server/src/binary/handlers/topics/update_topic_handler.rs
@@ -21,6 +21,8 @@ pub async fn handle(
             &command.topic_id,
             &command.name,
             command.message_expiry,
+            command.max_topic_size,
+            command.replication_factor,
         )
         .await?;
     sender.send_empty_ok_response().await?;

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -213,6 +213,11 @@ async fn extend_topic(topic: &Topic, bytes: &mut Vec<u8>) {
         Some(message_expiry) => bytes.put_u32_le(message_expiry),
         None => bytes.put_u32_le(0),
     };
+    match topic.max_topic_size {
+        Some(max_topic_size) => bytes.put_u64_le(max_topic_size.as_bytes_u64()),
+        None => bytes.put_u64_le(0),
+    };
+    bytes.put_u8(topic.replication_factor);
     bytes.put_u64_le(topic.get_size().await.as_bytes_u64());
     bytes.put_u64_le(topic.get_messages_count().await);
     bytes.put_u8(topic.name.len() as u8);

--- a/server/src/channels/commands/clean_messages.rs
+++ b/server/src/channels/commands/clean_messages.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use flume::Sender;
 use iggy::error::Error;
 use iggy::utils::duration::IggyDuration;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use tokio::time;
 use tracing::{error, info};
 
@@ -63,7 +63,7 @@ impl MessagesCleaner {
 #[async_trait]
 impl ServerCommand<CleanMessagesCommand> for CleanMessagesExecutor {
     async fn execute(&mut self, system: &SharedSystem, _command: CleanMessagesCommand) {
-        let now = TimeStamp::now().to_micros();
+        let now = IggyTimestamp::now().to_micros();
         let system_read = system.read();
         let streams = system_read.get_streams();
         for stream in streams {

--- a/server/src/channels/commands/clean_personal_access_tokens.rs
+++ b/server/src/channels/commands/clean_personal_access_tokens.rs
@@ -4,7 +4,7 @@ use crate::streaming::systems::system::SharedSystem;
 use async_trait::async_trait;
 use flume::Sender;
 use iggy::utils::duration::IggyDuration;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use tokio::time;
 use tracing::{debug, error, info};
 
@@ -78,7 +78,7 @@ impl ServerCommand<CleanPersonalAccessTokensCommand> for CleanPersonalAccessToke
             return;
         }
 
-        let now = TimeStamp::now().to_micros();
+        let now = IggyTimestamp::now().to_micros();
         let expired_tokens = tokens
             .into_iter()
             .filter(|token| token.is_expired(now))

--- a/server/src/configs/displays.rs
+++ b/server/src/configs/displays.rs
@@ -157,9 +157,9 @@ impl Display for RetentionPolicyConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{{ message_expiry: {}, max_topic_size: {} }}",
-            self.message_expiry,
-            self.max_topic_size.to_human_string_with_special_zero()
+            "{{ message_expiry {}, max_topic_size: {} }}",
+            self.message_expiry.as_secs(),
+            self.max_topic_size.as_human_string_with_zero_as_unlimited()
         )
     }
 }
@@ -222,7 +222,7 @@ impl Display for LoggingConfig {
             "{{ path: {}, level: {}, max_size: {}, retention: {} }}",
             self.path,
             self.level,
-            self.max_size.to_human_string_with_special_zero(),
+            self.max_size.as_human_string_with_zero_as_unlimited(),
             self.retention
         )
     }

--- a/server/src/configs/validators.rs
+++ b/server/src/configs/validators.rs
@@ -49,9 +49,9 @@ impl Validatable<ServerError> for CacheConfig {
         let free_memory = sys.free_memory();
         let cache_percentage = (limit_bytes as f64 / total_memory as f64) * 100.0;
 
-        let pretty_cache_limit = IggyByteSize::from(limit_bytes).to_human_string();
-        let pretty_total_memory = IggyByteSize::from(total_memory).to_human_string();
-        let pretty_free_memory = IggyByteSize::from(free_memory).to_human_string();
+        let pretty_cache_limit = IggyByteSize::from(limit_bytes).as_human_string();
+        let pretty_total_memory = IggyByteSize::from(total_memory).as_human_string();
+        let pretty_free_memory = IggyByteSize::from(free_memory).as_human_string();
 
         if limit_bytes > total_memory {
             return Err(ServerError::CacheConfigValidationFailure(format!(

--- a/server/src/http/jwt/cleaner.rs
+++ b/server/src/http/jwt/cleaner.rs
@@ -1,5 +1,5 @@
 use crate::http::shared::AppState;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{error, info};
@@ -10,7 +10,7 @@ pub fn start_expired_tokens_cleaner(app_state: Arc<AppState>) {
         loop {
             interval_timer.tick().await;
             info!("Deleting expired tokens...");
-            let now = TimeStamp::now().to_secs();
+            let now = IggyTimestamp::now().to_secs();
             app_state
                 .jwt_manager
                 .delete_expired_revoked_tokens(now)

--- a/server/src/http/jwt/jwt_manager.rs
+++ b/server/src/http/jwt/jwt_manager.rs
@@ -5,7 +5,7 @@ use crate::http::jwt::storage::TokenStorage;
 use iggy::error::Error;
 use iggy::models::user_info::UserId;
 use iggy::utils::duration::IggyDuration;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use jsonwebtoken::{encode, Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use sled::Db;
 use std::collections::HashMap;
@@ -165,7 +165,7 @@ impl JwtManager {
 
     pub fn generate(&self, user_id: UserId) -> Result<GeneratedTokens, Error> {
         let header = Header::new(self.issuer.algorithm);
-        let now = TimeStamp::now().to_secs();
+        let now = IggyTimestamp::now().to_secs();
         let iat = now;
         let exp = iat + self.issuer.access_token_expiry.as_secs() as u64;
         let nbf = iat + self.issuer.not_before.as_secs() as u64;
@@ -202,7 +202,7 @@ impl JwtManager {
     }
 
     pub fn refresh_token(&self, refresh_token: &str) -> Result<GeneratedTokens, Error> {
-        let now = TimeStamp::now().to_secs();
+        let now = IggyTimestamp::now().to_secs();
         if refresh_token.is_empty() {
             return Err(Error::InvalidRefreshToken);
         }

--- a/server/src/http/jwt/refresh_token.rs
+++ b/server/src/http/jwt/refresh_token.rs
@@ -44,12 +44,12 @@ impl RefreshToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iggy::utils::timestamp::TimeStamp;
+    use iggy::utils::timestamp::IggyTimestamp;
 
     #[test]
     fn refresh_token_should_be_created_with_random_secure_value_and_hashed_successfully() {
         let user_id = 1;
-        let now = TimeStamp::now().to_secs();
+        let now = IggyTimestamp::now().to_secs();
         let expiry = 10;
         let (refresh_token, raw_token) = RefreshToken::new(user_id, now, expiry);
         assert_eq!(refresh_token.user_id, user_id);
@@ -65,7 +65,7 @@ mod tests {
     #[test]
     fn refresh_access_token_should_be_expired_given_passed_expiry() {
         let user_id = 1;
-        let now = TimeStamp::now().to_secs();
+        let now = IggyTimestamp::now().to_secs();
         let expiry = 1;
         let (refresh_token, _) = RefreshToken::new(user_id, now, expiry);
         assert!(refresh_token.is_expired(now + expiry + 1));

--- a/server/src/http/mapper.rs
+++ b/server/src/http/mapper.rs
@@ -55,10 +55,12 @@ pub async fn map_topics(topics: &[&Topic]) -> Vec<iggy::models::topic::Topic> {
             id: topic.topic_id,
             created_at: topic.created_at,
             name: topic.name.clone(),
-            size_bytes: topic.get_size().await,
+            size: topic.get_size().await,
             partitions_count: topic.get_partitions().len() as u32,
             messages_count: topic.get_messages_count().await,
             message_expiry: topic.message_expiry,
+            max_topic_size: topic.max_topic_size,
+            replication_factor: topic.replication_factor,
         };
         topics_data.push(topic);
     }
@@ -76,6 +78,8 @@ pub async fn map_topic(topic: &Topic) -> TopicDetails {
         partitions_count: topic.get_partitions().len() as u32,
         partitions: Vec::new(),
         message_expiry: topic.message_expiry,
+        max_topic_size: topic.max_topic_size,
+        replication_factor: topic.replication_factor,
     };
     for partition in topic.get_partitions() {
         let partition = partition.read().await;

--- a/server/src/http/topics.rs
+++ b/server/src/http/topics.rs
@@ -80,6 +80,8 @@ async fn create_topic(
             &command.name,
             command.partitions_count,
             command.message_expiry,
+            command.max_topic_size,
+            command.replication_factor,
         )
         .await?;
     Ok(StatusCode::CREATED)
@@ -102,6 +104,8 @@ async fn update_topic(
             &command.topic_id,
             &command.name,
             command.message_expiry,
+            command.max_topic_size,
+            command.replication_factor,
         )
         .await?;
     Ok(StatusCode::NO_CONTENT)

--- a/server/src/streaming/partitions/partition.rs
+++ b/server/src/streaming/partitions/partition.rs
@@ -7,7 +7,7 @@ use crate::streaming::storage::SystemStorage;
 use dashmap::DashMap;
 use iggy::consumer::ConsumerKind;
 use iggy::models::messages::Message;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -121,7 +121,7 @@ impl Partition {
             consumer_group_offsets: DashMap::new(),
             config,
             storage,
-            created_at: TimeStamp::now().to_micros(),
+            created_at: IggyTimestamp::now().to_micros(),
         };
 
         if with_segment {

--- a/server/src/streaming/personal_access_tokens/personal_access_token.rs
+++ b/server/src/streaming/personal_access_tokens/personal_access_token.rs
@@ -49,11 +49,11 @@ impl PersonalAccessToken {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use iggy::utils::timestamp::TimeStamp;
+    use iggy::utils::timestamp::IggyTimestamp;
     #[test]
     fn personal_access_token_should_be_created_with_random_secure_value_and_hashed_successfully() {
         let user_id = 1;
-        let now = TimeStamp::now().to_micros();
+        let now = IggyTimestamp::now().to_micros();
         let name = "test_token";
         let (personal_access_token, raw_token) = PersonalAccessToken::new(user_id, name, now, None);
         assert_eq!(personal_access_token.name, name);
@@ -69,7 +69,7 @@ mod tests {
     #[test]
     fn personal_access_token_should_be_expired_given_passed_expiry() {
         let user_id = 1;
-        let now = TimeStamp::now().to_micros();
+        let now = IggyTimestamp::now().to_micros();
         let expiry = 1;
         let name = "test_token";
         let (personal_access_token, _) = PersonalAccessToken::new(user_id, name, now, Some(expiry));

--- a/server/src/streaming/segments/segment.rs
+++ b/server/src/streaming/segments/segment.rs
@@ -3,7 +3,7 @@ use crate::streaming::segments::index::Index;
 use crate::streaming::segments::time_index::TimeIndex;
 use crate::streaming::storage::SystemStorage;
 use iggy::models::messages::Message;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use std::sync::Arc;
 
 pub const LOG_EXTENSION: &str = "log";
@@ -76,7 +76,7 @@ impl Segment {
             return true;
         }
 
-        self.is_expired(TimeStamp::now().to_micros()).await
+        self.is_expired(IggyTimestamp::now().to_micros()).await
     }
 
     pub async fn is_expired(&self, now: u64) -> bool {

--- a/server/src/streaming/streams/stream.rs
+++ b/server/src/streaming/streams/stream.rs
@@ -2,7 +2,7 @@ use crate::configs::system::SystemConfig;
 use crate::streaming::storage::SystemStorage;
 use crate::streaming::topics::topic::Topic;
 use iggy::utils::byte_size::IggyByteSize;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -42,7 +42,7 @@ impl Stream {
             topics: HashMap::new(),
             topics_ids: HashMap::new(),
             storage,
-            created_at: TimeStamp::now().to_micros(),
+            created_at: IggyTimestamp::now().to_micros(),
         }
     }
 

--- a/server/src/streaming/systems/personal_access_tokens.rs
+++ b/server/src/streaming/systems/personal_access_tokens.rs
@@ -4,7 +4,7 @@ use crate::streaming::systems::system::System;
 use crate::streaming::users::user::User;
 use iggy::error::Error;
 use iggy::utils::text;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use tracing::{error, info};
 
 impl System {
@@ -63,7 +63,7 @@ impl System {
 
         info!("Creating personal access token: {name} for user with ID: {user_id}...");
         let (personal_access_token, token) =
-            PersonalAccessToken::new(user_id, &name, TimeStamp::now().to_micros(), expiry);
+            PersonalAccessToken::new(user_id, &name, IggyTimestamp::now().to_micros(), expiry);
         self.storage
             .personal_access_token
             .save(&personal_access_token)
@@ -100,7 +100,7 @@ impl System {
             .personal_access_token
             .load_by_token(&token_hash)
             .await?;
-        if personal_access_token.is_expired(TimeStamp::now().to_micros()) {
+        if personal_access_token.is_expired(IggyTimestamp::now().to_micros()) {
             error!(
                 "Personal access token: {} for user with ID: {} has expired.",
                 personal_access_token.name, personal_access_token.user_id

--- a/server/src/streaming/topics/consumer_groups.rs
+++ b/server/src/streaming/topics/consumer_groups.rs
@@ -300,6 +300,17 @@ mod tests {
         let partitions_count = 3;
         let config = Arc::new(SystemConfig::default());
 
-        Topic::create(stream_id, id, name, partitions_count, config, storage, None).unwrap()
+        Topic::create(
+            stream_id,
+            id,
+            name,
+            partitions_count,
+            config,
+            storage,
+            None,
+            None,
+            1,
+        )
+        .unwrap()
     }
 }

--- a/server/src/streaming/topics/messages.rs
+++ b/server/src/streaming/topics/messages.rs
@@ -382,6 +382,17 @@ mod tests {
         let name = "test";
         let config = Arc::new(SystemConfig::default());
 
-        Topic::create(stream_id, id, name, partitions_count, config, storage, None).unwrap()
+        Topic::create(
+            stream_id,
+            id,
+            name,
+            partitions_count,
+            config,
+            storage,
+            None,
+            None,
+            1,
+        )
+        .unwrap()
     }
 }

--- a/server/src/streaming/topics/topic.rs
+++ b/server/src/streaming/topics/topic.rs
@@ -2,9 +2,10 @@ use crate::configs::system::SystemConfig;
 use crate::streaming::partitions::partition::Partition;
 use crate::streaming::storage::SystemStorage;
 use crate::streaming::topics::consumer_group::ConsumerGroup;
+use core::fmt;
 use iggy::error::Error;
 use iggy::utils::byte_size::IggyByteSize;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use std::collections::HashMap;
 use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
@@ -24,6 +25,8 @@ pub struct Topic {
     pub(crate) consumer_groups_ids: HashMap<String, u32>,
     pub(crate) current_partition_id: AtomicU32,
     pub message_expiry: Option<u32>,
+    pub max_topic_size: Option<IggyByteSize>,
+    pub replication_factor: u8,
     pub created_at: u64,
 }
 
@@ -34,9 +37,10 @@ impl Topic {
         config: Arc<SystemConfig>,
         storage: Arc<SystemStorage>,
     ) -> Topic {
-        Topic::create(stream_id, topic_id, "", 0, config, storage, None).unwrap()
+        Topic::create(stream_id, topic_id, "", 0, config, storage, None, None, 1).unwrap()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         stream_id: u32,
         topic_id: u32,
@@ -45,10 +49,12 @@ impl Topic {
         config: Arc<SystemConfig>,
         storage: Arc<SystemStorage>,
         message_expiry: Option<u32>,
+        max_topic_size: Option<IggyByteSize>,
+        replication_factor: u8,
     ) -> Result<Topic, Error> {
         let path = config.get_topic_path(stream_id, topic_id);
         let partitions_path = config.get_partitions_path(stream_id, topic_id);
-        let mut topic = Topic {
+        let mut topic: Topic = Topic {
             stream_id,
             topic_id,
             name: name.to_string(),
@@ -69,9 +75,12 @@ impl Topic {
                     expiry => Some(expiry),
                 },
             },
+            max_topic_size,
+            replication_factor,
             config,
-            created_at: TimeStamp::now().to_micros(),
+            created_at: IggyTimestamp::now().to_micros(),
         };
+
         topic.add_partitions(partitions_count)?;
         Ok(topic)
     }
@@ -101,8 +110,27 @@ impl Topic {
     }
 }
 
+impl fmt::Display for Topic {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        let max_topic_size = match self.max_topic_size {
+            Some(size) => size.as_human_string_with_zero_as_unlimited(),
+            None => "unlimited".to_owned(),
+        };
+        write!(f, "ID: {}, ", self.topic_id)?;
+        write!(f, "stream ID: {}, ", self.stream_id)?;
+        write!(f, "name: {}, ", self.name)?;
+        write!(f, "path: {}, ", self.path)?;
+        write!(f, "partitions count: {:?}, ", self.partitions.len())?;
+        write!(f, "message expiry (s): {:?}, ", self.message_expiry)?;
+        write!(f, "max topic size (B): {:?}, ", max_topic_size)?;
+        write!(f, "replication factor: {}, ", self.replication_factor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::streaming::storage::tests::get_test_system_storage;
 
@@ -114,6 +142,8 @@ mod tests {
         let name = "test";
         let partitions_count = 3;
         let message_expiry = 10;
+        let max_topic_size = IggyByteSize::from_str("2 GB").unwrap();
+        let replication_factor = 1;
         let config = Arc::new(SystemConfig::default());
         let path = config.get_topic_path(stream_id, topic_id);
 
@@ -125,6 +155,8 @@ mod tests {
             config,
             storage,
             Some(message_expiry),
+            Some(max_topic_size),
+            replication_factor,
         )
         .unwrap();
 

--- a/server/src/streaming/users/user.rs
+++ b/server/src/streaming/users/user.rs
@@ -2,7 +2,7 @@ use crate::streaming::utils::crypto;
 use iggy::models::user_status::UserStatus;
 use iggy::models::{permissions::Permissions, user_info::UserId};
 use iggy::users::defaults::*;
-use iggy::utils::timestamp::TimeStamp;
+use iggy::utils::timestamp::IggyTimestamp;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,7 +22,7 @@ impl Default for User {
             status: UserStatus::Active,
             username: "user".to_string(),
             password: "secret".to_string(),
-            created_at: TimeStamp::now().to_micros(),
+            created_at: IggyTimestamp::now().to_micros(),
             permissions: None,
         }
     }
@@ -47,7 +47,7 @@ impl User {
             id,
             username: username.to_string(),
             password: crypto::hash_password(password),
-            created_at: TimeStamp::now().to_micros(),
+            created_at: IggyTimestamp::now().to_micros(),
             status,
             permissions,
         }

--- a/tools/src/data-seeder/seeder.rs
+++ b/tools/src/data-seeder/seeder.rs
@@ -54,6 +54,8 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
                 name: "orders".to_string(),
                 partitions_count: 1,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await?;
 
@@ -64,6 +66,8 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
                 name: "users".to_string(),
                 partitions_count: 2,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await?;
 
@@ -74,6 +78,8 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
                 name: "notifications".to_string(),
                 partitions_count: 3,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await?;
 
@@ -84,6 +90,8 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
                 name: "payments".to_string(),
                 partitions_count: 2,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await?;
 
@@ -94,6 +102,8 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
                 name: "deliveries".to_string(),
                 partitions_count: 1,
                 message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
             })
             .await?;
     }


### PR DESCRIPTION
- Add `max_topic_size` and `replication_factor` parameters to topic creation and update functions
- Rename `TimeStamp` to `IggyTimestamp`
- Implement display formatting for topics to include new parameters
- Adjust tests and tools to use the new parameter names and additional topic settings
- Ensure all topic-related operations account for the new settings
- Update documentation and help messages to reflect changes