### PR TITLE
Add purge sub-command for stream and topic commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cli"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cli/src/args/stream.rs
+++ b/cli/src/args/stream.rs
@@ -46,6 +46,16 @@ pub(crate) enum StreamAction {
     ///  iggy stream list -l table
     #[clap(verbatim_doc_comment, visible_alias = "l")]
     List(StreamListArgs),
+    /// Purge all topics in given stream ID
+    ///
+    /// Command removes all messages from given stream
+    /// Stream ID can be specified as a stream name or ID
+    ///
+    /// Examples:
+    ///  iggy stream purge 1
+    ///  iggy stream purge test
+    #[clap(verbatim_doc_comment, visible_alias = "p")]
+    Purge(StreamPurgeArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -87,4 +97,12 @@ pub(crate) struct StreamListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
     pub(crate) list_mode: ListMode,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct StreamPurgeArgs {
+    /// Stream ID to purge
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    pub(crate) stream_id: Identifier,
 }

--- a/cli/src/args/topic.rs
+++ b/cli/src/args/topic.rs
@@ -64,6 +64,19 @@ pub(crate) enum TopicAction {
     ///  iggy topic list prod
     #[clap(verbatim_doc_comment, visible_alias = "l")]
     List(TopicListArgs),
+    /// Purge topic with given ID in given stream ID
+    ///
+    /// Command removes all messages from given topic
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples
+    ///  iggy topic purge 1 1
+    ///  iggy topic purge prod 2
+    ///  iggy topic purge test debugs
+    ///  iggy topic purge 2 debugs
+    #[clap(verbatim_doc_comment, visible_alias = "p")]
+    Purge(TopicPurgeArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -164,4 +177,18 @@ pub(crate) struct TopicListArgs {
     /// List mode (table or list)
     #[clap(short, long, value_enum, default_value_t = ListMode::Table)]
     pub(crate) list_mode: ListMode,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct TopicPurgeArgs {
+    /// Stream ID to purge topic
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID to purge
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -31,12 +31,12 @@ use iggy::cli::{
     },
     streams::{
         create_stream::CreateStreamCmd, delete_stream::DeleteStreamCmd, get_stream::GetStreamCmd,
-        get_streams::GetStreamsCmd, update_stream::UpdateStreamCmd,
+        get_streams::GetStreamsCmd, purge_stream::PurgeStreamCmd, update_stream::UpdateStreamCmd,
     },
     system::{me::GetMeCmd, ping::PingCmd, stats::GetStatsCmd},
     topics::{
         create_topic::CreateTopicCmd, delete_topic::DeleteTopicCmd, get_topic::GetTopicCmd,
-        get_topics::GetTopicsCmd, update_topic::UpdateTopicCmd,
+        get_topics::GetTopicsCmd, purge_topic::PurgeTopicCmd, update_topic::UpdateTopicCmd,
     },
     users::{
         change_password::ChangePasswordCmd,
@@ -70,6 +70,7 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
             )),
             StreamAction::Get(args) => Box::new(GetStreamCmd::new(args.stream_id.clone())),
             StreamAction::List(args) => Box::new(GetStreamsCmd::new(args.list_mode.into())),
+            StreamAction::Purge(args) => Box::new(PurgeStreamCmd::new(args.stream_id.clone())),
         },
         Command::Topic(command) => match command {
             TopicAction::Create(args) => Box::new(CreateTopicCmd::new(
@@ -100,6 +101,10 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
             TopicAction::List(args) => Box::new(GetTopicsCmd::new(
                 args.stream_id.clone(),
                 args.list_mode.into(),
+            )),
+            TopicAction::Purge(args) => Box::new(PurgeTopicCmd::new(
+                args.stream_id.clone(),
+                args.topic_id.clone(),
             )),
         },
         Command::Partition(command) => match command {

--- a/integration/tests/cli/stream/mod.rs
+++ b/integration/tests/cli/stream/mod.rs
@@ -3,4 +3,5 @@ mod test_stream_delete_command;
 mod test_stream_get_command;
 mod test_stream_help_command;
 mod test_stream_list_command;
+mod test_stream_purge_command;
 mod test_stream_update_command;

--- a/integration/tests/cli/stream/test_stream_help_command.rs
+++ b/integration/tests/cli/stream/test_stream_help_command.rs
@@ -20,6 +20,7 @@ Commands:
   update  Update stream name for given stream ID [aliases: u]
   get     Get details of a single stream with given ID [aliases: g]
   list    List all streams [aliases: l]
+  purge   Purge all topics in given stream ID [aliases: p]
   help    Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cli/stream/test_stream_purge_command.rs
+++ b/integration/tests/cli/stream/test_stream_purge_command.rs
@@ -1,0 +1,214 @@
+use crate::cli::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, CLAP_INDENT,
+    USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::streams::get_stream::GetStream;
+use iggy::topics::create_topic::CreateTopic;
+use predicates::str::diff;
+use serial_test::parallel;
+use std::str::FromStr;
+
+struct TestStreamPurgeCmd {
+    stream_id: u32,
+    stream_name: String,
+    using_identifier: TestStreamId,
+    topic_id: u32,
+    topic_name: String,
+}
+
+impl TestStreamPurgeCmd {
+    fn new(stream_id: u32, name: String, using_identifier: TestStreamId) -> Self {
+        Self {
+            stream_id,
+            stream_name: name,
+            using_identifier,
+            topic_id: 1,
+            topic_name: String::from("test_topic"),
+        }
+    }
+
+    fn to_arg(&self) -> String {
+        match self.using_identifier {
+            TestStreamId::Named => self.stream_name.clone(),
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+        }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestStreamPurgeCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: Some(self.stream_id),
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Some(self.topic_id),
+                partitions_count: 10,
+                message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
+                name: self.topic_name.clone(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let messages = (1..100)
+            .map(|n| format!("message {}", n))
+            .filter_map(|s| Message::from_str(s.as_str()).ok())
+            .collect::<Vec<_>>();
+
+        let send_status = client
+            .send_messages(&mut SendMessages {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partitioning: Partitioning::default(),
+                messages,
+            })
+            .await;
+        assert!(send_status.is_ok());
+
+        let stream_state = client
+            .get_stream(&GetStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream_state.is_ok());
+        let stream_state = stream_state.unwrap();
+        assert!(stream_state.size_bytes > 0);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("stream")
+            .arg("purge")
+            .arg(self.to_arg())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_identifier {
+            TestStreamId::Named => self.stream_name.clone(),
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+        };
+
+        let start_message = format!(
+            "Executing purge stream with ID: {}\nStream with ID: {} purged\n",
+            stream_id, stream_id
+        );
+
+        command_state.success().stdout(diff(start_message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let stream_state = client
+            .get_stream(&GetStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream_state.is_ok());
+        let stream_state = stream_state.unwrap();
+        assert_eq!(stream_state.size_bytes, 0);
+
+        let stream_delete = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream_delete.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestStreamPurgeCmd::new(
+            1,
+            String::from("production"),
+            TestStreamId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestStreamPurgeCmd::new(
+            2,
+            String::from("testing"),
+            TestStreamId::Numeric,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "purge", "--help"],
+            format!(
+                r#"Purge all topics in given stream ID
+
+Command removes all messages from given stream
+Stream ID can be specified as a stream name or ID
+
+Examples:
+ iggy stream purge 1
+ iggy stream purge test
+
+{USAGE_PREFIX} stream purge <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to purge
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["stream", "purge", "-h"],
+            format!(
+                r#"Purge all topics in given stream ID
+
+{USAGE_PREFIX} stream purge <STREAM_ID>
+
+Arguments:
+  <STREAM_ID>  Stream ID to purge
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/topic/mod.rs
+++ b/integration/tests/cli/topic/mod.rs
@@ -3,4 +3,5 @@ mod test_topic_delete_command;
 mod test_topic_get_command;
 mod test_topic_help_command;
 mod test_topic_list_command;
+mod test_topic_purge_command;
 mod test_topic_update_command;

--- a/integration/tests/cli/topic/test_topic_help_command.rs
+++ b/integration/tests/cli/topic/test_topic_help_command.rs
@@ -21,6 +21,7 @@ Commands:
   update  Update topic name an message expiry time for given topic ID in given stream ID [aliases: u]
   get     Get topic detail for given topic ID and stream ID [aliases: g]
   list    List all topics in given stream ID [aliases: l]
+  purge   Purge topic with given ID in given stream ID [aliases: p]
   help    Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cli/topic/test_topic_purge_command.rs
+++ b/integration/tests/cli/topic/test_topic_purge_command.rs
@@ -1,0 +1,278 @@
+use crate::cli::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, TestTopicId,
+    CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use iggy::topics::get_topic::GetTopic;
+use iggy::{client::Client, identifier::Identifier};
+use predicates::str::diff;
+use serial_test::parallel;
+use std::str::FromStr;
+
+struct TestTopicPurgeCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+}
+
+impl TestTopicPurgeCmd {
+    fn new(
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            using_stream_id,
+            using_topic_id,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        };
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestTopicPurgeCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: Some(self.stream_id),
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Some(self.topic_id),
+                partitions_count: 10,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let messages = (1..100)
+            .map(|n| format!("message {}", n))
+            .filter_map(|s| Message::from_str(s.as_str()).ok())
+            .collect::<Vec<_>>();
+
+        let send_status = client
+            .send_messages(&mut SendMessages {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partitioning: Partitioning::default(),
+                messages,
+            })
+            .await;
+        assert!(send_status.is_ok());
+
+        let topic_state = client
+            .get_topic(&GetTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic_state.is_ok());
+        let topic_state = topic_state.unwrap();
+        assert!(topic_state.size > 0);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("topic")
+            .arg("purge")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let message = format!("Executing purge topic with ID: {} in stream with ID: {}\nTopic with ID: {} in stream with ID: {} purged\n",
+                              topic_id, stream_id, topic_id,  stream_id);
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let topic_state = client
+            .get_topic(&GetTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic_state.is_ok());
+        let topic_state = topic_state.unwrap();
+        assert_eq!(topic_state.size, 0);
+
+        let topic_delete = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic_delete.is_ok());
+
+        let stream_delete = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream_delete.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    iggy_cmd_test
+        .execute_test(TestTopicPurgeCmd::new(
+            1,
+            String::from("main"),
+            1,
+            String::from("sync"),
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestTopicPurgeCmd::new(
+            2,
+            String::from("testing"),
+            2,
+            String::from("topic"),
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestTopicPurgeCmd::new(
+            3,
+            String::from("prod"),
+            1,
+            String::from("named"),
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ))
+        .await;
+    iggy_cmd_test
+        .execute_test(TestTopicPurgeCmd::new(
+            4,
+            String::from("big"),
+            1,
+            String::from("probe"),
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["topic", "purge", "--help"],
+            format!(
+                r"Purge topic with given ID in given stream ID
+
+Command removes all messages from given topic
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples
+ iggy topic purge 1 1
+ iggy topic purge prod 2
+ iggy topic purge test debugs
+ iggy topic purge 2 debugs
+
+{USAGE_PREFIX} topic purge <STREAM_ID> <TOPIC_ID>
+
+Arguments:
+  <STREAM_ID>
+          Stream ID to purge topic
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID to purge
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+",
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["topic", "purge", "-h"],
+            format!(
+                r#"Purge topic with given ID in given stream ID
+
+{USAGE_PREFIX} topic purge <STREAM_ID> <TOPIC_ID>
+
+Arguments:
+  <STREAM_ID>  Stream ID to purge topic
+  <TOPIC_ID>   Topic ID to purge
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.0"
+version = "0.2.1"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/cli/streams/mod.rs
+++ b/sdk/src/cli/streams/mod.rs
@@ -2,4 +2,5 @@ pub mod create_stream;
 pub mod delete_stream;
 pub mod get_stream;
 pub mod get_streams;
+pub mod purge_stream;
 pub mod update_stream;

--- a/sdk/src/cli/streams/purge_stream.rs
+++ b/sdk/src/cli/streams/purge_stream.rs
@@ -1,0 +1,42 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use crate::streams::purge_stream::PurgeStream;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct PurgeStreamCmd {
+    purge_stream: PurgeStream,
+}
+
+impl PurgeStreamCmd {
+    pub fn new(stream_id: Identifier) -> Self {
+        Self {
+            purge_stream: PurgeStream { stream_id },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for PurgeStreamCmd {
+    fn explain(&self) -> String {
+        format!("purge stream with ID: {}", self.purge_stream.stream_id)
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .purge_stream(&self.purge_stream)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem purging stream with ID: {}",
+                    self.purge_stream.stream_id
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO, "Stream with ID: {} purged", self.purge_stream.stream_id);
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/topics/mod.rs
+++ b/sdk/src/cli/topics/mod.rs
@@ -2,4 +2,5 @@ pub mod create_topic;
 pub mod delete_topic;
 pub mod get_topic;
 pub mod get_topics;
+pub mod purge_topic;
 pub mod update_topic;

--- a/sdk/src/cli/topics/purge_topic.rs
+++ b/sdk/src/cli/topics/purge_topic.rs
@@ -1,0 +1,50 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use crate::topics::purge_topic::PurgeTopic;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct PurgeTopicCmd {
+    purge_topic: PurgeTopic,
+}
+
+impl PurgeTopicCmd {
+    pub fn new(stream_id: Identifier, topic_id: Identifier) -> Self {
+        Self {
+            purge_topic: PurgeTopic {
+                stream_id,
+                topic_id,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for PurgeTopicCmd {
+    fn explain(&self) -> String {
+        format!(
+            "purge topic with ID: {} in stream with ID: {}",
+            self.purge_topic.topic_id, self.purge_topic.stream_id
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .purge_topic(&self.purge_topic)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem purging topic with ID: {} in stream {}",
+                    self.purge_topic.topic_id, self.purge_topic.stream_id
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Topic with ID: {} in stream with ID: {} purged",
+            self.purge_topic.topic_id, self.purge_topic.stream_id);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Add purge sub-command for stream and topic commands which allow
user to remove all messages from specific topic or stream.
Add integration tests for the new purge commands.

Close #579
