### PR TITLE
Check if the process has existed while waiting for test server to start

### DIFF
--- a/integration/src/test_server.rs
+++ b/integration/src/test_server.rs
@@ -308,6 +308,12 @@ impl TestServer {
 
             for _ in 0..max_attempts {
                 if !Path::new(&config_path).exists() {
+                    if let Some(exit_status) = self.child_handle.as_mut().unwrap().try_wait().unwrap() {
+                        panic!(
+                            "Server process has exited with status {}!",
+                            exit_status
+                        );
+                    }
                     sleep(Duration::from_millis(SLEEP_INTERVAL_MS));
                     continue;
                 }

--- a/integration/src/test_server.rs
+++ b/integration/src/test_server.rs
@@ -308,11 +308,10 @@ impl TestServer {
 
             for _ in 0..max_attempts {
                 if !Path::new(&config_path).exists() {
-                    if let Some(exit_status) = self.child_handle.as_mut().unwrap().try_wait().unwrap() {
-                        panic!(
-                            "Server process has exited with status {}!",
-                            exit_status
-                        );
+                    if let Some(exit_status) =
+                        self.child_handle.as_mut().unwrap().try_wait().unwrap()
+                    {
+                        panic!("Server process has exited with status {}!", exit_status);
                     }
                     sleep(Duration::from_millis(SLEEP_INTERVAL_MS));
                     continue;


### PR DESCRIPTION
This PR is to fix #479. It adds a simple check to see if the server process has exited and panic in this case.

While doing integration tests, a separated server process is started, and the test case would wait for the server process to starting a loop to check if the `local_data_xxx/runtime/current_config.toml` file is created. If the file is not created, it would sleep and check again. If the server process exited, the waiting would take a long time until the loop reaches the max attempts. By checking the process status, we can fail the test sooner.
