### PR TITLE
Supports concurrent handling of quic streams

### DIFF
--- a/iggy/src/models/user_info.rs
+++ b/iggy/src/models/user_info.rs
@@ -1,9 +1,13 @@
 use crate::models::permissions::Permissions;
 use crate::models::user_status::UserStatus;
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::AtomicU32;
 
 /// `UserId` represents the unique identifier (numeric) of the user.
 pub type UserId = u32;
+/// `AtomicUserId` represents the unique identifier (numeric) of the user
+/// which can be safely modified concurrently across threads
+pub type AtomicUserId = AtomicU32;
 
 /// `UserInfo` represents the basic information about the user.
 /// It consists of the following fields:

--- a/server/src/binary/command.rs
+++ b/server/src/binary/command.rs
@@ -27,7 +27,7 @@ use tracing::{debug, error};
 pub async fn handle(
     command: &Command,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: SharedSystem,
 ) -> Result<(), Error> {
     match try_handle(command, sender, session, &system).await {
@@ -45,7 +45,7 @@ pub async fn handle(
 async fn try_handle(
     command: &Command,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("Handling command '{command}', session: {session}...");

--- a/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 pub async fn handle(
     command: &CreatePersonalAccessToken,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &DeletePersonalAccessToken,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 pub async fn handle(
     command: &LoginWithPersonalAccessToken,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/change_password_handler.rs
+++ b/server/src/binary/handlers/users/change_password_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &ChangePassword,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/create_user_handler.rs
+++ b/server/src/binary/handlers/users/create_user_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &CreateUser,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/delete_user_handler.rs
+++ b/server/src/binary/handlers/users/delete_user_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &DeleteUser,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/login_user_handler.rs
+++ b/server/src/binary/handlers/users/login_user_handler.rs
@@ -10,7 +10,7 @@ use tracing::debug;
 pub async fn handle(
     command: &LoginUser,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/logout_user_handler.rs
+++ b/server/src/binary/handlers/users/logout_user_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &LogoutUser,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/update_permissions_handler.rs
+++ b/server/src/binary/handlers/users/update_permissions_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &UpdatePermissions,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/binary/handlers/users/update_user_handler.rs
+++ b/server/src/binary/handlers/users/update_user_handler.rs
@@ -9,7 +9,7 @@ use tracing::debug;
 pub async fn handle(
     command: &UpdateUser,
     sender: &mut dyn Sender,
-    session: &mut Session,
+    session: &Session,
     system: &SharedSystem,
 ) -> Result<(), Error> {
     debug!("session: {session}, command: {command}");

--- a/server/src/quic/listener.rs
+++ b/server/src/quic/listener.rs
@@ -44,10 +44,10 @@ async fn handle_connection(
     let address = connection.remote_address();
     info!("Client has connected: {address}");
     let client_id = system.read().add_client(&address, Transport::Quic).await;
-    let mut session = Session::from_client_id(client_id, address);
+    let session = Session::from_client_id(client_id, address);
 
     while let Some(stream) = accept_stream(&connection, &system, &address).await? {
-        if let Err(err) = handle_stream(stream, &system, &mut session).await {
+        if let Err(err) = handle_stream(stream, &system, &session).await {
             error!("Error when handling QUIC stream: {:?}", err)
         }
     }
@@ -79,7 +79,7 @@ async fn accept_stream(
 async fn handle_stream(
     stream: BiStream,
     system: &SharedSystem,
-    session: &mut Session,
+    session: &Session,
 ) -> anyhow::Result<()> {
     let (send_stream, mut recv_stream) = stream;
     let request = recv_stream

--- a/server/src/streaming/session.rs
+++ b/server/src/streaming/session.rs
@@ -1,11 +1,12 @@
-use iggy::models::user_info::UserId;
+use iggy::models::user_info::{AtomicUserId, UserId};
 use std::fmt::Display;
 use std::net::SocketAddr;
+use std::sync::atomic::Ordering;
 
 // This might be extended with more fields in the future e.g. custom name, permissions etc.
 #[derive(Debug)]
 pub struct Session {
-    pub user_id: UserId,
+    user_id: AtomicUserId,
     pub client_id: u32,
     pub ip_address: SocketAddr,
 }
@@ -14,7 +15,7 @@ impl Session {
     pub fn new(client_id: u32, user_id: UserId, ip_address: SocketAddr) -> Self {
         Self {
             client_id,
-            user_id,
+            user_id: AtomicUserId::new(user_id),
             ip_address,
         }
     }
@@ -27,26 +28,31 @@ impl Session {
         Self::new(client_id, 0, ip_address)
     }
 
-    pub fn set_user_id(&mut self, user_id: UserId) {
-        self.user_id = user_id;
+    pub fn get_user_id(&self) -> UserId {
+        self.user_id.load(Ordering::Acquire)
     }
 
-    pub fn clear_user_id(&mut self) {
-        self.user_id = 0;
+    pub fn set_user_id(&self, user_id: UserId) {
+        self.user_id.store(user_id, Ordering::Release)
+    }
+
+    pub fn clear_user_id(&self) {
+        self.set_user_id(0)
     }
 
     pub fn is_authenticated(&self) -> bool {
-        self.user_id > 0
+        self.get_user_id() > 0
     }
 }
 
 impl Display for Session {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.user_id > 0 {
+        let user_id = self.get_user_id();
+        if user_id > 0 {
             return write!(
                 f,
                 "client ID: {}, user ID: {}, IP address: {}",
-                self.client_id, self.user_id, self.ip_address
+                self.client_id, user_id, self.ip_address
             );
         }
 

--- a/server/src/streaming/systems/clients.rs
+++ b/server/src/streaming/systems/clients.rs
@@ -80,14 +80,14 @@ impl System {
         client_id: u32,
     ) -> Result<Arc<RwLock<Client>>, Error> {
         self.ensure_authenticated(session)?;
-        self.permissioner.get_client(session.user_id)?;
+        self.permissioner.get_client(session.get_user_id())?;
         let client_manager = self.client_manager.read().await;
         client_manager.get_client_by_id(client_id)
     }
 
     pub async fn get_clients(&self, session: &Session) -> Result<Vec<Arc<RwLock<Client>>>, Error> {
         self.ensure_authenticated(session)?;
-        self.permissioner.get_clients(session.user_id)?;
+        self.permissioner.get_clients(session.get_user_id())?;
         let client_manager = self.client_manager.read().await;
         Ok(client_manager.get_clients())
     }

--- a/server/src/streaming/systems/consumer_groups.rs
+++ b/server/src/streaming/systems/consumer_groups.rs
@@ -16,8 +16,11 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
-        self.permissioner
-            .get_consumer_group(session.user_id, stream.stream_id, topic.topic_id)?;
+        self.permissioner.get_consumer_group(
+            session.get_user_id(),
+            stream.stream_id,
+            topic.topic_id,
+        )?;
 
         topic.get_consumer_group(consumer_group_id)
     }
@@ -31,8 +34,11 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
-        self.permissioner
-            .get_consumer_groups(session.user_id, stream.stream_id, topic.topic_id)?;
+        self.permissioner.get_consumer_groups(
+            session.get_user_id(),
+            stream.stream_id,
+            topic.topic_id,
+        )?;
 
         Ok(topic.get_consumer_groups())
     }
@@ -50,7 +56,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.create_consumer_group(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;
@@ -75,7 +81,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.delete_consumer_group(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;
@@ -121,7 +127,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.join_consumer_group(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;
@@ -164,7 +170,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.leave_consumer_group(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;

--- a/server/src/streaming/systems/consumer_offsets.rs
+++ b/server/src/streaming/systems/consumer_offsets.rs
@@ -18,7 +18,7 @@ impl System {
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
         self.permissioner.store_consumer_offset(
-            session.user_id,
+            session.get_user_id(),
             stream.stream_id,
             topic.topic_id,
         )?;
@@ -36,8 +36,11 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
-        self.permissioner
-            .get_consumer_offset(session.user_id, stream.stream_id, topic.topic_id)?;
+        self.permissioner.get_consumer_offset(
+            session.get_user_id(),
+            stream.stream_id,
+            topic.topic_id,
+        )?;
 
         topic.get_consumer_offset(consumer).await
     }

--- a/server/src/streaming/systems/messages.rs
+++ b/server/src/streaming/systems/messages.rs
@@ -30,7 +30,7 @@ impl System {
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
         self.permissioner
-            .poll_messages(session.user_id, stream.stream_id, topic.topic_id)?;
+            .poll_messages(session.get_user_id(), stream.stream_id, topic.topic_id)?;
 
         if !topic.has_partitions() {
             return Err(Error::NoPartitions(topic.topic_id, topic.stream_id));
@@ -105,8 +105,11 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
-        self.permissioner
-            .append_messages(session.user_id, stream.stream_id, topic.topic_id)?;
+        self.permissioner.append_messages(
+            session.get_user_id(),
+            stream.stream_id,
+            topic.topic_id,
+        )?;
 
         let mut received_messages = Vec::with_capacity(messages.len());
         let mut batch_size_bytes = 0u64;

--- a/server/src/streaming/systems/partitions.rs
+++ b/server/src/streaming/systems/partitions.rs
@@ -16,7 +16,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.create_partitons(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;
@@ -42,7 +42,7 @@ impl System {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
             self.permissioner.delete_partitions(
-                session.user_id,
+                session.get_user_id(),
                 stream.stream_id,
                 topic.topic_id,
             )?;

--- a/server/src/streaming/systems/personal_access_tokens.rs
+++ b/server/src/streaming/systems/personal_access_tokens.rs
@@ -13,7 +13,7 @@ impl System {
         session: &Session,
     ) -> Result<Vec<PersonalAccessToken>, Error> {
         self.ensure_authenticated(session)?;
-        let user_id = session.user_id;
+        let user_id = session.get_user_id();
         info!("Loading personal access tokens for user with ID: {user_id}...",);
         let personal_access_tokens = self
             .storage
@@ -34,7 +34,7 @@ impl System {
         expiry: Option<u32>,
     ) -> Result<String, Error> {
         self.ensure_authenticated(session)?;
-        let user_id = session.user_id;
+        let user_id = session.get_user_id();
         let max_token_per_user = self.personal_access_token.max_tokens_per_user;
         let name = text::to_lowercase_non_whitespace(name);
         let personal_access_tokens = self
@@ -78,7 +78,7 @@ impl System {
         name: &str,
     ) -> Result<(), Error> {
         self.ensure_authenticated(session)?;
-        let user_id = session.user_id;
+        let user_id = session.get_user_id();
         let name = text::to_lowercase_non_whitespace(name);
         info!("Deleting personal access token: {name} for user with ID: {user_id}...");
         self.storage
@@ -92,7 +92,7 @@ impl System {
     pub async fn login_with_personal_access_token(
         &self,
         token: &str,
-        session: Option<&mut Session>,
+        session: Option<&Session>,
     ) -> Result<User, Error> {
         let token_hash = PersonalAccessToken::hash_token(token);
         let personal_access_token = self

--- a/server/src/streaming/systems/stats.rs
+++ b/server/src/streaming/systems/stats.rs
@@ -8,7 +8,7 @@ const PROCESS_NAME: &str = "iggy-server";
 impl System {
     pub async fn get_stats(&self, session: &Session) -> Result<Stats, Error> {
         self.ensure_authenticated(session)?;
-        self.permissioner.get_stats(session.user_id)?;
+        self.permissioner.get_stats(session.get_user_id())?;
         let mut sys = sysinfo::System::new_all();
         sys.refresh_all();
 

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -90,7 +90,7 @@ impl System {
 
     pub fn find_streams(&self, session: &Session) -> Result<Vec<&Stream>, Error> {
         self.ensure_authenticated(session)?;
-        self.permissioner.get_streams(session.user_id)?;
+        self.permissioner.get_streams(session.get_user_id())?;
         Ok(self.get_streams())
     }
 
@@ -102,7 +102,7 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(identifier)?;
         self.permissioner
-            .get_stream(session.user_id, stream.stream_id)?;
+            .get_stream(session.get_user_id(), stream.stream_id)?;
         Ok(stream)
     }
 
@@ -168,7 +168,7 @@ impl System {
         name: &str,
     ) -> Result<(), Error> {
         self.ensure_authenticated(session)?;
-        self.permissioner.create_stream(session.user_id)?;
+        self.permissioner.create_stream(session.get_user_id())?;
         if self.streams.contains_key(&stream_id) {
             return Err(Error::StreamIdAlreadyExists(stream_id));
         }
@@ -201,7 +201,7 @@ impl System {
         }
 
         self.permissioner
-            .update_stream(session.user_id, stream_id)?;
+            .update_stream(session.get_user_id(), stream_id)?;
         let updated_name = text::to_lowercase_non_whitespace(name);
 
         {
@@ -241,7 +241,7 @@ impl System {
         let stream = self.get_stream(id)?;
         let stream_id = stream.stream_id;
         self.permissioner
-            .delete_stream(session.user_id, stream_id)?;
+            .delete_stream(session.get_user_id(), stream_id)?;
         let stream_name = stream.name.clone();
         if stream.delete().await.is_err() {
             return Err(Error::CannotDeleteStream(stream_id));
@@ -272,7 +272,7 @@ impl System {
     ) -> Result<(), Error> {
         let stream = self.get_stream(stream_id)?;
         self.permissioner
-            .purge_stream(session.user_id, stream.stream_id)?;
+            .purge_stream(session.get_user_id(), stream.stream_id)?;
         stream.purge().await
     }
 }

--- a/server/src/streaming/systems/topics.rs
+++ b/server/src/streaming/systems/topics.rs
@@ -15,7 +15,7 @@ impl System {
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
         self.permissioner
-            .get_topic(session.user_id, stream.stream_id, topic.topic_id)?;
+            .get_topic(session.get_user_id(), stream.stream_id, topic.topic_id)?;
         Ok(topic)
     }
 
@@ -27,7 +27,7 @@ impl System {
         self.ensure_authenticated(session)?;
         let stream = self.get_stream(stream_id)?;
         self.permissioner
-            .get_topics(session.user_id, stream.stream_id)?;
+            .get_topics(session.get_user_id(), stream.stream_id)?;
         Ok(stream.get_topics())
     }
 
@@ -44,7 +44,7 @@ impl System {
         {
             let stream = self.get_stream(stream_id)?;
             self.permissioner
-                .create_topic(session.user_id, stream.stream_id)?;
+                .create_topic(session.get_user_id(), stream.stream_id)?;
         }
 
         self.get_stream_mut(stream_id)?
@@ -68,8 +68,11 @@ impl System {
         {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
-            self.permissioner
-                .update_topic(session.user_id, stream.stream_id, topic.topic_id)?;
+            self.permissioner.update_topic(
+                session.get_user_id(),
+                stream.stream_id,
+                topic.topic_id,
+            )?;
         }
 
         self.get_stream_mut(stream_id)?
@@ -89,8 +92,11 @@ impl System {
         {
             let stream = self.get_stream(stream_id)?;
             let topic = stream.get_topic(topic_id)?;
-            self.permissioner
-                .delete_topic(session.user_id, stream.stream_id, topic.topic_id)?;
+            self.permissioner.delete_topic(
+                session.get_user_id(),
+                stream.stream_id,
+                topic.topic_id,
+            )?;
             stream_id_value = stream.stream_id;
         }
 
@@ -121,7 +127,7 @@ impl System {
         let stream = self.get_stream(stream_id)?;
         let topic = stream.get_topic(topic_id)?;
         self.permissioner
-            .purge_topic(session.user_id, stream.stream_id, topic.topic_id)?;
+            .purge_topic(session.get_user_id(), stream.stream_id, topic.topic_id)?;
         topic.purge().await
     }
 }

--- a/server/src/tcp/connection_handler.rs
+++ b/server/src/tcp/connection_handler.rs
@@ -19,7 +19,7 @@ pub(crate) async fn handle_connection(
 ) -> Result<(), ServerError> {
     let client_id = system.read().add_client(&address, Transport::Tcp).await;
 
-    let mut session = Session::from_client_id(client_id, address);
+    let session = Session::from_client_id(client_id, address);
     let mut initial_buffer = [0u8; INITIAL_BYTES_LENGTH];
     loop {
         let read_length = sender.read(&mut initial_buffer).await?;
@@ -36,7 +36,7 @@ pub(crate) async fn handle_connection(
         sender.read(&mut command_buffer).await?;
         let command = Command::from_bytes(&command_buffer)?;
         debug!("Received a TCP command: {command}, payload size: {length}");
-        let result = command::handle(&command, sender, &mut session, system.clone()).await;
+        let result = command::handle(&command, sender, &session, system.clone()).await;
         if result.is_err() {
             error!("Error when handling the TCP request: {:?}", result.err());
             continue;


### PR DESCRIPTION
Currently, the quic server handles `streams` serially per `connection`. It seems that a change to parallel processing of `streams` is necessary, as clients can afford to send streams concurrently using a single `quic connection`.