### PR TITLE
Fix testing examples on MacOS

### DIFF
--- a/integration/src/test_server.rs
+++ b/integration/src/test_server.rs
@@ -28,9 +28,15 @@ use uuid::Uuid;
 pub const SYSTEM_PATH_ENV_VAR: &str = "IGGY_SYSTEM_PATH";
 pub const TEST_VERBOSITY_ENV_VAR: &str = "IGGY_TEST_VERBOSE";
 const USER_PASSWORD: &str = "secret";
-const MAX_PORT_WAIT_DURATION_S: u64 = 120;
 const SLEEP_INTERVAL_MS: u64 = 20;
 const LOCAL_DATA_PREFIX: &str = "local_data_";
+
+// When running action from github CI, binary needs to be started via QEMU.
+// This is why we sometimes have to wait for longer time for server to bind to ports.
+#[cfg(env = "IGGY_CI_BUILD")]
+const MAX_PORT_WAIT_DURATION_S: u64 = 120;
+#[cfg(not(env = "IGGY_CI_BUILD"))]
+const MAX_PORT_WAIT_DURATION_S: u64 = 5;
 
 pub enum IpAddrKind {
     V4,

--- a/integration/tests/examples/test_basic.rs
+++ b/integration/tests/examples/test_basic.rs
@@ -35,7 +35,7 @@ impl<'a> IggyExampleTestCase for TestBasic<'a> {
 #[tokio::test]
 #[parallel]
 async fn should_successfully_execute() {
-    let mut iggy_example_test = IggyExampleTest::new("basic", None);
+    let mut iggy_example_test = IggyExampleTest::new("basic");
     iggy_example_test.setup(false).await;
 
     iggy_example_test

--- a/integration/tests/examples/test_getting_started.rs
+++ b/integration/tests/examples/test_getting_started.rs
@@ -1,19 +1,14 @@
 use super::verify_stdout_contains_expected_logs;
 use crate::examples::{IggyExampleTest, IggyExampleTestCase};
-use serial_test::serial;
+use serial_test::parallel;
 
-static EXPECTED_CONSUMER_OUTPUT: [&str; 11] = [
+static EXPECTED_CONSUMER_OUTPUT: [&str; 6] = [
     "Messages will be consumed from stream: 1, topic: 1, partition: 1 with interval 500 ms.",
     "Handling message at offset: 0, payload: message-1...",
     "Handling message at offset: 1, payload: message-2...",
     "Handling message at offset: 2, payload: message-3...",
     "Handling message at offset: 3, payload: message-4...",
     "Handling message at offset: 4, payload: message-5...",
-    "Handling message at offset: 5, payload: message-6...",
-    "Handling message at offset: 6, payload: message-7...",
-    "Handling message at offset: 7, payload: message-8...",
-    "Handling message at offset: 8, payload: message-9...",
-    "Handling message at offset: 9, payload: message-10...",
 ];
 
 struct TestGettingStarted<'a> {
@@ -35,9 +30,9 @@ impl<'a> IggyExampleTestCase for TestGettingStarted<'a> {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 async fn should_succeed_with_no_existing_stream_or_topic() {
-    let mut iggy_example_test = IggyExampleTest::default();
+    let mut iggy_example_test = IggyExampleTest::new("getting-started");
     iggy_example_test.setup(false).await;
 
     iggy_example_test
@@ -54,9 +49,9 @@ async fn should_succeed_with_no_existing_stream_or_topic() {
 }
 
 #[tokio::test]
-#[serial]
+#[parallel]
 async fn should_succeed_with_preexisting_stream_and_topic() {
-    let mut iggy_example_test = IggyExampleTest::default();
+    let mut iggy_example_test = IggyExampleTest::new("getting-started");
     iggy_example_test.setup(true).await;
 
     iggy_example_test

--- a/integration/tests/examples/test_message_envelope.rs
+++ b/integration/tests/examples/test_message_envelope.rs
@@ -33,7 +33,7 @@ impl<'a> IggyExampleTestCase for TestMessageEnvelope<'a> {
 #[tokio::test]
 #[parallel]
 async fn should_successfully_execute() {
-    let mut iggy_example_test = IggyExampleTest::new("message-envelope", None);
+    let mut iggy_example_test = IggyExampleTest::new("message-envelope");
     iggy_example_test.setup(false).await;
 
     iggy_example_test

--- a/integration/tests/examples/test_message_headers.rs
+++ b/integration/tests/examples/test_message_headers.rs
@@ -34,7 +34,7 @@ impl<'a> IggyExampleTestCase for TestMessageMeaders<'a> {
 #[tokio::test]
 #[parallel]
 async fn should_successfully_execute() {
-    let mut iggy_example_test = IggyExampleTest::new("message-headers", None);
+    let mut iggy_example_test = IggyExampleTest::new("message-headers");
     iggy_example_test.setup(false).await;
 
     iggy_example_test


### PR DESCRIPTION
There was problem on MacOS in which examples output was collected too quickly. This commit changes behavior of testcase so that is checks the output of consumer/producer after the executable is finished.

Besides that, this commit refactors the TCP client creation process in the getting-started examples for both consumer and producer. It introduces the ability to specify the server address via command-line arguments.

Additionally, it adjusts the BATCHES_LIMIT constant and adds a new function to retrieve the TCP server address. The integration tests have been updated to reflect these changes, and the MAX_PORT_WAIT_ DURATION_S constant has been conditionally set based on the build environment.

Besides that, now all tests (-1) are working in parallel 🦀 