### PR TITLE
Log stream/topic already exists as debug events.

### DIFF
--- a/integration/tests/examples/test_getting_started.rs
+++ b/integration/tests/examples/test_getting_started.rs
@@ -57,9 +57,7 @@ async fn should_succeed_with_preexisting_stream_and_topic() {
     iggy_example_test
         .execute_test(TestGettingStarted {
             expected_producer_output: vec![
-                "Received an invalid response with status: 1012 (stream_name_already_exists).",
                 "Stream already exists and will not be created again.",
-                "Received an invalid response with status: 2013 (topic_name_already_exists).",
                 "Topic already exists and will not be created again.",
                 "Sent 10 message(s).",
             ],

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 #[repr(u32)]
 #[strum(serialize_all = "snake_case")]
 #[strum_discriminants(
-    vis(pub(self)),
+    vis(pub(crate)),
     derive(FromRepr, IntoStaticStr),
     strum(serialize_all = "snake_case")
 )]


### PR DESCRIPTION
To summarize what was discussed on discord:

Attempting to create topics and streams that have already been created currently logs at the error level. For example:
```
2024-01-25T15:27:32Z ERROR  Received an invalid response with status: 1012 (stream_name_already_exists).
```

This may happen as a result of users simply to always create a topic upon producer/consumer initialization, as a means to avoid topic/stream not found error handling.  One fix would be to require users to check topic existences first, but this would often result in two request being done rather than just one.

Users already need to explicitly ignore this "error" in the SDK, so I think it's ok to simply increase the corresponding log levels to debug. It also makes things easier for users that don't want to filter away all error layer events just to get rid of those.

Currently, however, all logging is handled centrally by `handle_response()`, and for each transport backend. This makes it hard to individually tune log levels.  This PR solves the tuning by using a conditional for the TCP backend only, but it's a solution that won't scale well at all. Got the go-ahead for this anyway, with the mutual understanding it's merely a temporary change to a solution that would require greater overhaul of the SDK ✌️

 