### PR TITLE
Allow optional numeric ID for string and topic create command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.1.8"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "iggy_examples"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.9"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/bench/src/benchmarks/benchmark.rs
+++ b/bench/src/benchmarks/benchmark.rs
@@ -70,7 +70,10 @@ pub trait Benchmarkable {
                 info!("Creating the test stream {}", stream_id);
                 let name = format!("stream {}", stream_id);
                 client
-                    .create_stream(&CreateStream { stream_id, name })
+                    .create_stream(&CreateStream {
+                        stream_id: Some(stream_id),
+                        name,
+                    })
                     .await?;
 
                 info!(
@@ -81,7 +84,7 @@ pub trait Benchmarkable {
                 client
                     .create_topic(&CreateTopic {
                         stream_id: Identifier::numeric(stream_id)?,
-                        topic_id,
+                        topic_id: Some(topic_id),
                         partitions_count,
                         name,
                         message_expiry: None,

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy_examples"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 
 [[example]]

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn init_system(client: &IggyClient) {
     match client
         .create_stream(&CreateStream {
-            stream_id: STREAM_ID,
+            stream_id: Some(STREAM_ID),
             name: "sample-stream".to_string(),
         })
         .await
@@ -62,7 +62,7 @@ async fn init_system(client: &IggyClient) {
     match client
         .create_topic(&CreateTopic {
             stream_id: Identifier::numeric(STREAM_ID).unwrap(),
-            topic_id: TOPIC_ID,
+            topic_id: Some(TOPIC_ID),
             partitions_count: 1,
             name: "sample-topic".to_string(),
             message_expiry: None,

--- a/examples/src/shared/system.rs
+++ b/examples/src/shared/system.rs
@@ -79,14 +79,14 @@ pub async fn init_by_producer(args: &Args, client: &dyn Client) -> Result<(), Er
     info!("Stream does not exist, creating...");
     client
         .create_stream(&CreateStream {
-            stream_id: args.stream_id,
+            stream_id: Some(args.stream_id),
             name: "sample".to_string(),
         })
         .await?;
     client
         .create_topic(&CreateTopic {
             stream_id: Identifier::numeric(args.stream_id).unwrap(),
-            topic_id: args.topic_id,
+            topic_id: Some(args.topic_id),
             partitions_count: args.partitions_count,
             name: "orders".to_string(),
             message_expiry: None,

--- a/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
@@ -71,7 +71,7 @@ impl IggyCmdTestCase for TestConsumerGroupCreateCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -80,7 +80,7 @@ impl IggyCmdTestCase for TestConsumerGroupCreateCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
@@ -77,7 +77,7 @@ impl IggyCmdTestCase for TestConsumerGroupDeleteCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -86,7 +86,7 @@ impl IggyCmdTestCase for TestConsumerGroupDeleteCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
@@ -77,7 +77,7 @@ impl IggyCmdTestCase for TestConsumerGroupGetCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -86,7 +86,7 @@ impl IggyCmdTestCase for TestConsumerGroupGetCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
@@ -74,7 +74,7 @@ impl IggyCmdTestCase for TestConsumerGroupListCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -83,7 +83,7 @@ impl IggyCmdTestCase for TestConsumerGroupListCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 0,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/message/test_message_poll_command.rs
+++ b/integration/tests/cli/message/test_message_poll_command.rs
@@ -99,7 +99,7 @@ impl IggyCmdTestCase for TestMessagePollCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -108,7 +108,7 @@ impl IggyCmdTestCase for TestMessagePollCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/message/test_message_send_command.rs
+++ b/integration/tests/cli/message/test_message_send_command.rs
@@ -128,7 +128,7 @@ impl IggyCmdTestCase for TestMessageSendCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -137,7 +137,7 @@ impl IggyCmdTestCase for TestMessageSendCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/partition/test_partition_create_command.rs
+++ b/integration/tests/cli/partition/test_partition_create_command.rs
@@ -70,7 +70,7 @@ impl IggyCmdTestCase for TestPartitionCreateCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -79,7 +79,7 @@ impl IggyCmdTestCase for TestPartitionCreateCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/partition/test_partition_delete_command.rs
+++ b/integration/tests/cli/partition/test_partition_delete_command.rs
@@ -70,7 +70,7 @@ impl IggyCmdTestCase for TestPartitionDeleteCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -79,7 +79,7 @@ impl IggyCmdTestCase for TestPartitionDeleteCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: self.partitions_count,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/stream/test_stream_delete_command.rs
+++ b/integration/tests/cli/stream/test_stream_delete_command.rs
@@ -38,7 +38,7 @@ impl IggyCmdTestCase for TestStreamDeleteCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.name.clone(),
             })
             .await;

--- a/integration/tests/cli/stream/test_stream_get_command.rs
+++ b/integration/tests/cli/stream/test_stream_get_command.rs
@@ -37,7 +37,7 @@ impl IggyCmdTestCase for TestStreamGetCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.name.clone(),
             })
             .await;

--- a/integration/tests/cli/stream/test_stream_list_command.rs
+++ b/integration/tests/cli/stream/test_stream_list_command.rs
@@ -34,7 +34,7 @@ impl IggyCmdTestCase for TestStreamListCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.name.clone(),
             })
             .await;

--- a/integration/tests/cli/stream/test_stream_update_command.rs
+++ b/integration/tests/cli/stream/test_stream_update_command.rs
@@ -42,7 +42,7 @@ impl IggyCmdTestCase for TestStreamUpdateCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.name.clone(),
             })
             .await;

--- a/integration/tests/cli/system/test_stats_command.rs
+++ b/integration/tests/cli/system/test_stats_command.rs
@@ -15,7 +15,7 @@ impl IggyCmdTestCase for TestStatsCmd {
         let stream_id = Identifier::from_str_value("logs").unwrap();
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: 1,
+                stream_id: Some(1),
                 name: stream_id.as_string(),
             })
             .await;
@@ -23,7 +23,7 @@ impl IggyCmdTestCase for TestStatsCmd {
 
         let topic = client
             .create_topic(&CreateTopic {
-                topic_id: 1,
+                topic_id: Some(1),
                 stream_id,
                 partitions_count: 5,
                 message_expiry: None,

--- a/integration/tests/cli/topic/test_topic_create_command.rs
+++ b/integration/tests/cli/topic/test_topic_create_command.rs
@@ -72,7 +72,7 @@ impl IggyCmdTestCase for TestTopicCreateCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;

--- a/integration/tests/cli/topic/test_topic_delete_command.rs
+++ b/integration/tests/cli/topic/test_topic_delete_command.rs
@@ -59,7 +59,7 @@ impl IggyCmdTestCase for TestTopicDeleteCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -68,7 +68,7 @@ impl IggyCmdTestCase for TestTopicDeleteCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/topic/test_topic_get_command.rs
+++ b/integration/tests/cli/topic/test_topic_get_command.rs
@@ -60,7 +60,7 @@ impl IggyCmdTestCase for TestTopicGetCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -69,7 +69,7 @@ impl IggyCmdTestCase for TestTopicGetCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/topic/test_topic_list_command.rs
+++ b/integration/tests/cli/topic/test_topic_list_command.rs
@@ -57,7 +57,7 @@ impl IggyCmdTestCase for TestTopicListCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -66,7 +66,7 @@ impl IggyCmdTestCase for TestTopicListCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry: None,

--- a/integration/tests/cli/topic/test_topic_update_command.rs
+++ b/integration/tests/cli/topic/test_topic_update_command.rs
@@ -104,7 +104,7 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let stream = client
             .create_stream(&CreateStream {
-                stream_id: self.stream_id,
+                stream_id: Some(self.stream_id),
                 name: self.stream_name.clone(),
             })
             .await;
@@ -125,7 +125,7 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
         let topic = client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(self.stream_id).unwrap(),
-                topic_id: self.topic_id,
+                topic_id: Some(self.topic_id),
                 partitions_count: 1,
                 name: self.topic_name.clone(),
                 message_expiry,

--- a/integration/tests/examples/mod.rs
+++ b/integration/tests/examples/mod.rs
@@ -122,7 +122,7 @@ impl<'a> IggyExampleTest<'a> {
         if existing_stream_and_topic {
             self.client
                 .create_stream(&CreateStream {
-                    stream_id: 1,
+                    stream_id: Some(1),
                     name: "sample-stream".to_string(),
                 })
                 .await
@@ -130,7 +130,7 @@ impl<'a> IggyExampleTest<'a> {
             self.client
                 .create_topic(&CreateTopic {
                     stream_id: Identifier::numeric(1).unwrap(),
-                    topic_id: 1,
+                    topic_id: Some(1),
                     partitions_count: 1,
                     name: "sample-topic".to_string(),
                     message_expiry: None,

--- a/integration/tests/examples/test_getting_started.rs
+++ b/integration/tests/examples/test_getting_started.rs
@@ -57,9 +57,9 @@ async fn should_succeed_with_preexisting_stream_and_topic() {
     iggy_example_test
         .execute_test(TestGettingStarted {
             expected_producer_output: vec![
-                "Received an invalid response with status: 1011 (stream_id_already_exists).",
+                "Received an invalid response with status: 1012 (stream_name_already_exists).",
                 "Stream already exists and will not be created again.",
-                "Received an invalid response with status: 2012 (topic_id_already_exists).",
+                "Received an invalid response with status: 2013 (topic_name_already_exists).",
                 "Topic already exists and will not be created again.",
                 "Sent 10 message(s).",
             ],

--- a/integration/tests/server/scenarios/consumer_group_join_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_join_scenario.rs
@@ -34,7 +34,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 
     // 1. Create the stream
     let create_stream = CreateStream {
-        stream_id: STREAM_ID,
+        stream_id: Some(STREAM_ID),
         name: STREAM_NAME.to_string(),
     };
     system_client.create_stream(&create_stream).await.unwrap();
@@ -42,7 +42,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     // 2. Create the topic
     let create_topic = CreateTopic {
         stream_id: Identifier::numeric(STREAM_ID).unwrap(),
-        topic_id: TOPIC_ID,
+        topic_id: Some(TOPIC_ID),
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,

--- a/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
@@ -58,7 +58,7 @@ async fn init_system(
 ) {
     // 1. Create the stream
     let create_stream = CreateStream {
-        stream_id: STREAM_ID,
+        stream_id: Some(STREAM_ID),
         name: STREAM_NAME.to_string(),
     };
     system_client.create_stream(&create_stream).await.unwrap();
@@ -66,7 +66,7 @@ async fn init_system(
     // 2. Create the topic
     let create_topic = CreateTopic {
         stream_id: Identifier::numeric(STREAM_ID).unwrap(),
-        topic_id: TOPIC_ID,
+        topic_id: Some(TOPIC_ID),
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,

--- a/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
@@ -45,7 +45,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 async fn init_system(client: &IggyClient) {
     // 1. Create the stream
     let create_stream = CreateStream {
-        stream_id: STREAM_ID,
+        stream_id: Some(STREAM_ID),
         name: STREAM_NAME.to_string(),
     };
     client.create_stream(&create_stream).await.unwrap();
@@ -53,7 +53,7 @@ async fn init_system(client: &IggyClient) {
     // 2. Create the topic
     let create_topic = CreateTopic {
         stream_id: Identifier::numeric(STREAM_ID).unwrap(),
-        topic_id: TOPIC_ID,
+        topic_id: Some(TOPIC_ID),
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,

--- a/integration/tests/server/scenarios/message_headers_scenario.rs
+++ b/integration/tests/server/scenarios/message_headers_scenario.rs
@@ -97,7 +97,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 async fn init_system(client: &IggyClient) {
     // 1. Create the stream
     let create_stream = CreateStream {
-        stream_id: STREAM_ID,
+        stream_id: Some(STREAM_ID),
         name: STREAM_NAME.to_string(),
     };
     client.create_stream(&create_stream).await.unwrap();
@@ -105,7 +105,7 @@ async fn init_system(client: &IggyClient) {
     // 2. Create the topic
     let create_topic = CreateTopic {
         stream_id: Identifier::numeric(STREAM_ID).unwrap(),
-        topic_id: TOPIC_ID,
+        topic_id: Some(TOPIC_ID),
         partitions_count: PARTITIONS_COUNT,
         name: TOPIC_NAME.to_string(),
         message_expiry: None,

--- a/integration/tests/streaming/stream.rs
+++ b/integration/tests/streaming/stream.rs
@@ -94,7 +94,7 @@ async fn should_purge_existing_stream_on_disk() {
 
         let topic_id = 1;
         stream
-            .create_topic(topic_id, "test", 1, None, None, 1)
+            .create_topic(Some(topic_id), "test", 1, None, None, 1)
             .await
             .unwrap();
 

--- a/integration/tests/streaming/system.rs
+++ b/integration/tests/streaming/system.rs
@@ -44,7 +44,28 @@ async fn should_create_and_persist_stream() {
     system.init().await.unwrap();
 
     system
-        .create_stream(&session, stream_id, stream_name)
+        .create_stream(&session, Some(stream_id), stream_name)
+        .await
+        .unwrap();
+
+    assert_persisted_stream(&setup.config.get_streams_path(), stream_id).await;
+}
+
+#[tokio::test]
+async fn should_create_and_persist_stream_with_automatically_generated_id() {
+    let setup = TestSetup::init().await;
+    let mut system = System::new(
+        setup.config.clone(),
+        Some(setup.db.clone()),
+        PersonalAccessTokenConfig::default(),
+    );
+    let stream_id = 1;
+    let stream_name = "test";
+    let session = Session::new(1, 1, SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234));
+    system.init().await.unwrap();
+
+    system
+        .create_stream(&session, None, stream_name)
         .await
         .unwrap();
 
@@ -64,7 +85,7 @@ async fn should_delete_persisted_stream() {
     let session = Session::new(1, 1, SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234));
     system.init().await.unwrap();
     system
-        .create_stream(&session, stream_id, stream_name)
+        .create_stream(&session, Some(stream_id), stream_name)
         .await
         .unwrap();
     assert_persisted_stream(&setup.config.get_streams_path(), stream_id).await;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.1.8"
+version = "0.2.0"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/cli/streams/create_stream.rs
+++ b/sdk/src/cli/streams/create_stream.rs
@@ -12,7 +12,10 @@ pub struct CreateStreamCmd {
 impl CreateStreamCmd {
     pub fn new(stream_id: u32, name: String) -> Self {
         Self {
-            create_stream: CreateStream { stream_id, name },
+            create_stream: CreateStream {
+                stream_id: Some(stream_id),
+                name,
+            },
         }
     }
 }
@@ -22,7 +25,8 @@ impl CliCommand for CreateStreamCmd {
     fn explain(&self) -> String {
         format!(
             "create stream with ID: {} and name: {}",
-            self.create_stream.stream_id, self.create_stream.name
+            self.create_stream.stream_id.unwrap_or(0),
+            self.create_stream.name
         )
     }
 
@@ -33,13 +37,14 @@ impl CliCommand for CreateStreamCmd {
             .with_context(|| {
                 format!(
                     "Problem creating stream (ID: {} and name: {})",
-                    self.create_stream.stream_id, self.create_stream.name
+                    self.create_stream.stream_id.unwrap_or(0),
+                    self.create_stream.name
                 )
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
             "Stream with ID: {} and name: {} created",
-            self.create_stream.stream_id, self.create_stream.name
+            self.create_stream.stream_id.unwrap_or(0), self.create_stream.name
         );
 
         Ok(())

--- a/sdk/src/cli/topics/create_topic.rs
+++ b/sdk/src/cli/topics/create_topic.rs
@@ -29,7 +29,7 @@ impl CreateTopicCmd {
         Self {
             create_topic: CreateTopic {
                 stream_id,
-                topic_id,
+                topic_id: Some(topic_id),
                 partitions_count,
                 name,
                 message_expiry: message_expiry.clone().into(),
@@ -56,13 +56,13 @@ impl CliCommand for CreateTopicCmd {
             .with_context(|| {
                 format!(
                     "Problem creating topic (ID: {}, name: {}, partitions count: {}) in stream with ID: {}",
-                    self.create_topic.topic_id, self.create_topic.name, self.create_topic.partitions_count, self.create_topic.stream_id
+                    self.create_topic.topic_id.unwrap_or(0), self.create_topic.name, self.create_topic.partitions_count, self.create_topic.stream_id
                 )
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
             "Topic with ID: {}, name: {}, partitions count: {}, message expiry: {}, max topic size: {}, replication factor: {} created in stream with ID: {}",
-            self.create_topic.topic_id,
+            self.create_topic.topic_id.unwrap_or(0),
             self.create_topic.name,
             self.create_topic.partitions_count,
             self.message_expiry,
@@ -77,7 +77,7 @@ impl CliCommand for CreateTopicCmd {
 
 impl fmt::Display for CreateTopicCmd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let topic_id = &self.create_topic.topic_id;
+        let topic_id = &self.create_topic.topic_id.unwrap_or(0);
         let topic_name = &self.create_topic.name;
         let message_expiry = &self.message_expiry;
         let max_topic_size = &self.max_topic_size.as_human_string_with_zero_as_unlimited();

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.9"
+version = "0.2.0"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/streaming/streams/stream.rs
+++ b/server/src/streaming/streams/stream.rs
@@ -4,6 +4,7 @@ use crate::streaming::topics::topic::Topic;
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::timestamp::IggyTimestamp;
 use std::collections::HashMap;
+use std::sync::atomic::AtomicU32;
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -13,6 +14,7 @@ pub struct Stream {
     pub path: String,
     pub topics_path: String,
     pub created_at: u64,
+    pub current_topic_id: AtomicU32,
     pub(crate) topics: HashMap<u32, Topic>,
     pub(crate) topics_ids: HashMap<String, u32>,
     pub(crate) config: Arc<SystemConfig>,
@@ -39,6 +41,7 @@ impl Stream {
             path,
             topics_path,
             config,
+            current_topic_id: AtomicU32::new(1),
             topics: HashMap::new(),
             topics_ids: HashMap::new(),
             storage,

--- a/server/src/streaming/systems/topics.rs
+++ b/server/src/streaming/systems/topics.rs
@@ -37,7 +37,7 @@ impl System {
         &mut self,
         session: &Session,
         stream_id: &Identifier,
-        topic_id: u32,
+        topic_id: Option<u32>,
         name: &str,
         partitions_count: u32,
         message_expiry: Option<u32>,

--- a/tools/src/data-seeder/seeder.rs
+++ b/tools/src/data-seeder/seeder.rs
@@ -25,19 +25,19 @@ pub async fn seed(client: &IggyClient) -> Result<(), Error> {
 async fn create_streams(client: &IggyClient) -> Result<(), Error> {
     client
         .create_stream(&CreateStream {
-            stream_id: PROD_STREAM_ID,
+            stream_id: Some(PROD_STREAM_ID),
             name: "prod".to_string(),
         })
         .await?;
     client
         .create_stream(&CreateStream {
-            stream_id: TEST_STREAM_ID,
+            stream_id: Some(TEST_STREAM_ID),
             name: "test".to_string(),
         })
         .await?;
     client
         .create_stream(&CreateStream {
-            stream_id: DEV_STREAM_ID,
+            stream_id: Some(DEV_STREAM_ID),
             name: "dev".to_string(),
         })
         .await?;
@@ -50,7 +50,7 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(stream_id)?,
-                topic_id: 1,
+                topic_id: Some(1),
                 name: "orders".to_string(),
                 partitions_count: 1,
                 message_expiry: None,
@@ -62,7 +62,7 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(stream_id)?,
-                topic_id: 2,
+                topic_id: Some(2),
                 name: "users".to_string(),
                 partitions_count: 2,
                 message_expiry: None,
@@ -74,7 +74,7 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(stream_id)?,
-                topic_id: 3,
+                topic_id: Some(3),
                 name: "notifications".to_string(),
                 partitions_count: 3,
                 message_expiry: None,
@@ -86,7 +86,7 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(stream_id)?,
-                topic_id: 4,
+                topic_id: Some(4),
                 name: "payments".to_string(),
                 partitions_count: 2,
                 message_expiry: None,
@@ -98,7 +98,7 @@ async fn create_topics(client: &IggyClient) -> Result<(), Error> {
         client
             .create_topic(&CreateTopic {
                 stream_id: Identifier::numeric(stream_id)?,
-                topic_id: 5,
+                topic_id: Some(5),
                 name: "deliveries".to_string(),
                 partitions_count: 1,
                 message_expiry: None,


### PR DESCRIPTION
If ID is not provided during the topic or stream creation, the server will automatically assign next available ID.