### PR TITLE
Refactor QUIC stream handling

### DIFF
--- a/iggy/src/messages/mod.rs
+++ b/iggy/src/messages/mod.rs
@@ -2,4 +2,4 @@ pub mod poll_messages;
 pub mod send_messages;
 
 const MAX_HEADERS_SIZE: u32 = 100 * 1000;
-const MAX_PAYLOAD_SIZE: u32 = 10 * 1000 * 1000;
+pub const MAX_PAYLOAD_SIZE: u32 = 10 * 1000 * 1000;

--- a/server/src/binary/command.rs
+++ b/server/src/binary/command.rs
@@ -30,16 +30,16 @@ pub async fn handle(
     session: &mut Session,
     system: SharedSystem,
 ) -> Result<(), Error> {
-    let result = try_handle(command, sender, session, &system).await;
-    if result.is_ok() {
-        debug!("Command was handled successfully, session: {session}.",);
-        return Ok(());
+    match try_handle(command, sender, session, &system).await {
+        Ok(_) => {
+            debug!("Command was handled successfully, session: {session}.");
+            Ok(())
+        }
+        Err(error) => {
+            error!("Command was not handled successfully, session: {session}, error: {error}");
+            sender.send_error_response(error).await
+        }
     }
-
-    let error = result.err().unwrap();
-    error!("Command was not handled successfully, session: {session}, error: {error}",);
-    sender.send_error_response(error).await?;
-    Ok(())
 }
 
 async fn try_handle(

--- a/server/src/quic/listener.rs
+++ b/server/src/quic/listener.rs
@@ -1,12 +1,15 @@
+use std::net::SocketAddr;
+
 use crate::binary::command;
 use crate::quic::quic_sender::QuicSender;
 use crate::server_error::ServerError;
 use crate::streaming::clients::client_manager::Transport;
 use crate::streaming::session::Session;
 use crate::streaming::systems::system::SharedSystem;
-use iggy::bytes_serializable::BytesSerializable;
+use anyhow::{anyhow, Context};
 use iggy::command::Command;
-use quinn::Endpoint;
+use iggy::{bytes_serializable::BytesSerializable, messages::MAX_PAYLOAD_SIZE};
+use quinn::{Connection, Endpoint, RecvStream, SendStream};
 use tracing::{debug, error, info};
 
 const LISTENERS_COUNT: u32 = 10;
@@ -39,75 +42,71 @@ async fn handle_connection(
 ) -> Result<(), ServerError> {
     let connection = incoming_connection.await?;
     let address = connection.remote_address();
-    async {
-        info!("Client has connected: {address}");
-        let client_id = system
-            .read()
-            .add_client(&address, Transport::Quic)
-            .await;
-        let mut session = Session::from_client_id(client_id, address);
-        loop {
-            let stream = connection.accept_bi().await;
-            let mut stream = match stream {
-                Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
-                    info!("Connection closed");
-                    system.read().delete_client(&address).await;
-                    return Ok(());
-                }
-                Err(error) => {
-                    error!("Error when handling QUIC stream: {:?}", error);
-                    system.read().delete_client(&address).await;
-                    return Err(error);
-                }
-                Ok(stream) => stream,
-            };
+    info!("Client has connected: {address}");
+    let client_id = system.read().add_client(&address, Transport::Quic).await;
+    let mut session = Session::from_client_id(client_id, address);
 
-            let request = stream.1.read_to_end(10 * 1000 * 1000).await;
-            if request.is_err() {
-                error!("Error when reading the QUIC request: {:?}", request.err());
-                continue;
-            }
-
-            let request = request.unwrap();
-            if request.len() < INITIAL_BYTES_LENGTH {
-                error!(
-                "Unable to read the QUIC request length, expected: {INITIAL_BYTES_LENGTH} bytes, received: {} bytes.",
-                request.len()
-            );
-                continue;
-            }
-
-            debug!("Trying to read command...");
-            let length = &request[..INITIAL_BYTES_LENGTH];
-            let length = u32::from_le_bytes(length.try_into().unwrap_or([0; 4]));
-            let command = Command::from_bytes(&request[INITIAL_BYTES_LENGTH..]);
-            if command.is_err() {
-                error!(
-                    "Error when reading the QUIC request command: {:?}",
-                    command.err()
-                );
-                continue;
-            }
-
-            let command = command.unwrap();
-            debug!("Received a QUIC command: {command}, payload size: {length}");
-
-            let result = command::handle(
-                &command,
-                &mut QuicSender {
-                    send: stream.0,
-                    recv: stream.1,
-                },
-                &mut session,
-                system.clone(),
-            )
-            .await;
-            if result.is_err() {
-                error!("Error when handling the QUIC request: {:?}", result.err());
-                continue;
-            }
+    while let Some(stream) = accept_stream(&connection, &system, &address).await? {
+        if let Err(err) = handle_stream(stream, &system, &mut session).await {
+            error!("Error when handling QUIC stream: {:?}", err)
         }
     }
-    .await?;
     Ok(())
+}
+
+type BiStream = (SendStream, RecvStream);
+
+async fn accept_stream(
+    connection: &Connection,
+    system: &SharedSystem,
+    address: &SocketAddr,
+) -> Result<Option<BiStream>, ServerError> {
+    match connection.accept_bi().await {
+        Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
+            info!("Connection closed");
+            system.read().delete_client(address).await;
+            Ok(None)
+        }
+        Err(error) => {
+            error!("Error when handling QUIC stream: {:?}", error);
+            system.read().delete_client(address).await;
+            Err(error.into())
+        }
+        Ok(stream) => Ok(Some(stream)),
+    }
+}
+
+async fn handle_stream(
+    stream: BiStream,
+    system: &SharedSystem,
+    session: &mut Session,
+) -> anyhow::Result<()> {
+    let (send_stream, mut recv_stream) = stream;
+    let request = recv_stream
+        .read_to_end(MAX_PAYLOAD_SIZE as usize)
+        .await
+        .with_context(|| "Error when reading the QUIC request.")?;
+
+    if request.len() < INITIAL_BYTES_LENGTH {
+        return Err(anyhow!(
+            "Unable to read the QUIC request length, expected: {INITIAL_BYTES_LENGTH} bytes, received: {} bytes.",
+            request.len()
+        ));
+    }
+
+    debug!("Trying to read command...");
+    let length = &request[..INITIAL_BYTES_LENGTH];
+    let length = u32::from_le_bytes(length.try_into().unwrap_or([0; 4]));
+    let command = Command::from_bytes(&request[INITIAL_BYTES_LENGTH..])
+        .with_context(|| "Error when reading the QUIC request command.")?;
+
+    debug!("Received a QUIC command: {command}, payload size: {length}");
+
+    let mut sender = QuicSender {
+        send: send_stream,
+        recv: recv_stream,
+    };
+    command::handle(&command, &mut sender, session, system.clone())
+        .await
+        .with_context(|| "Error when handling the QUIC request.")
 }


### PR DESCRIPTION
I found that some of the code in `QUIC server` was not rusty enough, so I refactored it to make it more readable.

I'm using anyhow in some places for now, it's not the final solution. But if a more standard error handling is needed it may require a refactoring of the current Errors, maybe we can improve it later.😊