### PR TITLE
Assign CODEOWNERS for .github directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+.github/** @iggy-rs/maintainers


### PR DESCRIPTION
So that workflow approval is required when this
directory is changed by person that isn't maintainer.
