### PR TITLE
Refactor stream and topic creation to support auto ID assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cli"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cli/src/args/stream.rs
+++ b/cli/src/args/stream.rs
@@ -4,11 +4,13 @@ use iggy::identifier::Identifier;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum StreamAction {
-    /// Create stream with given ID and name
+    /// Create stream with given name
+    ///
+    /// If stream ID is not provided then the server will automatically assign it
     ///
     /// Examples:
-    ///  iggy stream create 1 prod
-    ///  iggy stream create 2 test
+    ///  iggy stream create prod
+    ///  iggy stream create -s 1 test
     #[clap(verbatim_doc_comment, visible_alias = "c")]
     Create(StreamCreateArgs),
     /// Delete stream with given ID
@@ -60,8 +62,9 @@ pub(crate) enum StreamAction {
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct StreamCreateArgs {
-    /// Stream ID to create topic
-    pub(crate) stream_id: u32,
+    /// Stream ID to create
+    #[clap(short, long)]
+    pub(crate) stream_id: Option<u32>,
     /// Name of the stream
     pub(crate) name: String,
 }

--- a/cli/src/args/topic.rs
+++ b/cli/src/args/topic.rs
@@ -7,15 +7,16 @@ use std::convert::From;
 
 #[derive(Debug, Clone, Subcommand)]
 pub(crate) enum TopicAction {
-    /// Create topic with given ID, name, number of partitions
-    /// and expiry time for given stream ID
+    /// Create topic with given name, number of partitions and expiry time for given stream ID
     ///
     /// Stream ID can be specified as a stream name or ID
+    /// If topic ID is not provided then the server will automatically assign it
     ///
     /// Examples
-    ///  iggy topic create 1 1 2 sensor1 15days
-    ///  iggy topic create prod 2 2 sensor2
-    ///  iggy topic create test 3 2 debugs 1day 1hour 1min 1sec
+    ///  iggy topic create 1 sensor1 2 15days
+    ///  iggy topic create prod sensor2 2
+    ///  iggy topic create test debugs 2 1day 1hour 1min 1sec
+    ///  iggy topic create -t 3 1 sensor3 2 unlimited
     #[clap(verbatim_doc_comment, visible_alias = "c")]
     Create(TopicCreateArgs),
     /// Delete topic with given ID in given stream ID
@@ -86,12 +87,13 @@ pub(crate) struct TopicCreateArgs {
     /// Stream ID can be specified as a stream name or ID
     #[arg(value_parser = clap::value_parser!(Identifier))]
     pub(crate) stream_id: Identifier,
-    /// Topic ID to create
-    pub(crate) topic_id: u32,
-    /// Number of partitions inside the topic
-    pub(crate) partitions_count: u32,
     /// Name of the topic
     pub(crate) name: String,
+    /// Topic ID to create
+    #[clap(short, long)]
+    pub(crate) topic_id: Option<u32>,
+    /// Number of partitions inside the topic
+    pub(crate) partitions_count: u32,
     /// Max topic size
     ///
     /// ("unlimited" or skipping parameter disables max topic size functionality in topic)

--- a/integration/tests/cli/stream/test_stream_help_command.rs
+++ b/integration/tests/cli/stream/test_stream_help_command.rs
@@ -15,7 +15,7 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} stream <COMMAND>
 
 Commands:
-  create  Create stream with given ID and name [aliases: c]
+  create  Create stream with given name [aliases: c]
   delete  Delete stream with given ID [aliases: d]
   update  Update stream name for given stream ID [aliases: u]
   get     Get details of a single stream with given ID [aliases: g]

--- a/integration/tests/cli/topic/test_topic_help_command.rs
+++ b/integration/tests/cli/topic/test_topic_help_command.rs
@@ -15,8 +15,7 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} topic <COMMAND>
 
 Commands:
-  create  Create topic with given ID, name, number of partitions
-              and expiry time for given stream ID [aliases: c]
+  create  Create topic with given name, number of partitions and expiry time for given stream ID [aliases: c]
   delete  Delete topic with given ID in given stream ID [aliases: d]
   update  Update topic name an message expiry time for given topic ID in given stream ID [aliases: u]
   get     Get topic detail for given topic ID and stream ID [aliases: g]

--- a/sdk/src/cli/streams/create_stream.rs
+++ b/sdk/src/cli/streams/create_stream.rs
@@ -10,12 +10,16 @@ pub struct CreateStreamCmd {
 }
 
 impl CreateStreamCmd {
-    pub fn new(stream_id: u32, name: String) -> Self {
+    pub fn new(stream_id: Option<u32>, name: String) -> Self {
         Self {
-            create_stream: CreateStream {
-                stream_id: Some(stream_id),
-                name,
-            },
+            create_stream: CreateStream { stream_id, name },
+        }
+    }
+
+    fn get_stream_id_info(&self) -> String {
+        match self.create_stream.stream_id {
+            Some(stream_id) => format!("ID: {}", stream_id),
+            None => "ID auto incremented".to_string(),
         }
     }
 }
@@ -24,9 +28,9 @@ impl CreateStreamCmd {
 impl CliCommand for CreateStreamCmd {
     fn explain(&self) -> String {
         format!(
-            "create stream with ID: {} and name: {}",
-            self.create_stream.stream_id.unwrap_or(0),
-            self.create_stream.name
+            "create stream with name: {} and {}",
+            self.create_stream.name,
+            self.get_stream_id_info(),
         )
     }
 
@@ -36,15 +40,16 @@ impl CliCommand for CreateStreamCmd {
             .await
             .with_context(|| {
                 format!(
-                    "Problem creating stream (ID: {} and name: {})",
-                    self.create_stream.stream_id.unwrap_or(0),
-                    self.create_stream.name
+                    "Problem creating stream (name: {} and {})",
+                    self.create_stream.name,
+                    self.get_stream_id_info(),
                 )
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
-            "Stream with ID: {} and name: {} created",
-            self.create_stream.stream_id.unwrap_or(0), self.create_stream.name
+            "Stream with name: {} and {} created",
+            self.create_stream.name,
+            self.get_stream_id_info(),
         );
 
         Ok(())

--- a/sdk/src/cli/topics/create_topic.rs
+++ b/sdk/src/cli/topics/create_topic.rs
@@ -19,7 +19,7 @@ pub struct CreateTopicCmd {
 impl CreateTopicCmd {
     pub fn new(
         stream_id: Identifier,
-        topic_id: u32,
+        topic_id: Option<u32>,
         partitions_count: u32,
         name: String,
         message_expiry: MessageExpiry,
@@ -29,7 +29,7 @@ impl CreateTopicCmd {
         Self {
             create_topic: CreateTopic {
                 stream_id,
-                topic_id: Some(topic_id),
+                topic_id,
                 partitions_count,
                 name,
                 message_expiry: message_expiry.clone().into(),
@@ -39,6 +39,13 @@ impl CreateTopicCmd {
             message_expiry,
             max_topic_size,
             replication_factor,
+        }
+    }
+
+    fn get_topic_id_info(&self) -> String {
+        match self.create_topic.topic_id {
+            Some(topic_id) => format!("ID: {}", topic_id),
+            None => "ID auto incremented".to_string(),
         }
     }
 }
@@ -61,9 +68,9 @@ impl CliCommand for CreateTopicCmd {
             })?;
 
         event!(target: PRINT_TARGET, Level::INFO,
-            "Topic with ID: {}, name: {}, partitions count: {}, message expiry: {}, max topic size: {}, replication factor: {} created in stream with ID: {}",
-            self.create_topic.topic_id.unwrap_or(0),
+            "Topic with name: {}, {}, partitions count: {}, message expiry: {}, max topic size: {}, replication factor: {} created in stream with ID: {}",
             self.create_topic.name,
+            self.get_topic_id_info(),
             self.create_topic.partitions_count,
             self.message_expiry,
             self.max_topic_size.as_human_string_with_zero_as_unlimited(),
@@ -77,7 +84,7 @@ impl CliCommand for CreateTopicCmd {
 
 impl fmt::Display for CreateTopicCmd {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let topic_id = &self.create_topic.topic_id.unwrap_or(0);
+        let topic_id = self.get_topic_id_info();
         let topic_name = &self.create_topic.name;
         let message_expiry = &self.message_expiry;
         let max_topic_size = &self.max_topic_size.as_human_string_with_zero_as_unlimited();
@@ -86,7 +93,7 @@ impl fmt::Display for CreateTopicCmd {
 
         write!(
             f,
-            "create topic with ID: {topic_id}, name: {topic_name}, message expiry: {message_expiry}, \
+            "create topic with name: {topic_name}, {topic_id}, message expiry: {message_expiry}, \
             max topic size: {max_topic_size}, replication factor: {replication_factor} in stream with ID: {stream_id}",
         )
     }


### PR DESCRIPTION
Modify the stream and topic creation commands to allow the server to
automatically assign IDs if they are not provided by the user. Update
help messages, tests, and internal command structures to reflect the
new optional ID behavior.

Close #579
