### PR TITLE
Remove useless params in persist_messages

### DIFF
--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -130,10 +130,7 @@ async fn should_persist_and_load_segment_with_messages() {
         segment.append_messages(&[Arc::new(message)]).await.unwrap();
     }
 
-    segment
-        .persist_messages(setup.storage.segment.clone())
-        .await
-        .unwrap();
+    segment.persist_messages().await.unwrap();
 
     let mut loaded_segment = segment::Segment::create(
         stream_id,
@@ -191,10 +188,7 @@ async fn given_all_expired_messages_segment_should_be_expired() {
         segment.append_messages(&[Arc::new(message)]).await.unwrap();
     }
 
-    segment
-        .persist_messages(setup.storage.segment.clone())
-        .await
-        .unwrap();
+    segment.persist_messages().await.unwrap();
 
     let is_expired = segment.is_expired(now).await;
     assert!(is_expired);
@@ -244,10 +238,7 @@ async fn given_at_least_one_not_expired_message_segment_should_not_be_expired() 
         .append_messages(&[Arc::new(not_expired_message)])
         .await
         .unwrap();
-    segment
-        .persist_messages(setup.storage.segment.clone())
-        .await
-        .unwrap();
+    segment.persist_messages().await.unwrap();
 
     let is_expired = segment.is_expired(now).await;
     assert!(!is_expired);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,11 +12,9 @@ use server::http::http_server;
 use server::logging::Logging;
 use server::quic::quic_server;
 use server::server_error::ServerError;
-use server::streaming::persistence::persister::FileWithSyncPersister;
-use server::streaming::segments::storage::FileSegmentStorage;
+
 use server::streaming::systems::system::{SharedSystem, System};
 use server::tcp::tcp_server;
-use std::sync::Arc;
 use tokio::time::Instant;
 use tracing::info;
 
@@ -109,9 +107,7 @@ async fn main() -> Result<(), ServerError> {
 
     let shutdown_timestamp = Instant::now();
     let mut system = system.write();
-    let persister = Arc::new(FileWithSyncPersister);
-    let storage = Arc::new(FileSegmentStorage::new(persister));
-    system.shutdown(storage).await?;
+    system.shutdown().await?;
     let elapsed_time = shutdown_timestamp.elapsed();
 
     info!(

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -384,9 +384,7 @@ impl Partition {
                     last_segment.start_offset,
                     self.partition_id
                 );
-                last_segment
-                    .persist_messages(self.storage.segment.clone())
-                    .await?;
+                last_segment.persist_messages().await?;
                 self.unsaved_messages_count = 0;
             }
         }

--- a/server/src/streaming/segments/messages.rs
+++ b/server/src/streaming/segments/messages.rs
@@ -1,7 +1,6 @@
 use crate::streaming::segments::index::{Index, IndexRange};
 use crate::streaming::segments::segment::Segment;
 use crate::streaming::segments::time_index::TimeIndex;
-use crate::streaming::storage::SegmentStorage;
 use iggy::error::Error;
 use iggy::models::messages::Message;
 use std::sync::Arc;
@@ -252,10 +251,8 @@ impl Segment {
         Ok(())
     }
 
-    pub async fn persist_messages(
-        &mut self,
-        storage: Arc<dyn SegmentStorage>,
-    ) -> Result<(), Error> {
+    pub async fn persist_messages(&mut self) -> Result<(), Error> {
+        let storage = self.storage.segment.clone();
         if self.unsaved_messages.is_none() {
             return Ok(());
         }

--- a/server/src/streaming/streams/persistence.rs
+++ b/server/src/streaming/streams/persistence.rs
@@ -1,7 +1,5 @@
-use crate::streaming::storage::SegmentStorage;
 use crate::streaming::streams::stream::Stream;
 use iggy::error::Error;
-use std::sync::Arc;
 
 impl Stream {
     pub async fn load(&mut self) -> Result<(), Error> {
@@ -21,9 +19,9 @@ impl Stream {
         self.storage.stream.delete(self).await
     }
 
-    pub async fn persist_messages(&self, storage: Arc<dyn SegmentStorage>) -> Result<(), Error> {
+    pub async fn persist_messages(&self) -> Result<(), Error> {
         for topic in self.get_topics() {
-            topic.persist_messages(storage.clone()).await?;
+            topic.persist_messages().await?;
         }
 
         Ok(())

--- a/server/src/streaming/systems/system.rs
+++ b/server/src/streaming/systems/system.rs
@@ -5,7 +5,7 @@ use crate::streaming::clients::client_manager::ClientManager;
 use crate::streaming::diagnostics::metrics::Metrics;
 use crate::streaming::persistence::persister::*;
 use crate::streaming::session::Session;
-use crate::streaming::storage::{SegmentStorage, SystemStorage};
+use crate::streaming::storage::SystemStorage;
 use crate::streaming::streams::stream::Stream;
 use crate::streaming::users::permissioner::Permissioner;
 use iggy::error::Error;
@@ -158,15 +158,15 @@ impl System {
         Ok(())
     }
 
-    pub async fn shutdown(&mut self, storage: Arc<dyn SegmentStorage>) -> Result<(), Error> {
-        self.persist_messages(storage.clone()).await?;
+    pub async fn shutdown(&mut self) -> Result<(), Error> {
+        self.persist_messages().await?;
         Ok(())
     }
 
-    pub async fn persist_messages(&self, storage: Arc<dyn SegmentStorage>) -> Result<(), Error> {
+    pub async fn persist_messages(&self) -> Result<(), Error> {
         trace!("Saving buffered messages on disk...");
         for stream in self.streams.values() {
-            stream.persist_messages(storage.clone()).await?;
+            stream.persist_messages().await?;
         }
 
         Ok(())

--- a/server/src/streaming/topics/persistence.rs
+++ b/server/src/streaming/topics/persistence.rs
@@ -1,8 +1,6 @@
-use crate::streaming::storage::SegmentStorage;
 use crate::streaming::topics::consumer_group::ConsumerGroup;
 use crate::streaming::topics::topic::Topic;
 use iggy::error::Error;
-use std::sync::Arc;
 use tokio::sync::RwLock;
 
 impl Topic {
@@ -41,11 +39,11 @@ impl Topic {
         self.storage.topic.delete(self).await
     }
 
-    pub async fn persist_messages(&self, storage: Arc<dyn SegmentStorage>) -> Result<(), Error> {
+    pub async fn persist_messages(&self) -> Result<(), Error> {
         for partition in self.get_partitions() {
             let mut partition = partition.write().await;
             for segment in partition.get_segments_mut() {
-                segment.persist_messages(storage.clone()).await?;
+                segment.persist_messages().await?;
             }
         }
 


### PR DESCRIPTION
The parameter in `persist_messages` method, which seemed redundant, so I removed it.