### PR TITLE
Use atomics to track message sizes and counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,6 +1981,8 @@ dependencies = [
  "sled",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "xxhash-rust",
 ]

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -24,10 +24,12 @@ server = { path = "../server" }
 sled = "0.34.7"
 tokio = { version = "1.28.2", features = ["full"] }
 toml = "0.8.8"
+tracing = "0.1"
+tracing-subscriber = "0.3.18"
 uuid = { version = "1.7.0", features = ["v4", "fast-rng", "zerocopy"] }
 xxhash-rust = { version = "0.8.8", features = ["xxh32"] }
 
 # Some tests are failing in CI due to lack of IPv6 interfaces
-# inside the docker container. This is a temporary workaround (hopefully).
+# inside the docker containers. This is a temporary workaround (hopefully).
 [features]
 ci-qemu = []

--- a/integration/tests/server/http_server.rs
+++ b/integration/tests/server/http_server.rs
@@ -1,4 +1,6 @@
-use crate::server::scenarios::{message_headers_scenario, system_scenario, user_scenario};
+use crate::server::scenarios::{
+    message_headers_scenario, stream_size_validation_scenario, system_scenario, user_scenario,
+};
 use integration::{http_client::HttpClientFactory, test_server::TestServer};
 use serial_test::parallel;
 
@@ -30,4 +32,14 @@ async fn message_headers_scenario_should_be_valid() {
     let server_addr = test_server.get_http_api_addr().unwrap();
     let client_factory = HttpClientFactory { server_addr };
     message_headers_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn stream_size_validation_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_http_api_addr().unwrap();
+    let client_factory = HttpClientFactory { server_addr };
+    stream_size_validation_scenario::run(&client_factory).await;
 }

--- a/integration/tests/server/quic_server.rs
+++ b/integration/tests/server/quic_server.rs
@@ -1,7 +1,7 @@
 use crate::server::scenarios::{
     consumer_group_join_scenario, consumer_group_with_multiple_clients_polling_messages_scenario,
     consumer_group_with_single_client_polling_messages_scenario, message_headers_scenario,
-    system_scenario, user_scenario,
+    stream_size_validation_scenario, system_scenario, user_scenario,
 };
 use integration::{quic_client::QuicClientFactory, test_server::TestServer};
 use serial_test::parallel;
@@ -64,4 +64,14 @@ async fn consumer_group_with_multiple_clients_polling_messages_scenario_should_b
     let server_addr = test_server.get_quic_udp_addr().unwrap();
     let client_factory = QuicClientFactory { server_addr };
     consumer_group_with_multiple_clients_polling_messages_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn stream_size_validation_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_quic_udp_addr().unwrap();
+    let client_factory = QuicClientFactory { server_addr };
+    stream_size_validation_scenario::run(&client_factory).await;
 }

--- a/integration/tests/server/scenarios/mod.rs
+++ b/integration/tests/server/scenarios/mod.rs
@@ -2,5 +2,6 @@ pub mod consumer_group_join_scenario;
 pub mod consumer_group_with_multiple_clients_polling_messages_scenario;
 pub mod consumer_group_with_single_client_polling_messages_scenario;
 pub mod message_headers_scenario;
+pub mod stream_size_validation_scenario;
 pub mod system_scenario;
 pub mod user_scenario;

