### PR TITLE
Update version extraction method in publish_sdk workflow

### DIFF
--- a/.github/workflows/publish_sdk.yml
+++ b/.github/workflows/publish_sdk.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.all_changed_files.outputs.all_changed_files == 'Cargo.lock sdk/Cargo.toml' }}
         id: extract_version
         run: |
-          version=$(cargo pkgid -p iggy | cut -d# -f2 | cut -d: -f2)
+          version=$(cargo pkgid -p iggy | cut -d@ -f2)
           echo "iggy_version=$version" >> "$GITHUB_OUTPUT"
           echo "::notice ::Version from Cargo.toml $version"
 


### PR DESCRIPTION
Change the version extraction command in the publish_sdk.yml
workflow to use '@' as the delimiter instead of '#'. This ensures
correct version parsing for the iggy package.
