### PR TITLE
Add dashmap crate for concurrent hashmap operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3548,6 +3548,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dashmap",
  "figlet-rs",
  "figment",
  "flume",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -24,6 +24,7 @@ byte-unit = { version = "5.1.2", default-features = false, features = [
 bytes = "1.5.0"
 chrono = "0.4.31"
 clap = { version = "4.4.13", features = ["derive"] }
+dashmap = "5.5.3"
 figlet-rs = "0.1.5"
 figment = { version = "0.10.13", features = ["json", "toml", "env"] }
 flume = "0.11.0"

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -135,11 +135,9 @@ impl Partition {
         count: u32,
     ) -> Result<Vec<Arc<Message>>, Error> {
         let (consumer_offsets, consumer_id) = match consumer {
-            PollingConsumer::Consumer(consumer_id, _) => {
-                (self.consumer_offsets.read().await, consumer_id)
-            }
+            PollingConsumer::Consumer(consumer_id, _) => (&self.consumer_offsets, consumer_id),
             PollingConsumer::ConsumerGroup(consumer_group_id, _) => {
-                (self.consumer_group_offsets.read().await, consumer_group_id)
+                (&self.consumer_group_offsets, consumer_group_id)
             }
         };
 


### PR DESCRIPTION
Resolve https://github.com/iggy-rs/iggy/issues/226

I used the `DashMap` to replace the original `RwLock<HashMap>`, and because the locking of `DashMap` is synchronous semantics, I had to use clone in the `fn store_offset` to avoid the lock crossing await.