### PR TITLE
Test latest docker image in CI after it's release to dockerhub

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,15 +1,14 @@
 name: post_release
 on:
-  [pull_request]
-  # workflow_run:
-  #   workflows: ["release"]
-  #   types:
-  #     - completed
+  workflow_run:
+    workflows: ["release"]
+    types:
+      - completed
 
 jobs:
   post_release:
     runs-on: ubuntu-latest
-    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@v4
       - name: Cache cargo & target directories

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -41,7 +41,7 @@ jobs:
           expected_send_poll_lines=("${expected_send_lines[@]}"
                                     "${expected_poll_lines[@]}")
 
-          # Check for successful timeout
+          # Verify processes successfully timed out with exit code 124
           exit_codes=($send_code $poll_code $send_poll_code)
           for code in "${exit_codes[@]}"; do
             if [ "${code:-0}" -ne 124 ]; then

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -22,6 +22,11 @@ jobs:
           command: "build"
           target: x86_64-unknown-linux-musl
           args: "--verbose --release --package bench"
+      - name: Install musl-tools, gnome-keyring and keyutils on Linux
+        run: |
+          sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
+          rm -f $HOME/.local/share/keyrings/*
+          echo -n "test" | gnome-keyring-daemon --unlock
       - name: Spin up Docker Container
         run: docker run -d -p 8090:8090 --name iggy_container iggyrs/iggy
       - name: Test Benchmark

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -16,17 +16,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: "v2"
+      - name: Install musl-tools, gnome-keyring and keyutils on Linux
+        run: |
+          sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
+          rm -f $HOME/.local/share/keyrings/*
+          echo -n "test" | gnome-keyring-daemon --unlock
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v0
         with:
           command: "build"
           target: x86_64-unknown-linux-musl
           args: "--verbose --release --package bench"
-      - name: Install musl-tools, gnome-keyring and keyutils on Linux
-        run: |
-          sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
-          rm -f $HOME/.local/share/keyrings/*
-          echo -n "test" | gnome-keyring-daemon --unlock
       - name: Spin up Docker Container
         run: docker run -d -p 8090:8090 --name iggy_container iggyrs/iggy
       - name: Test Benchmark

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -1,0 +1,66 @@
+name: post_release
+on:
+  [pull_request]
+  # workflow_run:
+  #   workflows: ["release"]
+  #   types:
+  #     - completed
+
+jobs:
+  post_release:
+    runs-on: ubuntu-latest
+    # if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: "v2"
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: x86_64-unknown-linux-musl
+          args: "--verbose --release --package bench"
+      - name: Spin up Docker Container
+        run: docker run -d -p 8090:8090 --name iggy_container iggyrs/iggy
+      - name: Test Benchmark
+        run: |
+          send_output=$(timeout 1s ./target/x86_64-unknown-linux-musl/release/iggy-bench send tcp --server-address 127.0.0.1:8090 2>&1) || send_code=$?;
+          poll_output=$(timeout 1s ./target/x86_64-unknown-linux-musl/release/iggy-bench poll tcp --server-address 127.0.0.1:8090 2>&1) || poll_code=$?;
+          send_poll_output=$(timeout 1s ./target/x86_64-unknown-linux-musl/release/iggy-bench send-and-poll tcp --server-address 127.0.0.1:8090 2>&1) || send_poll_code=$?;
+
+          expected_send_lines=("Producer #1 → preparing the test messages..."
+                               "Producer #1 → sending 1000000 messages in 1000 batches of 1000 messages...")
+          expected_poll_lines=("Consumer #1 → preparing the test messages..."
+                               "Consumer #1 → polling 1000000 messages in 1000 batches of 1000 messages...")
+          expected_send_poll_lines=("${expected_send_lines[@]}"
+                                    "${expected_poll_lines[@]}")
+
+          # Check for successful timeout
+          exit_codes=($send_code $poll_code $send_poll_code)
+          for code in "${exit_codes[@]}"; do
+            if [ "${code:-0}" -ne 124 ]; then
+              echo "Unexpected exit code: $code"
+              exit 1
+            fi
+          done
+
+          # Check for correct output
+          declare -A expected_output=(
+            [send_output]=expected_send_lines[@]
+            [poll_output]=expected_poll_lines[@]
+            [send_poll_output]=expected_send_poll_lines[@]
+          )
+          for command_name in "${!expected_output[@]}"; do
+              actual_output="${!command_name}"
+              expected_lines=("${!expected_output[$command_name]}")
+              for line in "${expected_lines[@]}"; do
+                if ! echo "$actual_output" | grep -q "$line"; then
+                  echo "Expected line '$line' was not found in the output of $command_name."
+                  exit 1
+                fi
+              done
+          done
+      - name: Clean up
+        run: docker rm -f iggy_container


### PR DESCRIPTION
Closes #361

Sample post_release workflow run: https://github.com/iggy-rs/iggy/actions/runs/7613469410/job/20733424469?pr=581

Discord chat: https://discord.com/channels/1144142576266530928/1144144507315691521/1196486487143878727

**Notes / Assumptions:** 

**1. Choice of Docker Image Tagging:**
- Our current `release.yml` workflow automatically tags images pushed to Dockerhub with `latest`. If a new version tag exists, the image will also be tagged with that specific version number. 
- In `post_release.yml`, I have opted to only use `iggrs/iggy:latest`, excluding specific version tags. To fetch version tags, we would need to integrate the `post_release` job into `release.yml`, which would lengthen the release process.

**2. Execution Environment for the Workflow:**
- In `post_release.yml`, I have opted to run the job on the **host runner machine** and take care of manually spinning up and tearing down the docker container.
- I have tested executing the job directly in a container and have noticed several drawbacks (longer build times, additional installation steps). Furthermore, it’s uncertain if this approach aligns with the desired outcome 