--- a/integration/tests/server/scenarios/stream_size_validation_scenario.rs
+++ b/integration/tests/server/scenarios/stream_size_validation_scenario.rs
@@ -1,0 +1,293 @@
+use bytes::Bytes;
+use iggy::client::{MessageClient, StreamClient, SystemClient, TopicClient, UserClient};
+use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::identifier::Identifier;
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::streams::get_stream::GetStream;
+use iggy::streams::get_streams::GetStreams;
+use iggy::streams::purge_stream::PurgeStream;
+use iggy::system::ping::Ping;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::topics::get_topic::GetTopic;
+use iggy::topics::purge_topic::PurgeTopic;
+use iggy::users::defaults::*;
+use iggy::users::login_user::LoginUser;
+use integration::test_server::{assert_clean_system, ClientFactory};
+use std::str::FromStr;
+
+const PARTITIONS_COUNT: u32 = 3;
+const S1_NAME: &str = "test-stream-1";
+const T1_NAME: &str = "test-topic-1";
+const S2_NAME: &str = "test-stream-2";
+const T2_NAME: &str = "test-topic-2";
+const PARTITION_ID: u32 = 1;
+const MESSAGE_PAYLOAD_SIZE_BYTES: u64 = 57;
+const MSG_SIZE: u64 = 8 + 1 + 8 + 16 + 4 + 4 + 4 + MESSAGE_PAYLOAD_SIZE_BYTES; // number of bytes in a single message
+const MSGS_COUNT: u64 = 117; // number of messages in a single topic after one pass of appending
+const MSGS_SIZE: u64 = MSG_SIZE * MSGS_COUNT; // number of bytes in a single topic after one pass of appending
+
+pub async fn run(client_factory: &dyn ClientFactory) {
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let client = client_factory.create_client().await;
+    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+
+    // 0. Ping server, login as root user and ensure that streams do not exist
+    ping_login_and_validate(&client).await;
+
+    // 1. Create first stream
+    create_stream_assert_empty(&client, S1_NAME).await;
+
+    // 2. Create second stream
+    create_stream_assert_empty(&client, S2_NAME).await;
+
+    // 3. Create first topic on the first stream
+    create_topic_assert_empty(&client, S1_NAME, T1_NAME).await;
+
+    // 4. Do operations on the first topic, first stream and validate sizes
+    validate_operations_on_topic_twice(&client, S1_NAME, T1_NAME, PARTITION_ID).await;
+
+    // 5. Validate both streams, second stream should be empty
+    validate_stream(&client, S1_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+    validate_stream(&client, S2_NAME, 0, 0).await;
+
+    // 6. Create second topic on the first stream
+    create_topic_assert_empty(&client, S1_NAME, T2_NAME).await;
+
+    // 7. Do operations on the second topic, first stream and validate sizes
+    validate_operations_on_topic_twice(&client, S1_NAME, T2_NAME, PARTITION_ID).await;
+
+    // 8. Create first topic on the second stream
+    create_topic_assert_empty(&client, S2_NAME, T1_NAME).await;
+
+    // 9. Do operations on the first topic, second stream and validate sizes
+    validate_operations_on_topic_twice(&client, S2_NAME, T1_NAME, PARTITION_ID).await;
+
+    // 10. Create second topic on the second stream
+    create_topic_assert_empty(&client, S2_NAME, T2_NAME).await;
+
+    // 11. Do operations on the second topic, second stream and validate sizes
+    validate_operations_on_topic_twice(&client, S2_NAME, T2_NAME, PARTITION_ID).await;
+
+    // 12. Validate both streams, should have exactly same sizes and number of messages
+    validate_stream(&client, S1_NAME, MSGS_SIZE * 4, MSGS_COUNT * 4).await;
+    validate_stream(&client, S2_NAME, MSGS_SIZE * 4, MSGS_COUNT * 4).await;
+
+    // 13. Validate all topics, should have exactly same sizes and number of messages
+    validate_topic(&client, S1_NAME, T1_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+    validate_topic(&client, S1_NAME, T2_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+    validate_topic(&client, S2_NAME, T1_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+    validate_topic(&client, S2_NAME, T2_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+
+    // 14. Delete first topic on the first stream
+    delete_topic(&client, S1_NAME, T1_NAME).await;
+
+    // 15. Validate both streams, first should have it's message count and size should be reduced by 50%, second stream should be unchanged
+    validate_stream(&client, S1_NAME, MSGS_SIZE * 2, MSGS_COUNT * 2).await;
+    validate_stream(&client, S2_NAME, MSGS_SIZE * 4, MSGS_COUNT * 4).await;
+
+    // 16. Purge second topic on the first stream
+    purge_topic(&client, S1_NAME, T2_NAME).await;
+
+    // 17. Validate both streams, first should be empty, second should be unchanged
+    validate_stream(&client, S1_NAME, 0, 0).await;
+    validate_stream(&client, S2_NAME, MSGS_SIZE * 4, MSGS_COUNT * 4).await;
+
+    // 18. Delete first stream
+    delete_stream(&client, S1_NAME).await;
+
+    // 19. Validate second stream, should be unchanged
+    validate_stream(&client, S2_NAME, MSGS_SIZE * 4, MSGS_COUNT * 4).await;
+
+    // 20. Purge second stream
+    purge_stream(&client, S2_NAME).await;
+
+    // 21. Validate second stream and it's topics, should be empty
+    validate_stream(&client, S2_NAME, 0, 0).await;
+    validate_topic(&client, S2_NAME, T1_NAME, 0, 0).await;
+    validate_topic(&client, S2_NAME, T2_NAME, 0, 0).await;
+
+    // 22. Delete second stream
+    delete_stream(&client, S2_NAME).await;
+
+    // 23. Validate system, should be empty
+    assert_clean_system(&client).await;
+}
+
+async fn ping_login_and_validate(client: &IggyClient) {
+    // 1. Ping server
+    let ping = Ping {};
+    client.ping(&ping).await.unwrap();
+
+    // 2. Login as root user
+    client
+        .login_user(&LoginUser {
+            username: DEFAULT_ROOT_USERNAME.to_string(),
+            password: DEFAULT_ROOT_PASSWORD.to_string(),
+        })
+        .await
+        .unwrap();
+
+    // 3. Ensure that streams do not exist
+    let streams = client.get_streams(&GetStreams {}).await.unwrap();
+    assert!(streams.is_empty());
+}
+
+async fn create_topic_assert_empty(client: &IggyClient, stream_name: &str, topic_name: &str) {
+    // 1. Create topic
+    let create_topic = CreateTopic {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+        topic_id: None,
+        partitions_count: PARTITIONS_COUNT,
+        name: topic_name.to_string(),
+        message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
+    };
+    client.create_topic(&create_topic).await.unwrap();
+
+    // 2. Validate topic size and number of messages
+    validate_topic(client, stream_name, topic_name, 0, 0).await;
+}
+
+async fn create_stream_assert_empty(client: &IggyClient, stream_name: &str) {
+    // 1. Create stream
+    let create_stream = CreateStream {
+        stream_id: None,
+        name: stream_name.to_string(),
+    };
+    client.create_stream(&create_stream).await.unwrap();
+
+    // 2. Validate stream size and number of messages
+    validate_stream(client, stream_name, 0, 0).await;
+}
+
+async fn validate_operations_on_topic_twice(
+    client: &IggyClient,
+    stream_name: &str,
+    topic_name: &str,
+    partition_id: u32,
+) {
+    // 1. Append messages to the topic
+    let messages = create_messages();
+    let mut send_messages = SendMessages {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+        topic_id: Identifier::from_str(topic_name).unwrap(),
+        partitioning: Partitioning::partition_id(partition_id),
+        messages,
+    };
+    client.send_messages(&mut send_messages).await.unwrap();
+
+    // 2. Validate topic size and number of messages
+    validate_topic(client, stream_name, topic_name, MSGS_SIZE, MSGS_COUNT).await;
+
+    // 3. Again append same number of messages to the topic
+    let messages = create_messages();
+    let mut send_messages = SendMessages {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+        topic_id: Identifier::from_str(topic_name).unwrap(),
+        partitioning: Partitioning::partition_id(partition_id),
+        messages,
+    };
+    client.send_messages(&mut send_messages).await.unwrap();
+
+    // 4. Validate topic size and number of messages
+    validate_topic(
+        client,
+        stream_name,
+        topic_name,
+        MSGS_SIZE * 2,
+        MSGS_COUNT * 2,
+    )
+    .await;
+}
+
+async fn validate_stream(
+    client: &IggyClient,
+    stream_name: &str,
+    expected_size: u64,
+    expected_messages_count: u64,
+) {
+    // 1. Validate stream size and number of messages
+    let stream = client
+        .get_stream(&GetStream {
+            stream_id: Identifier::from_str(stream_name).unwrap(),
+        })
+        .await
+        .unwrap();
+
+    // 2. Validate stream size and number of messages
+    assert_eq!(stream.size_bytes, expected_size);
+    assert_eq!(stream.messages_count, expected_messages_count);
+}
+
+async fn validate_topic(
+    client: &IggyClient,
+    stream_name: &str,
+    topic_name: &str,
+    expected_size: u64,
+    expected_messages_count: u64,
+) {
+    // 1. Validate topic size and number of messages
+    let topic = client
+        .get_topic(&GetTopic {
+            stream_id: Identifier::from_str(stream_name).unwrap(),
+            topic_id: Identifier::from_str(topic_name).unwrap(),
+        })
+        .await
+        .unwrap();
+
+    // 2. Validate topic size and number of messages
+    assert_eq!(topic.size, expected_size);
+    assert_eq!(topic.messages_count, expected_messages_count);
+}
+
+async fn delete_topic(client: &IggyClient, stream_name: &str, topic_name: &str) {
+    let delete_topic = DeleteTopic {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+        topic_id: Identifier::from_str(topic_name).unwrap(),
+    };
+    client.delete_topic(&delete_topic).await.unwrap();
+}
+
+async fn purge_topic(client: &IggyClient, stream_name: &str, topic_name: &str) {
+    let purge_topic = PurgeTopic {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+        topic_id: Identifier::from_str(topic_name).unwrap(),
+    };
+    client.purge_topic(&purge_topic).await.unwrap();
+}
+
+async fn delete_stream(client: &IggyClient, stream_name: &str) {
+    let delete_stream = DeleteStream {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+    };
+    client.delete_stream(&delete_stream).await.unwrap();
+}
+
+async fn purge_stream(client: &IggyClient, stream_name: &str) {
+    let purge_stream = PurgeStream {
+        stream_id: Identifier::from_str(stream_name).unwrap(),
+    };
+    client.purge_stream(&purge_stream).await.unwrap();
+}
+
+fn create_messages() -> Vec<Message> {
+    let mut messages = Vec::new();
+    for offset in 0..MSGS_COUNT {
+        let id = (offset + 1) as u128;
+        let payload = Bytes::from(vec![0xD; MESSAGE_PAYLOAD_SIZE_BYTES as usize]);
+
+        let message = Message {
+            id,
+            length: payload.len() as u32,
+            payload,
+            headers: None,
+        };
+        messages.push(message);
+    }
+    messages
+}

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -291,7 +291,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     assert_eq!(topic.name, TOPIC_NAME);
     assert_eq!(topic.partitions_count, PARTITIONS_COUNT);
     assert_eq!(topic.partitions.len(), PARTITIONS_COUNT as usize);
-    assert!(topic.size > 0);
+    assert_eq!(topic.size, 55890);
     assert_eq!(topic.messages_count, MESSAGES_COUNT as u64);
     let topic_partition = topic.partitions.get((PARTITION_ID - 1) as usize).unwrap();
     assert_eq!(topic_partition.id, PARTITION_ID);

--- a/integration/tests/server/tcp_server.rs
+++ b/integration/tests/server/tcp_server.rs
@@ -1,7 +1,7 @@
 use crate::server::scenarios::{
     consumer_group_join_scenario, consumer_group_with_multiple_clients_polling_messages_scenario,
     consumer_group_with_single_client_polling_messages_scenario, message_headers_scenario,
-    system_scenario, user_scenario,
+    stream_size_validation_scenario, system_scenario, user_scenario,
 };
 use integration::{tcp_client::TcpClientFactory, test_server::TestServer};
 use serial_test::parallel;
@@ -64,4 +64,14 @@ async fn consumer_group_with_multiple_clients_polling_messages_scenario_should_b
     let server_addr = test_server.get_raw_tcp_addr().unwrap();
     let client_factory = TcpClientFactory { server_addr };
     consumer_group_with_multiple_clients_polling_messages_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn stream_size_validation_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
+    stream_size_validation_scenario::run(&client_factory).await;
 }

--- a/integration/tests/streaming/consumer_group.rs
+++ b/integration/tests/streaming/consumer_group.rs
@@ -1,6 +1,7 @@
 use crate::streaming::common::test_setup::TestSetup;
 use iggy::identifier::Identifier;
 use server::streaming::topics::topic::Topic;
+use std::sync::{atomic::AtomicU64, Arc};
 
 #[tokio::test]
 async fn should_persist_consumer_group_and_then_load_it_from_disk() {
@@ -71,6 +72,9 @@ async fn should_delete_consumer_group_from_disk() {
 
 async fn init_topic(setup: &TestSetup) -> Topic {
     let stream_id = 1;
+    let size_of_parent_stream = Arc::new(AtomicU64::new(0));
+    let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
+
     setup.create_topics_directory(stream_id).await;
     let name = "test";
     let topic = Topic::create(
@@ -80,6 +84,8 @@ async fn init_topic(setup: &TestSetup) -> Topic {
         1,
         setup.config.clone(),
         setup.storage.clone(),
+        size_of_parent_stream,
+        messages_count_of_parent_stream,
         None,
         None,
         1,

--- a/integration/tests/streaming/messages.rs
+++ b/integration/tests/streaming/messages.rs
@@ -7,6 +7,7 @@ use server::configs::system::{PartitionConfig, SystemConfig};
 use server::streaming::partitions::partition::Partition;
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -32,6 +33,10 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         config.clone(),
         setup.storage.clone(),
         None,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
 
     let mut messages = Vec::with_capacity(messages_count as usize);
@@ -91,6 +96,10 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         config.clone(),
         setup.storage.clone(),
         None,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
     loaded_partition.load().await.unwrap();
     let loaded_messages = loaded_partition

--- a/integration/tests/streaming/partition.rs
+++ b/integration/tests/streaming/partition.rs
@@ -2,6 +2,8 @@ use crate::streaming::common::test_setup::TestSetup;
 use crate::streaming::create_messages;
 use server::streaming::partitions::partition::Partition;
 use server::streaming::segments::segment::{INDEX_EXTENSION, LOG_EXTENSION, TIME_INDEX_EXTENSION};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 use tokio::fs;
 
 #[tokio::test]
@@ -21,6 +23,10 @@ async fn should_persist_partition_with_segment() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
 
         partition.persist().await.unwrap();
@@ -46,6 +52,10 @@ async fn should_load_existing_partition_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;
@@ -58,6 +68,10 @@ async fn should_load_existing_partition_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         loaded_partition.load().await.unwrap();
 
@@ -102,6 +116,10 @@ async fn should_delete_existing_partition_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;
@@ -129,6 +147,10 @@ async fn should_purge_existing_partition_on_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;

--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -4,6 +4,7 @@ use iggy::models::messages::{Message, MessageState};
 use iggy::utils::{checksum, timestamp::IggyTimestamp};
 use server::streaming::segments::segment;
 use server::streaming::segments::segment::{INDEX_EXTENSION, LOG_EXTENSION, TIME_INDEX_EXTENSION};
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use tokio::fs;
 
@@ -23,6 +24,12 @@ async fn should_persist_segment() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
 
         setup
@@ -55,6 +62,12 @@ async fn should_load_existing_segment_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         setup
             .create_partition_directory(stream_id, topic_id, partition_id)
@@ -76,6 +89,12 @@ async fn should_load_existing_segment_from_disk() {
             setup.config.clone(),
             setup.storage.clone(),
             None,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
         );
         loaded_segment.load().await.unwrap();
         let loaded_messages = loaded_segment.get_messages(0, 10).await.unwrap();
@@ -84,10 +103,7 @@ async fn should_load_existing_segment_from_disk() {
         assert_eq!(loaded_segment.start_offset, segment.start_offset);
         assert_eq!(loaded_segment.current_offset, segment.current_offset);
         assert_eq!(loaded_segment.end_offset, segment.end_offset);
-        assert_eq!(
-            loaded_segment.current_size_bytes,
-            segment.current_size_bytes
-        );
+        assert_eq!(loaded_segment.size_bytes, segment.size_bytes);
         assert_eq!(loaded_segment.is_closed, segment.is_closed);
         assert_eq!(loaded_segment.log_path, segment.log_path);
         assert_eq!(loaded_segment.index_path, segment.index_path);
@@ -111,6 +127,12 @@ async fn should_persist_and_load_segment_with_messages() {
         setup.config.clone(),
         setup.storage.clone(),
         None,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
 
     setup
@@ -140,6 +162,12 @@ async fn should_persist_and_load_segment_with_messages() {
         setup.config.clone(),
         setup.storage.clone(),
         None,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
     loaded_segment.load().await.unwrap();
     let messages = loaded_segment
@@ -165,6 +193,12 @@ async fn given_all_expired_messages_segment_should_be_expired() {
         setup.config.clone(),
         setup.storage.clone(),
         Some(message_expiry),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
 
     setup
@@ -210,6 +244,12 @@ async fn given_at_least_one_not_expired_message_segment_should_not_be_expired() 
         setup.config.clone(),
         setup.storage.clone(),
         Some(message_expiry),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
     );
 
     setup

--- a/integration/tests/streaming/topic.rs
+++ b/integration/tests/streaming/topic.rs
@@ -1,3 +1,6 @@
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
 use crate::streaming::common::test_setup::TestSetup;
 use crate::streaming::create_messages;
 use iggy::messages::poll_messages::PollingStrategy;
@@ -22,6 +25,8 @@ async fn should_persist_topics_with_partitions_directories_and_info_file() {
             partitions_count,
             setup.config.clone(),
             setup.storage.clone(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
             None,
             None,
             1,
@@ -55,6 +60,8 @@ async fn should_load_existing_topic_from_disk() {
             partitions_count,
             setup.config.clone(),
             setup.storage.clone(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
             None,
             None,
             1,
@@ -100,6 +107,8 @@ async fn should_delete_existing_topic_from_disk() {
             partitions_count,
             setup.config.clone(),
             setup.storage.clone(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
             None,
             None,
             1,
@@ -135,6 +144,8 @@ async fn should_purge_existing_topic_on_disk() {
             partitions_count,
             setup.config.clone(),
             setup.storage.clone(),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
             None,
             None,
             1,

--- a/integration/tests/streaming/topic_messages.rs
+++ b/integration/tests/streaming/topic_messages.rs
@@ -11,6 +11,8 @@ use server::streaming::topics::topic::Topic;
 use server::streaming::utils::hash;
 use std::collections::HashMap;
 use std::str::{from_utf8, FromStr};
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
 
 #[tokio::test]
 async fn given_disabled_cache_all_messages_should_be_polled() {
@@ -203,6 +205,8 @@ async fn init_topic(setup: &TestSetup, partitions_count: u32) -> Topic {
         partitions_count,
         setup.config.clone(),
         setup.storage.clone(),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
         None,
         None,
         1,

--- a/sdk/src/command.rs
+++ b/sdk/src/command.rs
@@ -44,6 +44,7 @@ use crate::users::update_permissions::UpdatePermissions;
 use crate::users::update_user::UpdateUser;
 use bytes::BufMut;
 use std::fmt::{Display, Formatter};
+use strum::EnumString;
 
 pub const PING: &str = "ping";
 pub const PING_CODE: u32 = 1;
@@ -130,7 +131,7 @@ pub const JOIN_CONSUMER_GROUP_CODE: u32 = 604;
 pub const LEAVE_CONSUMER_GROUP: &str = "consumer_group.leave";
 pub const LEAVE_CONSUMER_GROUP_CODE: u32 = 605;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, EnumString)]
 pub enum Command {
     Ping(Ping),
     GetStats(GetStats),

--- a/sdk/src/utils/byte_size.rs
+++ b/sdk/src/utils/byte_size.rs
@@ -1,10 +1,9 @@
+use super::duration::IggyDuration;
 use crate::error::IggyError;
 use byte_unit::{Byte, UnitType};
 use core::fmt;
 use serde::{Deserialize, Serialize};
-use std::str::FromStr;
-
-use super::duration::IggyDuration;
+use std::{ops::Add, str::FromStr};
 
 /// A struct for representing byte sizes with various utility functions.
 ///
@@ -116,6 +115,14 @@ impl PartialOrd<u64> for IggyByteSize {
 impl fmt::Display for IggyByteSize {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_human_string())
+    }
+}
+
+impl Add for IggyByteSize {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        IggyByteSize(Byte::from_u64(self.as_bytes_u64() + rhs.as_bytes_u64()))
     }
 }
 

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -199,8 +199,8 @@ async fn extend_stream(stream: &Stream, bytes: &mut Vec<u8>) {
     bytes.put_u32_le(stream.stream_id);
     bytes.put_u64_le(stream.created_at);
     bytes.put_u32_le(stream.get_topics().len() as u32);
-    bytes.put_u64_le(stream.get_size().await.as_bytes_u64());
-    bytes.put_u64_le(stream.get_messages_count().await);
+    bytes.put_u64_le(stream.get_size().as_bytes_u64());
+    bytes.put_u64_le(stream.get_messages_count());
     bytes.put_u8(stream.name.len() as u8);
     bytes.extend(stream.name.as_bytes());
 }
@@ -218,8 +218,8 @@ async fn extend_topic(topic: &Topic, bytes: &mut Vec<u8>) {
         None => bytes.put_u64_le(0),
     };
     bytes.put_u8(topic.replication_factor);
-    bytes.put_u64_le(topic.get_size().await.as_bytes_u64());
-    bytes.put_u64_le(topic.get_messages_count().await);
+    bytes.put_u64_le(topic.get_size().as_bytes_u64());
+    bytes.put_u64_le(topic.get_messages_count());
     bytes.put_u8(topic.name.len() as u8);
     bytes.extend(topic.name.as_bytes());
 }

--- a/server/src/http/mapper.rs
+++ b/server/src/http/mapper.rs
@@ -22,8 +22,8 @@ pub async fn map_stream(stream: &Stream) -> StreamDetails {
         created_at: stream.created_at,
         name: stream.name.clone(),
         topics_count: topics.len() as u32,
-        size_bytes: stream.get_size().await,
-        messages_count: stream.get_messages_count().await,
+        size_bytes: stream.get_size(),
+        messages_count: stream.get_messages_count(),
         topics,
     };
     stream_details.topics.sort_by(|a, b| a.id.cmp(&b.id));
@@ -37,9 +37,9 @@ pub async fn map_streams(streams: &[&Stream]) -> Vec<iggy::models::stream::Strea
             id: stream.stream_id,
             created_at: stream.created_at,
             name: stream.name.clone(),
-            size_bytes: stream.get_size().await,
+            size_bytes: stream.get_size(),
             topics_count: stream.get_topics().len() as u32,
-            messages_count: stream.get_messages_count().await,
+            messages_count: stream.get_messages_count(),
         };
         streams_data.push(stream);
     }
@@ -55,9 +55,9 @@ pub async fn map_topics(topics: &[&Topic]) -> Vec<iggy::models::topic::Topic> {
             id: topic.topic_id,
             created_at: topic.created_at,
             name: topic.name.clone(),
-            size: topic.get_size().await,
+            size: topic.get_size(),
             partitions_count: topic.get_partitions().len() as u32,
-            messages_count: topic.get_messages_count().await,
+            messages_count: topic.get_messages_count(),
             message_expiry: topic.message_expiry,
             max_topic_size: topic.max_topic_size,
             replication_factor: topic.replication_factor,
@@ -73,8 +73,8 @@ pub async fn map_topic(topic: &Topic) -> TopicDetails {
         id: topic.topic_id,
         created_at: topic.created_at,
         name: topic.name.clone(),
-        size: topic.get_size().await,
-        messages_count: topic.get_messages_count().await,
+        size: topic.get_size(),
+        messages_count: topic.get_messages_count(),
         partitions_count: topic.get_partitions().len() as u32,
         partitions: Vec::new(),
         message_expiry: topic.message_expiry,

--- a/server/src/streaming/partitions/persistence.rs
+++ b/server/src/streaming/partitions/persistence.rs
@@ -13,6 +13,9 @@ impl Partition {
     }
 
     pub async fn delete(&self) -> Result<(), IggyError> {
+        for segment in &self.segments {
+            self.storage.segment.delete(segment).await?;
+        }
         self.storage.partition.delete(self).await
     }
 
@@ -46,6 +49,7 @@ impl Partition {
             )
             .await?;
         self.add_persisted_segment(0).await?;
+
         Ok(())
     }
 }

--- a/server/src/streaming/partitions/segments.rs
+++ b/server/src/streaming/partitions/segments.rs
@@ -46,6 +46,12 @@ impl Partition {
             self.config.clone(),
             self.storage.clone(),
             self.message_expiry,
+            self.size_of_parent_stream.clone(),
+            self.size_of_parent_topic.clone(),
+            self.size_bytes.clone(),
+            self.messages_count_of_parent_stream.clone(),
+            self.messages_count_of_parent_topic.clone(),
+            self.messages_count.clone(),
         );
         new_segment.persist().await?;
         self.segments.push(new_segment);
@@ -65,6 +71,7 @@ impl Partition {
 
             let segment = segment.unwrap();
             self.storage.segment.delete(segment).await?;
+
             deleted_segment = DeletedSegment {
                 end_offset: segment.end_offset,
                 messages_count: segment.get_messages_count(),

--- a/server/src/streaming/partitions/storage.rs
+++ b/server/src/streaming/partitions/storage.rs
@@ -212,6 +212,12 @@ impl Storage<Partition> for FilePartitionStorage {
                 partition.config.clone(),
                 partition.storage.clone(),
                 partition.message_expiry,
+                partition.size_of_parent_stream.clone(),
+                partition.size_of_parent_topic.clone(),
+                partition.size_bytes.clone(),
+                partition.messages_count_of_parent_stream.clone(),
+                partition.messages_count_of_parent_topic.clone(),
+                partition.messages_count.clone(),
             );
             segment.load().await?;
             if !segment.is_closed {
@@ -220,7 +226,7 @@ impl Storage<Partition> for FilePartitionStorage {
 
             // If the first segment has at least a single message, we should increment the offset.
             if !partition.should_increment_offset {
-                partition.should_increment_offset = segment.current_size_bytes > 0;
+                partition.should_increment_offset = segment.size_bytes > 0;
             }
 
             if partition.config.partition.validate_checksum {

--- a/server/src/streaming/segments/storage.rs
+++ b/server/src/streaming/segments/storage.rs
@@ -14,6 +14,7 @@ use iggy::utils::checksum;
 use std::collections::HashMap;
 use std::io::SeekFrom;
 use std::path::Path;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
 use tracing::log::{trace, warn};
@@ -47,12 +48,13 @@ impl Storage<Segment> for FileSegmentStorage {
             segment.start_offset, segment.partition_id, segment.topic_id, segment.stream_id
         );
         let log_file = file::open(&segment.log_path).await?;
-        let file_size = log_file.metadata().await.unwrap().len() as u32;
-        segment.current_size_bytes = file_size;
+        let file_size = log_file.metadata().await.unwrap().len() as u64;
+        segment.size_bytes = file_size as u32;
+        let messages_count = segment.get_messages_count();
 
         info!(
-            "Segment log file for start offset {}, current offset: {}, and partition with ID: {} for topic with ID: {} and stream with ID: {} has {} bytes of size.",
-            segment.start_offset, segment.current_offset, segment.partition_id, segment.topic_id, segment.stream_id, segment.current_size_bytes
+            "Segment log file of size {} for start offset {}, current offset: {}, and partition with ID: {} for topic with ID: {} and stream with ID: {}.",
+            segment.size_bytes, segment.start_offset, segment.current_offset, segment.partition_id, segment.topic_id, segment.stream_id
         );
 
         if segment.config.segment.cache_indexes {
@@ -100,6 +102,25 @@ impl Storage<Segment> for FileSegmentStorage {
         if segment.is_full().await {
             segment.is_closed = true;
         }
+
+        segment
+            .size_of_parent_stream
+            .fetch_add(file_size, Ordering::SeqCst);
+        segment
+            .size_of_parent_topic
+            .fetch_add(file_size, Ordering::SeqCst);
+        segment
+            .size_of_parent_partition
+            .fetch_add(file_size, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_stream
+            .fetch_add(messages_count, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_topic
+            .fetch_add(messages_count, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_partition
+            .fetch_add(messages_count, Ordering::SeqCst);
 
         Ok(())
     }
@@ -150,16 +171,36 @@ impl Storage<Segment> for FileSegmentStorage {
     }
 
     async fn delete(&self, segment: &Segment) -> Result<(), IggyError> {
+        let segment_size = segment.size_bytes;
+        let segment_count_of_messages = segment.get_messages_count();
         info!(
-            "Deleting segment with start offset: {} for partition with ID: {} for stream with ID: {} and topic with ID: {}...",
-            segment.start_offset, segment.partition_id, segment.stream_id, segment.topic_id,
+            "Deleting segment of size {} with start offset: {} for partition with ID: {} for stream with ID: {} and topic with ID: {}...",
+            segment_size, segment.start_offset, segment.partition_id, segment.stream_id, segment.topic_id,
         );
         self.persister.delete(&segment.log_path).await?;
         self.persister.delete(&segment.index_path).await?;
         self.persister.delete(&segment.time_index_path).await?;
+        segment
+            .size_of_parent_stream
+            .fetch_sub(segment.size_bytes as u64, Ordering::SeqCst);
+        segment
+            .size_of_parent_topic
+            .fetch_sub(segment.size_bytes as u64, Ordering::SeqCst);
+        segment
+            .size_of_parent_partition
+            .fetch_sub(segment.size_bytes as u64, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_stream
+            .fetch_sub(segment_count_of_messages, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_topic
+            .fetch_sub(segment_count_of_messages, Ordering::SeqCst);
+        segment
+            .messages_count_of_parent_partition
+            .fetch_sub(segment_count_of_messages, Ordering::SeqCst);
         info!(
-            "Deleted segment with start offset: {} for partition with ID: {} for stream with ID: {} and topic with ID: {}.",
-            segment.start_offset, segment.partition_id, segment.stream_id, segment.topic_id,
+            "Deleted segment of size {} with start offset: {} for partition with ID: {} for stream with ID: {} and topic with ID: {}.",
+            segment_size, segment.start_offset, segment.partition_id, segment.stream_id, segment.topic_id,
         );
         Ok(())
     }

--- a/server/src/streaming/streams/messages.rs
+++ b/server/src/streaming/streams/messages.rs
@@ -1,11 +1,8 @@
 use crate::streaming::streams::stream::Stream;
+use std::sync::atomic::Ordering;
 
 impl Stream {
-    pub async fn get_messages_count(&self) -> u64 {
-        let mut messages_count = 0;
-        for topic in self.topics.values() {
-            messages_count += topic.get_messages_count().await;
-        }
-        messages_count
+    pub fn get_messages_count(&self) -> u64 {
+        self.messages_count.load(Ordering::SeqCst)
     }
 }

--- a/server/src/streaming/streams/topics.rs
+++ b/server/src/streaming/streams/topics.rs
@@ -55,6 +55,8 @@ impl Stream {
             partitions_count,
             self.config.clone(),
             self.storage.clone(),
+            self.size_bytes.clone(),
+            self.messages_count.clone(),
             message_expiry,
             max_topic_size,
             replication_factor,

--- a/server/src/streaming/systems/stats.rs
+++ b/server/src/streaming/systems/stats.rs
@@ -78,7 +78,7 @@ impl System {
             break;
         }
 
-        let mut message_size_bytes = 0u64;
+        let mut messages_size_bytes = 0u64;
         for stream in self.streams.values() {
             for topic in stream.topics.values() {
                 for partition in topic.partitions.values() {
@@ -86,12 +86,12 @@ impl System {
                     stats.messages_count += partition.get_messages_count();
                     stats.segments_count += partition.segments.len() as u32;
                     for segment in &partition.segments {
-                        message_size_bytes += segment.current_size_bytes as u64;
+                        messages_size_bytes += segment.size_bytes as u64;
                     }
                 }
             }
         }
-        stats.messages_size_bytes = message_size_bytes.into();
+        stats.messages_size_bytes = messages_size_bytes.into();
 
         Ok(stats)
     }

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -64,8 +64,7 @@ impl System {
                 .increment_partitions(stream.get_partitions_count());
             self.metrics
                 .increment_segments(stream.get_segments_count().await);
-            self.metrics
-                .increment_messages(stream.get_messages_count().await);
+            self.metrics.increment_messages(stream.get_messages_count());
 
             self.streams_ids
                 .insert(stream.name.clone(), stream.stream_id);
@@ -260,8 +259,7 @@ impl System {
         self.metrics.decrement_topics(stream.get_topics_count());
         self.metrics
             .decrement_partitions(stream.get_partitions_count());
-        self.metrics
-            .decrement_messages(stream.get_messages_count().await);
+        self.metrics.decrement_messages(stream.get_messages_count());
         self.metrics
             .decrement_segments(stream.get_segments_count().await);
 

--- a/server/src/streaming/systems/topics.rs
+++ b/server/src/streaming/systems/topics.rs
@@ -131,8 +131,7 @@ impl System {
         self.metrics.decrement_topics(1);
         self.metrics
             .decrement_partitions(topic.get_partitions_count());
-        self.metrics
-            .decrement_messages(topic.get_messages_count().await);
+        self.metrics.decrement_messages(topic.get_messages_count());
         self.metrics
             .decrement_segments(topic.get_segments_count().await);
         let client_manager = self.client_manager.read().await;

--- a/server/src/streaming/topics/consumer_groups.rs
+++ b/server/src/streaming/topics/consumer_groups.rs
@@ -163,6 +163,7 @@ mod tests {
     use super::*;
     use crate::configs::system::SystemConfig;
     use crate::streaming::storage::tests::get_test_system_storage;
+    use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
 
     #[tokio::test]
@@ -308,6 +309,8 @@ mod tests {
         let name = "test";
         let partitions_count = 3;
         let config = Arc::new(SystemConfig::default());
+        let size_of_parent_stream = Arc::new(AtomicU64::new(0));
+        let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
 
         Topic::create(
             stream_id,
@@ -316,6 +319,8 @@ mod tests {
             partitions_count,
             config,
             storage,
+            size_of_parent_stream,
+            messages_count_of_parent_stream,
             None,
             None,
             1,

--- a/server/src/streaming/topics/storage.rs
+++ b/server/src/streaming/topics/storage.rs
@@ -218,6 +218,10 @@ impl Storage<Topic> for FileTopicStorage {
                 topic.config.clone(),
                 topic.storage.clone(),
                 topic.message_expiry,
+                topic.messages_count_of_parent_stream.clone(),
+                topic.messages_count.clone(),
+                topic.size_of_parent_stream.clone(),
+                topic.size_bytes.clone(),
             );
             unloaded_partitions.push(partition);
         }


### PR DESCRIPTION
Replace locks with atomic operations to manage partition size updates
across multiple threads. This enhances performance by avoiding lock
contention and ensures thread-safe size calculations for partitions.

E2E test is added to ensure correct behavior in case when purging topic,
deleting topic, purging stream and deleting stream.

Closes #546.