### PR TITLE
Use Bytes instead of &[u8] to reduce memory copying

### DIFF
--- a/sdk/src/binary/binary_client.rs
+++ b/sdk/src/binary/binary_client.rs
@@ -1,6 +1,7 @@
 use crate::client::Client;
 use crate::error::IggyError;
 use async_trait::async_trait;
+use bytes::Bytes;
 
 /// The state of the client.
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -21,5 +22,5 @@ pub trait BinaryClient: Client {
     /// Sets the state of the client.
     async fn set_state(&self, state: ClientState);
     /// Sends a command and returns the response.
-    async fn send_with_response(&self, command: u32, payload: &[u8]) -> Result<Vec<u8>, IggyError>;
+    async fn send_with_response(&self, command: u32, payload: Bytes) -> Result<Bytes, IggyError>;
 }

--- a/sdk/src/binary/consumer_groups.rs
+++ b/sdk/src/binary/consumer_groups.rs
@@ -23,9 +23,9 @@ impl<B: BinaryClient> ConsumerGroupClient for B {
     ) -> Result<ConsumerGroupDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_CONSUMER_GROUP_CODE, &command.as_bytes())
+            .send_with_response(GET_CONSUMER_GROUP_CODE, command.as_bytes())
             .await?;
-        mapper::map_consumer_group(&response)
+        mapper::map_consumer_group(response)
     }
 
     async fn get_consumer_groups(
@@ -34,35 +34,35 @@ impl<B: BinaryClient> ConsumerGroupClient for B {
     ) -> Result<Vec<ConsumerGroup>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_CONSUMER_GROUPS_CODE, &command.as_bytes())
+            .send_with_response(GET_CONSUMER_GROUPS_CODE, command.as_bytes())
             .await?;
-        mapper::map_consumer_groups(&response)
+        mapper::map_consumer_groups(response)
     }
 
     async fn create_consumer_group(&self, command: &CreateConsumerGroup) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CREATE_CONSUMER_GROUP_CODE, &command.as_bytes())
+        self.send_with_response(CREATE_CONSUMER_GROUP_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn delete_consumer_group(&self, command: &DeleteConsumerGroup) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_CONSUMER_GROUP_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_CONSUMER_GROUP_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn join_consumer_group(&self, command: &JoinConsumerGroup) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(JOIN_CONSUMER_GROUP_CODE, &command.as_bytes())
+        self.send_with_response(JOIN_CONSUMER_GROUP_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn leave_consumer_group(&self, command: &LeaveConsumerGroup) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(LEAVE_CONSUMER_GROUP_CODE, &command.as_bytes())
+        self.send_with_response(LEAVE_CONSUMER_GROUP_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/consumer_offsets.rs
+++ b/sdk/src/binary/consumer_offsets.rs
@@ -12,7 +12,7 @@ use crate::models::consumer_offset_info::ConsumerOffsetInfo;
 impl<B: BinaryClient> ConsumerOffsetClient for B {
     async fn store_consumer_offset(&self, command: &StoreConsumerOffset) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(STORE_CONSUMER_OFFSET_CODE, &command.as_bytes())
+        self.send_with_response(STORE_CONSUMER_OFFSET_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
@@ -23,8 +23,8 @@ impl<B: BinaryClient> ConsumerOffsetClient for B {
     ) -> Result<ConsumerOffsetInfo, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_CONSUMER_OFFSET_CODE, &command.as_bytes())
+            .send_with_response(GET_CONSUMER_OFFSET_CODE, command.as_bytes())
             .await?;
-        mapper::map_consumer_offset(&response)
+        mapper::map_consumer_offset(response)
     }
 }

--- a/sdk/src/binary/messages.rs
+++ b/sdk/src/binary/messages.rs
@@ -13,14 +13,14 @@ impl<B: BinaryClient> MessageClient for B {
     async fn poll_messages(&self, command: &PollMessages) -> Result<PolledMessages, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(POLL_MESSAGES_CODE, &command.as_bytes())
+            .send_with_response(POLL_MESSAGES_CODE, command.as_bytes())
             .await?;
-        mapper::map_polled_messages(&response)
+        mapper::map_polled_messages(response)
     }
 
     async fn send_messages(&self, command: &mut SendMessages) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(SEND_MESSAGES_CODE, &command.as_bytes())
+        self.send_with_response(SEND_MESSAGES_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/partitions.rs
+++ b/sdk/src/binary/partitions.rs
@@ -11,14 +11,14 @@ use crate::partitions::delete_partitions::DeletePartitions;
 impl<B: BinaryClient> PartitionClient for B {
     async fn create_partitions(&self, command: &CreatePartitions) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CREATE_PARTITIONS_CODE, &command.as_bytes())
+        self.send_with_response(CREATE_PARTITIONS_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn delete_partitions(&self, command: &DeletePartitions) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_PARTITIONS_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_PARTITIONS_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/personal_access_tokens.rs
+++ b/sdk/src/binary/personal_access_tokens.rs
@@ -19,9 +19,9 @@ impl<B: BinaryClient> PersonalAccessTokenClient for B {
     ) -> Result<Vec<PersonalAccessTokenInfo>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_PERSONAL_ACCESS_TOKENS_CODE, &command.as_bytes())
+            .send_with_response(GET_PERSONAL_ACCESS_TOKENS_CODE, command.as_bytes())
             .await?;
-        mapper::map_personal_access_tokens(&response)
+        mapper::map_personal_access_tokens(response)
     }
 
     async fn create_personal_access_token(
@@ -30,9 +30,9 @@ impl<B: BinaryClient> PersonalAccessTokenClient for B {
     ) -> Result<RawPersonalAccessToken, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(CREATE_PERSONAL_ACCESS_TOKEN_CODE, &command.as_bytes())
+            .send_with_response(CREATE_PERSONAL_ACCESS_TOKEN_CODE, command.as_bytes())
             .await?;
-        mapper::map_raw_pat(&response)
+        mapper::map_raw_pat(response)
     }
 
     async fn delete_personal_access_token(
@@ -40,7 +40,7 @@ impl<B: BinaryClient> PersonalAccessTokenClient for B {
         command: &DeletePersonalAccessToken,
     ) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_PERSONAL_ACCESS_TOKEN_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_PERSONAL_ACCESS_TOKEN_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
@@ -50,9 +50,9 @@ impl<B: BinaryClient> PersonalAccessTokenClient for B {
         command: &LoginWithPersonalAccessToken,
     ) -> Result<IdentityInfo, IggyError> {
         let response = self
-            .send_with_response(LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, &command.as_bytes())
+            .send_with_response(LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, command.as_bytes())
             .await?;
         self.set_state(ClientState::Authenticated).await;
-        mapper::map_identity_info(&response)
+        mapper::map_identity_info(response)
     }
 }

--- a/sdk/src/binary/streams.rs
+++ b/sdk/src/binary/streams.rs
@@ -20,43 +20,43 @@ impl<B: BinaryClient> StreamClient for B {
     async fn get_stream(&self, command: &GetStream) -> Result<StreamDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_STREAM_CODE, &command.as_bytes())
+            .send_with_response(GET_STREAM_CODE, command.as_bytes())
             .await?;
-        mapper::map_stream(&response)
+        mapper::map_stream(response)
     }
 
     async fn get_streams(&self, command: &GetStreams) -> Result<Vec<Stream>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_STREAMS_CODE, &command.as_bytes())
+            .send_with_response(GET_STREAMS_CODE, command.as_bytes())
             .await?;
-        mapper::map_streams(&response)
+        mapper::map_streams(response)
     }
 
     async fn create_stream(&self, command: &CreateStream) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CREATE_STREAM_CODE, &command.as_bytes())
+        self.send_with_response(CREATE_STREAM_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn delete_stream(&self, command: &DeleteStream) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_STREAM_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_STREAM_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn update_stream(&self, command: &UpdateStream) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(UPDATE_STREAM_CODE, &command.as_bytes())
+        self.send_with_response(UPDATE_STREAM_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn purge_stream(&self, command: &PurgeStream) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(PURGE_STREAM_CODE, &command.as_bytes())
+        self.send_with_response(PURGE_STREAM_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/system.rs
+++ b/sdk/src/binary/system.rs
@@ -17,37 +17,37 @@ impl<B: BinaryClient> SystemClient for B {
     async fn get_stats(&self, command: &GetStats) -> Result<Stats, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_STATS_CODE, &command.as_bytes())
+            .send_with_response(GET_STATS_CODE, command.as_bytes())
             .await?;
-        mapper::map_stats(&response)
+        mapper::map_stats(response)
     }
 
     async fn get_me(&self, command: &GetMe) -> Result<ClientInfoDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_ME_CODE, &command.as_bytes())
+            .send_with_response(GET_ME_CODE, command.as_bytes())
             .await?;
-        mapper::map_client(&response)
+        mapper::map_client(response)
     }
 
     async fn get_client(&self, command: &GetClient) -> Result<ClientInfoDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_CLIENT_CODE, &command.as_bytes())
+            .send_with_response(GET_CLIENT_CODE, command.as_bytes())
             .await?;
-        mapper::map_client(&response)
+        mapper::map_client(response)
     }
 
     async fn get_clients(&self, command: &GetClients) -> Result<Vec<ClientInfo>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_CLIENTS_CODE, &command.as_bytes())
+            .send_with_response(GET_CLIENTS_CODE, command.as_bytes())
             .await?;
-        mapper::map_clients(&response)
+        mapper::map_clients(response)
     }
 
     async fn ping(&self, command: &Ping) -> Result<(), IggyError> {
-        self.send_with_response(PING_CODE, &command.as_bytes())
+        self.send_with_response(PING_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/topics.rs
+++ b/sdk/src/binary/topics.rs
@@ -20,43 +20,43 @@ impl<B: BinaryClient> TopicClient for B {
     async fn get_topic(&self, command: &GetTopic) -> Result<TopicDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_TOPIC_CODE, &command.as_bytes())
+            .send_with_response(GET_TOPIC_CODE, command.as_bytes())
             .await?;
-        mapper::map_topic(&response)
+        mapper::map_topic(response)
     }
 
     async fn get_topics(&self, command: &GetTopics) -> Result<Vec<Topic>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_TOPICS_CODE, &command.as_bytes())
+            .send_with_response(GET_TOPICS_CODE, command.as_bytes())
             .await?;
-        mapper::map_topics(&response)
+        mapper::map_topics(response)
     }
 
     async fn create_topic(&self, command: &CreateTopic) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CREATE_TOPIC_CODE, &command.as_bytes())
+        self.send_with_response(CREATE_TOPIC_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn delete_topic(&self, command: &DeleteTopic) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_TOPIC_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_TOPIC_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn update_topic(&self, command: &UpdateTopic) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(UPDATE_TOPIC_CODE, &command.as_bytes())
+        self.send_with_response(UPDATE_TOPIC_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn purge_topic(&self, command: &PurgeTopic) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(PURGE_TOPIC_CODE, &command.as_bytes())
+        self.send_with_response(PURGE_TOPIC_CODE, command.as_bytes())
             .await?;
         Ok(())
     }

--- a/sdk/src/binary/users.rs
+++ b/sdk/src/binary/users.rs
@@ -21,65 +21,65 @@ impl<B: BinaryClient> UserClient for B {
     async fn get_user(&self, command: &GetUser) -> Result<UserInfoDetails, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_USER_CODE, &command.as_bytes())
+            .send_with_response(GET_USER_CODE, command.as_bytes())
             .await?;
-        mapper::map_user(&response)
+        mapper::map_user(response)
     }
 
     async fn get_users(&self, command: &GetUsers) -> Result<Vec<UserInfo>, IggyError> {
         fail_if_not_authenticated(self).await?;
         let response = self
-            .send_with_response(GET_USERS_CODE, &command.as_bytes())
+            .send_with_response(GET_USERS_CODE, command.as_bytes())
             .await?;
-        mapper::map_users(&response)
+        mapper::map_users(response)
     }
 
     async fn create_user(&self, command: &CreateUser) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CREATE_USER_CODE, &command.as_bytes())
+        self.send_with_response(CREATE_USER_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn delete_user(&self, command: &DeleteUser) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(DELETE_USER_CODE, &command.as_bytes())
+        self.send_with_response(DELETE_USER_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn update_user(&self, command: &UpdateUser) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(UPDATE_USER_CODE, &command.as_bytes())
+        self.send_with_response(UPDATE_USER_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn update_permissions(&self, command: &UpdatePermissions) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(UPDATE_PERMISSIONS_CODE, &command.as_bytes())
+        self.send_with_response(UPDATE_PERMISSIONS_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn change_password(&self, command: &ChangePassword) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(CHANGE_PASSWORD_CODE, &command.as_bytes())
+        self.send_with_response(CHANGE_PASSWORD_CODE, command.as_bytes())
             .await?;
         Ok(())
     }
 
     async fn login_user(&self, command: &LoginUser) -> Result<IdentityInfo, IggyError> {
         let response = self
-            .send_with_response(LOGIN_USER_CODE, &command.as_bytes())
+            .send_with_response(LOGIN_USER_CODE, command.as_bytes())
             .await?;
         self.set_state(ClientState::Authenticated).await;
-        mapper::map_identity_info(&response)
+        mapper::map_identity_info(response)
     }
 
     async fn logout_user(&self, command: &LogoutUser) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(LOGOUT_USER_CODE, &command.as_bytes())
+        self.send_with_response(LOGOUT_USER_CODE, command.as_bytes())
             .await?;
         self.set_state(ClientState::Connected).await;
         Ok(())

--- a/sdk/src/bytes_serializable.rs
+++ b/sdk/src/bytes_serializable.rs
@@ -1,12 +1,14 @@
+use bytes::Bytes;
+
 use crate::error::IggyError;
 
 /// The trait represents the logic responsible for serializing and deserializing the struct to and from bytes.
 pub trait BytesSerializable {
     /// Serializes the struct to bytes.
-    fn as_bytes(&self) -> Vec<u8>;
+    fn as_bytes(&self) -> Bytes;
 
     /// Deserializes the struct from bytes.
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError>
     where
         Self: Sized;
 }

--- a/sdk/src/command.rs
+++ b/sdk/src/command.rs
@@ -343,7 +343,7 @@ impl BytesSerializable for Command {
 fn as_bytes(command: u32, payload: Bytes) -> Bytes {
     let mut bytes = BytesMut::with_capacity(4 + payload.len());
     bytes.put_u32_le(command);
-    bytes.extend(payload);
+    bytes.put_slice(&payload);
     bytes.freeze()
 }
 
@@ -663,7 +663,7 @@ mod tests {
         let payload = payload.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + payload.len());
         bytes.put_u32_le(command_id);
-        bytes.extend(payload);
+        bytes.put_slice(&payload);
         assert_eq!(command.as_bytes(), bytes);
     }
 
@@ -675,7 +675,7 @@ mod tests {
         let payload = payload.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + payload.len());
         bytes.put_u32_le(command_id);
-        bytes.extend(payload);
+        bytes.put_slice(&payload);
         let bytes = Bytes::from(bytes);
         assert_eq!(&Command::from_bytes(bytes).unwrap(), command);
     }

--- a/sdk/src/command.rs
+++ b/sdk/src/command.rs
@@ -42,7 +42,7 @@ use crate::users::login_user::LoginUser;
 use crate::users::logout_user::LogoutUser;
 use crate::users::update_permissions::UpdatePermissions;
 use crate::users::update_user::UpdateUser;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use std::fmt::{Display, Formatter};
 
 pub const PING: &str = "ping";
@@ -180,86 +180,86 @@ pub enum Command {
 pub trait CommandPayload: BytesSerializable + Display {}
 
 impl BytesSerializable for Command {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         match self {
-            Command::Ping(payload) => as_bytes(PING_CODE, &payload.as_bytes()),
-            Command::GetStats(payload) => as_bytes(GET_STATS_CODE, &payload.as_bytes()),
-            Command::GetMe(payload) => as_bytes(GET_ME_CODE, &payload.as_bytes()),
-            Command::GetClient(payload) => as_bytes(GET_CLIENT_CODE, &payload.as_bytes()),
-            Command::GetClients(payload) => as_bytes(GET_CLIENTS_CODE, &payload.as_bytes()),
-            Command::GetUser(payload) => as_bytes(GET_USER_CODE, &payload.as_bytes()),
-            Command::GetUsers(payload) => as_bytes(GET_USERS_CODE, &payload.as_bytes()),
-            Command::CreateUser(payload) => as_bytes(CREATE_USER_CODE, &payload.as_bytes()),
-            Command::DeleteUser(payload) => as_bytes(DELETE_USER_CODE, &payload.as_bytes()),
-            Command::UpdateUser(payload) => as_bytes(UPDATE_USER_CODE, &payload.as_bytes()),
+            Command::Ping(payload) => as_bytes(PING_CODE, payload.as_bytes()),
+            Command::GetStats(payload) => as_bytes(GET_STATS_CODE, payload.as_bytes()),
+            Command::GetMe(payload) => as_bytes(GET_ME_CODE, payload.as_bytes()),
+            Command::GetClient(payload) => as_bytes(GET_CLIENT_CODE, payload.as_bytes()),
+            Command::GetClients(payload) => as_bytes(GET_CLIENTS_CODE, payload.as_bytes()),
+            Command::GetUser(payload) => as_bytes(GET_USER_CODE, payload.as_bytes()),
+            Command::GetUsers(payload) => as_bytes(GET_USERS_CODE, payload.as_bytes()),
+            Command::CreateUser(payload) => as_bytes(CREATE_USER_CODE, payload.as_bytes()),
+            Command::DeleteUser(payload) => as_bytes(DELETE_USER_CODE, payload.as_bytes()),
+            Command::UpdateUser(payload) => as_bytes(UPDATE_USER_CODE, payload.as_bytes()),
             Command::UpdatePermissions(payload) => {
-                as_bytes(UPDATE_PERMISSIONS_CODE, &payload.as_bytes())
+                as_bytes(UPDATE_PERMISSIONS_CODE, payload.as_bytes())
             }
-            Command::ChangePassword(payload) => as_bytes(CHANGE_PASSWORD_CODE, &payload.as_bytes()),
-            Command::LoginUser(payload) => as_bytes(LOGIN_USER_CODE, &payload.as_bytes()),
-            Command::LogoutUser(payload) => as_bytes(LOGOUT_USER_CODE, &payload.as_bytes()),
+            Command::ChangePassword(payload) => as_bytes(CHANGE_PASSWORD_CODE, payload.as_bytes()),
+            Command::LoginUser(payload) => as_bytes(LOGIN_USER_CODE, payload.as_bytes()),
+            Command::LogoutUser(payload) => as_bytes(LOGOUT_USER_CODE, payload.as_bytes()),
             Command::GetPersonalAccessTokens(payload) => {
-                as_bytes(GET_PERSONAL_ACCESS_TOKENS_CODE, &payload.as_bytes())
+                as_bytes(GET_PERSONAL_ACCESS_TOKENS_CODE, payload.as_bytes())
             }
             Command::CreatePersonalAccessToken(payload) => {
-                as_bytes(CREATE_PERSONAL_ACCESS_TOKEN_CODE, &payload.as_bytes())
+                as_bytes(CREATE_PERSONAL_ACCESS_TOKEN_CODE, payload.as_bytes())
             }
             Command::DeletePersonalAccessToken(payload) => {
-                as_bytes(DELETE_PERSONAL_ACCESS_TOKEN_CODE, &payload.as_bytes())
+                as_bytes(DELETE_PERSONAL_ACCESS_TOKEN_CODE, payload.as_bytes())
             }
             Command::LoginWithPersonalAccessToken(payload) => {
-                as_bytes(LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, &payload.as_bytes())
+                as_bytes(LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, payload.as_bytes())
             }
-            Command::SendMessages(payload) => as_bytes(SEND_MESSAGES_CODE, &payload.as_bytes()),
-            Command::PollMessages(payload) => as_bytes(POLL_MESSAGES_CODE, &payload.as_bytes()),
+            Command::SendMessages(payload) => as_bytes(SEND_MESSAGES_CODE, payload.as_bytes()),
+            Command::PollMessages(payload) => as_bytes(POLL_MESSAGES_CODE, payload.as_bytes()),
             Command::StoreConsumerOffset(payload) => {
-                as_bytes(STORE_CONSUMER_OFFSET_CODE, &payload.as_bytes())
+                as_bytes(STORE_CONSUMER_OFFSET_CODE, payload.as_bytes())
             }
             Command::GetConsumerOffset(payload) => {
-                as_bytes(GET_CONSUMER_OFFSET_CODE, &payload.as_bytes())
+                as_bytes(GET_CONSUMER_OFFSET_CODE, payload.as_bytes())
             }
-            Command::GetStream(payload) => as_bytes(GET_STREAM_CODE, &payload.as_bytes()),
-            Command::GetStreams(payload) => as_bytes(GET_STREAMS_CODE, &payload.as_bytes()),
-            Command::CreateStream(payload) => as_bytes(CREATE_STREAM_CODE, &payload.as_bytes()),
-            Command::DeleteStream(payload) => as_bytes(DELETE_STREAM_CODE, &payload.as_bytes()),
-            Command::UpdateStream(payload) => as_bytes(UPDATE_STREAM_CODE, &payload.as_bytes()),
-            Command::PurgeStream(payload) => as_bytes(PURGE_STREAM_CODE, &payload.as_bytes()),
-            Command::GetTopic(payload) => as_bytes(GET_TOPIC_CODE, &payload.as_bytes()),
-            Command::GetTopics(payload) => as_bytes(GET_TOPICS_CODE, &payload.as_bytes()),
-            Command::CreateTopic(payload) => as_bytes(CREATE_TOPIC_CODE, &payload.as_bytes()),
-            Command::DeleteTopic(payload) => as_bytes(DELETE_TOPIC_CODE, &payload.as_bytes()),
-            Command::UpdateTopic(payload) => as_bytes(UPDATE_TOPIC_CODE, &payload.as_bytes()),
-            Command::PurgeTopic(payload) => as_bytes(PURGE_TOPIC_CODE, &payload.as_bytes()),
+            Command::GetStream(payload) => as_bytes(GET_STREAM_CODE, payload.as_bytes()),
+            Command::GetStreams(payload) => as_bytes(GET_STREAMS_CODE, payload.as_bytes()),
+            Command::CreateStream(payload) => as_bytes(CREATE_STREAM_CODE, payload.as_bytes()),
+            Command::DeleteStream(payload) => as_bytes(DELETE_STREAM_CODE, payload.as_bytes()),
+            Command::UpdateStream(payload) => as_bytes(UPDATE_STREAM_CODE, payload.as_bytes()),
+            Command::PurgeStream(payload) => as_bytes(PURGE_STREAM_CODE, payload.as_bytes()),
+            Command::GetTopic(payload) => as_bytes(GET_TOPIC_CODE, payload.as_bytes()),
+            Command::GetTopics(payload) => as_bytes(GET_TOPICS_CODE, payload.as_bytes()),
+            Command::CreateTopic(payload) => as_bytes(CREATE_TOPIC_CODE, payload.as_bytes()),
+            Command::DeleteTopic(payload) => as_bytes(DELETE_TOPIC_CODE, payload.as_bytes()),
+            Command::UpdateTopic(payload) => as_bytes(UPDATE_TOPIC_CODE, payload.as_bytes()),
+            Command::PurgeTopic(payload) => as_bytes(PURGE_TOPIC_CODE, payload.as_bytes()),
             Command::CreatePartitions(payload) => {
-                as_bytes(CREATE_PARTITIONS_CODE, &payload.as_bytes())
+                as_bytes(CREATE_PARTITIONS_CODE, payload.as_bytes())
             }
             Command::DeletePartitions(payload) => {
-                as_bytes(DELETE_PARTITIONS_CODE, &payload.as_bytes())
+                as_bytes(DELETE_PARTITIONS_CODE, payload.as_bytes())
             }
             Command::GetConsumerGroup(payload) => {
-                as_bytes(GET_CONSUMER_GROUP_CODE, &payload.as_bytes())
+                as_bytes(GET_CONSUMER_GROUP_CODE, payload.as_bytes())
             }
             Command::GetConsumerGroups(payload) => {
-                as_bytes(GET_CONSUMER_GROUPS_CODE, &payload.as_bytes())
+                as_bytes(GET_CONSUMER_GROUPS_CODE, payload.as_bytes())
             }
             Command::CreateConsumerGroup(payload) => {
-                as_bytes(CREATE_CONSUMER_GROUP_CODE, &payload.as_bytes())
+                as_bytes(CREATE_CONSUMER_GROUP_CODE, payload.as_bytes())
             }
             Command::DeleteConsumerGroup(payload) => {
-                as_bytes(DELETE_CONSUMER_GROUP_CODE, &payload.as_bytes())
+                as_bytes(DELETE_CONSUMER_GROUP_CODE, payload.as_bytes())
             }
             Command::JoinConsumerGroup(payload) => {
-                as_bytes(JOIN_CONSUMER_GROUP_CODE, &payload.as_bytes())
+                as_bytes(JOIN_CONSUMER_GROUP_CODE, payload.as_bytes())
             }
             Command::LeaveConsumerGroup(payload) => {
-                as_bytes(LEAVE_CONSUMER_GROUP_CODE, &payload.as_bytes())
+                as_bytes(LEAVE_CONSUMER_GROUP_CODE, payload.as_bytes())
             }
         }
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError> {
         let command = u32::from_le_bytes(bytes[..4].try_into()?);
-        let payload = &bytes[4..];
+        let payload = bytes.slice(4..);
         match command {
             PING_CODE => Ok(Command::Ping(Ping::from_bytes(payload)?)),
             GET_STATS_CODE => Ok(Command::GetStats(GetStats::from_bytes(payload)?)),
@@ -340,11 +340,11 @@ impl BytesSerializable for Command {
     }
 }
 
-fn as_bytes(command: u32, payload: &[u8]) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(4 + payload.len());
+fn as_bytes(command: u32, payload: Bytes) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(4 + payload.len());
     bytes.put_u32_le(command);
     bytes.extend(payload);
-    bytes
+    bytes.freeze()
 }
 
 impl Display for Command {
@@ -661,7 +661,7 @@ mod tests {
         payload: &dyn CommandPayload,
     ) {
         let payload = payload.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + payload.len());
+        let mut bytes = BytesMut::with_capacity(4 + payload.len());
         bytes.put_u32_le(command_id);
         bytes.extend(payload);
         assert_eq!(command.as_bytes(), bytes);
@@ -673,9 +673,10 @@ mod tests {
         payload: &dyn CommandPayload,
     ) {
         let payload = payload.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + payload.len());
+        let mut bytes = BytesMut::with_capacity(4 + payload.len());
         bytes.put_u32_le(command_id);
         bytes.extend(payload);
-        assert_eq!(&Command::from_bytes(&bytes).unwrap(), command);
+        let bytes = Bytes::from(bytes);
+        assert_eq!(&Command::from_bytes(bytes).unwrap(), command);
     }
 }

--- a/sdk/src/consumer.rs
+++ b/sdk/src/consumer.rs
@@ -76,7 +76,7 @@ impl BytesSerializable for Consumer {
         let id_bytes = self.id.as_bytes();
         let mut bytes = BytesMut::with_capacity(1 + id_bytes.len());
         bytes.put_u8(self.kind.as_code());
-        bytes.extend(id_bytes);
+        bytes.put_slice(&id_bytes);
         bytes.freeze()
     }
 

--- a/sdk/src/consumer.rs
+++ b/sdk/src/consumer.rs
@@ -2,7 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::fmt::Display;
@@ -72,15 +72,15 @@ impl Consumer {
 }
 
 impl BytesSerializable for Consumer {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let id_bytes = self.id.as_bytes();
-        let mut bytes = Vec::with_capacity(1 + id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(1 + id_bytes.len());
         bytes.put_u8(self.kind.as_code());
         bytes.extend(id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError>
     where
         Self: Sized,
     {
@@ -89,7 +89,7 @@ impl BytesSerializable for Consumer {
         }
 
         let kind = ConsumerKind::from_code(bytes[0])?;
-        let id = Identifier::from_bytes(&bytes[1..])?;
+        let id = Identifier::from_bytes(bytes.slice(1..))?;
         let consumer = Consumer { kind, id };
         consumer.validate()?;
         Ok(consumer)

--- a/sdk/src/consumer_groups/create_consumer_group.rs
+++ b/sdk/src/consumer_groups/create_consumer_group.rs
@@ -68,12 +68,12 @@ impl BytesSerializable for CreateConsumerGroup {
         let mut bytes = BytesMut::with_capacity(
             4 + stream_id_bytes.len() + topic_id_bytes.len() + self.name.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(self.consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -153,12 +153,12 @@ mod tests {
         let topic_id_bytes = topic_id.as_bytes();
         let mut bytes =
             BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len() + name.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
         let command = CreateConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_groups/create_consumer_group.rs
+++ b/sdk/src/consumer_groups/create_consumer_group.rs
@@ -5,7 +5,7 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -62,29 +62,30 @@ impl Validatable<IggyError> for CreateConsumerGroup {
 }
 
 impl BytesSerializable for CreateConsumerGroup {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes =
-            Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len() + self.name.len());
+        let mut bytes = BytesMut::with_capacity(
+            4 + stream_id_bytes.len() + topic_id_bytes.len() + self.name.len(),
+        );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(self.consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
         bytes.extend(self.name.as_bytes());
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<CreateConsumerGroup, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<CreateConsumerGroup, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
         let consumer_group_id = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let name_length = bytes[position + 4];
@@ -126,9 +127,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
         let consumer_group_id =
             u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
@@ -151,14 +152,14 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let mut bytes =
-            Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len() + name.len());
+            BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len() + name.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
         bytes.extend(name.as_bytes());
-        let command = CreateConsumerGroup::from_bytes(&bytes);
+        let command = CreateConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_groups/create_consumer_group.rs
+++ b/sdk/src/consumer_groups/create_consumer_group.rs
@@ -73,7 +73,7 @@ impl BytesSerializable for CreateConsumerGroup {
         bytes.put_u32_le(self.consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -158,7 +158,7 @@ mod tests {
         bytes.put_u32_le(consumer_group_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
         let command = CreateConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_groups/delete_consumer_group.rs
+++ b/sdk/src/consumer_groups/delete_consumer_group.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -41,9 +41,9 @@ impl BytesSerializable for DeleteConsumerGroup {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         bytes.freeze()
     }
 
@@ -115,9 +115,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         let command = DeleteConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_groups/delete_consumer_group.rs
+++ b/sdk/src/consumer_groups/delete_consumer_group.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -33,30 +34,30 @@ impl Validatable<IggyError> for DeleteConsumerGroup {
 }
 
 impl BytesSerializable for DeleteConsumerGroup {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let consumer_group_id_bytes = self.consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<DeleteConsumerGroup, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<DeleteConsumerGroup, IggyError> {
         if bytes.len() < 9 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..])?;
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = DeleteConsumerGroup {
             stream_id,
             topic_id,
@@ -91,11 +92,11 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -111,13 +112,13 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let consumer_group_id_bytes = consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        let command = DeleteConsumerGroup::from_bytes(&bytes);
+        let command = DeleteConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_groups/get_consumer_group.rs
+++ b/sdk/src/consumer_groups/get_consumer_group.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -33,30 +34,30 @@ impl Validatable<IggyError> for GetConsumerGroup {
 }
 
 impl BytesSerializable for GetConsumerGroup {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let consumer_group_id_bytes = self.consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetConsumerGroup, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetConsumerGroup, IggyError> {
         if bytes.len() < 9 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..])?;
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = GetConsumerGroup {
             stream_id,
             topic_id,
@@ -91,11 +92,11 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -111,13 +112,13 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let consumer_group_id_bytes = consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        let command = GetConsumerGroup::from_bytes(&bytes);
+        let command = GetConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_groups/get_consumer_group.rs
+++ b/sdk/src/consumer_groups/get_consumer_group.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -41,9 +41,9 @@ impl BytesSerializable for GetConsumerGroup {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         bytes.freeze()
     }
 
@@ -115,9 +115,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         let command = GetConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_groups/get_consumer_groups.rs
+++ b/sdk/src/consumer_groups/get_consumer_groups.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -29,24 +30,24 @@ impl Validatable<IggyError> for GetConsumerGroups {
 }
 
 impl BytesSerializable for GetConsumerGroups {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetConsumerGroups, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetConsumerGroups, IggyError> {
         if bytes.len() < 6 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = GetConsumerGroups {
             stream_id,
             topic_id,
@@ -64,6 +65,8 @@ impl Display for GetConsumerGroups {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BufMut;
+
     use super::*;
 
     #[test]
@@ -75,9 +78,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -88,8 +91,10 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let topic_id = Identifier::numeric(2).unwrap();
-        let bytes = [stream_id.as_bytes(), topic_id.as_bytes()].concat();
-        let command = GetConsumerGroups::from_bytes(&bytes);
+        let mut bytes = BytesMut::new();
+        bytes.put(stream_id.as_bytes());
+        bytes.put(topic_id.as_bytes());
+        let command = GetConsumerGroups::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_groups/get_consumer_groups.rs
+++ b/sdk/src/consumer_groups/get_consumer_groups.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -34,8 +34,8 @@ impl BytesSerializable for GetConsumerGroups {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.freeze()
     }
 

--- a/sdk/src/consumer_groups/join_consumer_group.rs
+++ b/sdk/src/consumer_groups/join_consumer_group.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -33,30 +34,30 @@ impl Validatable<IggyError> for JoinConsumerGroup {
 }
 
 impl BytesSerializable for JoinConsumerGroup {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let consumer_group_id_bytes = self.consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<JoinConsumerGroup, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<JoinConsumerGroup, IggyError> {
         if bytes.len() < 9 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..])?;
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = JoinConsumerGroup {
             stream_id,
             topic_id,
@@ -91,11 +92,11 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
-        let consumer_group_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let consumer_group_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -111,13 +112,13 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let consumer_group_id_bytes = consumer_group_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.extend(consumer_group_id_bytes);
-        let command = JoinConsumerGroup::from_bytes(&bytes);
+        let command = JoinConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_groups/join_consumer_group.rs
+++ b/sdk/src/consumer_groups/join_consumer_group.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -41,9 +41,9 @@ impl BytesSerializable for JoinConsumerGroup {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         bytes.freeze()
     }
 
@@ -115,9 +115,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         let command = JoinConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_groups/leave_consumer_group.rs
+++ b/sdk/src/consumer_groups/leave_consumer_group.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -41,9 +41,9 @@ impl BytesSerializable for LeaveConsumerGroup {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         bytes.freeze()
     }
 
@@ -115,9 +115,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             stream_id_bytes.len() + topic_id_bytes.len() + consumer_group_id_bytes.len(),
         );
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
-        bytes.extend(consumer_group_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
+        bytes.put_slice(&consumer_group_id_bytes);
         let command = LeaveConsumerGroup::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/consumer_offsets/get_consumer_offset.rs
+++ b/sdk/src/consumer_offsets/get_consumer_offset.rs
@@ -61,9 +61,9 @@ impl BytesSerializable for GetConsumerOffset {
         let mut bytes = BytesMut::with_capacity(
             4 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         if let Some(partition_id) = self.partition_id {
             bytes.put_u32_le(partition_id);
         } else {
@@ -167,9 +167,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             4 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(partition_id);
 
         let command = GetConsumerOffset::from_bytes(bytes.freeze());

--- a/sdk/src/consumer_offsets/store_consumer_offset.rs
+++ b/sdk/src/consumer_offsets/store_consumer_offset.rs
@@ -4,7 +4,7 @@ use crate::consumer::{Consumer, ConsumerKind};
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -53,11 +53,11 @@ impl Validatable<IggyError> for StoreConsumerOffset {
 }
 
 impl BytesSerializable for StoreConsumerOffset {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let consumer_bytes = self.consumer.as_bytes();
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             12 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
         bytes.extend(consumer_bytes);
@@ -69,25 +69,25 @@ impl BytesSerializable for StoreConsumerOffset {
             bytes.put_u32_le(0);
         }
         bytes.put_u64_le(self.offset);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<StoreConsumerOffset, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<StoreConsumerOffset, IggyError> {
         if bytes.len() < 23 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
         let consumer_kind = ConsumerKind::from_code(bytes[0])?;
-        let consumer_id = Identifier::from_bytes(&bytes[1..])?;
+        let consumer_id = Identifier::from_bytes(bytes.slice(1..))?;
         position += 1 + consumer_id.get_size_bytes() as usize;
         let consumer = Consumer {
             kind: consumer_kind,
             id: consumer_id,
         };
-        let stream_id = Identifier::from_bytes(&bytes[position..])?;
+        let stream_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
         let partition_id = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let partition_id = if partition_id == 0 {
@@ -139,15 +139,15 @@ mod tests {
         let bytes = command.as_bytes();
         let mut position = 0;
         let consumer_kind = ConsumerKind::from_code(bytes[0]).unwrap();
-        let consumer_id = Identifier::from_bytes(&bytes[1..]).unwrap();
+        let consumer_id = Identifier::from_bytes(bytes.slice(1..)).unwrap();
         position += 1 + consumer_id.get_size_bytes() as usize;
         let consumer = Consumer {
             kind: consumer_kind,
             id: consumer_id,
         };
-        let stream_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
         let partition_id = u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
         let offset = u64::from_le_bytes(bytes[position + 4..position + 12].try_into().unwrap());
@@ -171,7 +171,7 @@ mod tests {
         let consumer_bytes = consumer.as_bytes();
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             12 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
         bytes.extend(consumer_bytes);
@@ -180,7 +180,7 @@ mod tests {
         bytes.put_u32_le(partition_id);
         bytes.put_u64_le(offset);
 
-        let command = StoreConsumerOffset::from_bytes(&bytes);
+        let command = StoreConsumerOffset::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/consumer_offsets/store_consumer_offset.rs
+++ b/sdk/src/consumer_offsets/store_consumer_offset.rs
@@ -60,9 +60,9 @@ impl BytesSerializable for StoreConsumerOffset {
         let mut bytes = BytesMut::with_capacity(
             12 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         if let Some(partition_id) = self.partition_id {
             bytes.put_u32_le(partition_id);
         } else {
@@ -174,9 +174,9 @@ mod tests {
         let mut bytes = BytesMut::with_capacity(
             12 + consumer_bytes.len() + stream_id_bytes.len() + topic_id_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(partition_id);
         bytes.put_u64_le(offset);
 

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -1,7 +1,7 @@
 use crate::bytes_serializable::BytesSerializable;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
 use serde_with::serde_as;
@@ -158,15 +158,15 @@ impl Identifier {
 }
 
 impl BytesSerializable for Identifier {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(2 + self.length as usize);
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
         bytes.put_u8(self.kind.as_code());
         bytes.put_u8(self.length);
         bytes.extend(&self.value);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError>
     where
         Self: Sized,
     {

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -162,7 +162,7 @@ impl BytesSerializable for Identifier {
         let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
         bytes.put_u8(self.kind.as_code());
         bytes.put_u8(self.length);
-        bytes.extend(&self.value);
+        bytes.put_slice(&&self.value);
         bytes.freeze()
     }
 

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -162,7 +162,7 @@ impl BytesSerializable for Identifier {
         let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
         bytes.put_u8(self.kind.as_code());
         bytes.put_u8(self.length);
-        bytes.put_slice(&&self.value);
+        bytes.put_slice(&self.value);
         bytes.freeze()
     }
 

--- a/sdk/src/messages/poll_messages.rs
+++ b/sdk/src/messages/poll_messages.rs
@@ -237,15 +237,15 @@ impl BytesSerializable for PollMessages {
                 + topic_id_bytes.len()
                 + strategy_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         if let Some(partition_id) = self.partition_id {
             bytes.put_u32_le(partition_id);
         } else {
             bytes.put_u32_le(0);
         }
-        bytes.extend(strategy_bytes);
+        bytes.put_slice(&strategy_bytes);
         bytes.put_u32_le(self.count);
         if self.auto_commit {
             bytes.put_u8(1);
@@ -423,11 +423,11 @@ mod tests {
                 + topic_id_bytes.len()
                 + strategy_bytes.len(),
         );
-        bytes.extend(consumer_bytes);
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&consumer_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(partition_id);
-        bytes.extend(strategy_bytes);
+        bytes.put_slice(&strategy_bytes);
         bytes.put_u32_le(count);
         bytes.put_u8(auto_commit);
 

--- a/sdk/src/messages/poll_messages.rs
+++ b/sdk/src/messages/poll_messages.rs
@@ -4,7 +4,7 @@ use crate::consumer::{Consumer, ConsumerKind};
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::fmt::Display;
@@ -226,12 +226,12 @@ impl Display for PollingKind {
 }
 
 impl BytesSerializable for PollMessages {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let consumer_bytes = self.consumer.as_bytes();
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let strategy_bytes = self.strategy.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             9 + consumer_bytes.len()
                 + stream_id_bytes.len()
                 + topic_id_bytes.len()
@@ -253,25 +253,25 @@ impl BytesSerializable for PollMessages {
             bytes.put_u8(0);
         }
 
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError> {
         if bytes.len() < 29 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
         let consumer_kind = ConsumerKind::from_code(bytes[0])?;
-        let consumer_id = Identifier::from_bytes(&bytes[1..])?;
+        let consumer_id = Identifier::from_bytes(bytes.slice(1..))?;
         position += 1 + consumer_id.get_size_bytes() as usize;
         let consumer = Consumer {
             kind: consumer_kind,
             id: consumer_id,
         };
-        let stream_id = Identifier::from_bytes(&bytes[position..])?;
+        let stream_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
         let partition_id = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let partition_id = match partition_id {
@@ -333,14 +333,14 @@ fn auto_commit_to_string(auto_commit: bool) -> &'static str {
 }
 
 impl BytesSerializable for PollingStrategy {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(9);
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(9);
         bytes.put_u8(self.kind.as_code());
         bytes.put_u64_le(self.value);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError> {
         if bytes.len() != 9 {
             return Err(IggyError::InvalidCommand);
         }
@@ -371,15 +371,15 @@ mod tests {
         let bytes = command.as_bytes();
         let mut position = 0;
         let consumer_kind = ConsumerKind::from_code(bytes[0]).unwrap();
-        let consumer_id = Identifier::from_bytes(&bytes[1..]).unwrap();
+        let consumer_id = Identifier::from_bytes(bytes.slice(1..)).unwrap();
         position += 1 + consumer_id.get_size_bytes() as usize;
         let consumer = Consumer {
             kind: consumer_kind,
             id: consumer_id,
         };
-        let stream_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
         let partition_id = u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
         let polling_kind = PollingKind::from_code(bytes[position + 4]).unwrap();
@@ -417,7 +417,7 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let strategy_bytes = strategy.as_bytes();
-        let mut bytes = Vec::with_capacity(
+        let mut bytes = BytesMut::with_capacity(
             9 + consumer_bytes.len()
                 + stream_id_bytes.len()
                 + topic_id_bytes.len()
@@ -431,7 +431,7 @@ mod tests {
         bytes.put_u32_le(count);
         bytes.put_u8(auto_commit);
 
-        let command = PollMessages::from_bytes(&bytes);
+        let command = PollMessages::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let auto_commit = matches!(auto_commit, 1);

--- a/sdk/src/messages/send_messages.rs
+++ b/sdk/src/messages/send_messages.rs
@@ -297,7 +297,7 @@ impl BytesSerializable for Partitioning {
         let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
         bytes.put_u8(self.kind.as_code());
         bytes.put_u8(self.length);
-        bytes.put_slice(&&self.value);
+        bytes.put_slice(&self.value);
         bytes.freeze()
     }
 
@@ -331,12 +331,12 @@ impl BytesSerializable for Message {
         if let Some(headers) = &self.headers {
             let headers_bytes = headers.as_bytes();
             bytes.put_u32_le(headers_bytes.len() as u32);
-            bytes.put_slice(&&headers_bytes);
+            bytes.put_slice(&headers_bytes);
         } else {
             bytes.put_u32_le(0);
         }
         bytes.put_u32_le(self.length);
-        bytes.put_slice(&&self.payload);
+        bytes.put_slice(&self.payload);
         bytes.freeze()
     }
 

--- a/sdk/src/models/header.rs
+++ b/sdk/src/models/header.rs
@@ -539,11 +539,11 @@ impl BytesSerializable for HashMap<HeaderKey, HeaderValue> {
         for (key, value) in self {
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(key.0.len() as u32);
-            bytes.extend(key.0.as_bytes());
+            bytes.put_slice(&key.0.as_bytes());
             bytes.put_u8(value.kind.as_code());
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(value.value.len() as u32);
-            bytes.extend(&value.value);
+            bytes.put_slice(&&value.value);
         }
 
         bytes.freeze()
@@ -873,10 +873,10 @@ mod tests {
         let mut bytes = BytesMut::new();
         for (key, value) in &headers {
             bytes.put_u32_le(key.0.len() as u32);
-            bytes.extend(key.0.as_bytes());
+            bytes.put_slice(&key.0.as_bytes());
             bytes.put_u8(value.kind.as_code());
             bytes.put_u32_le(value.value.len() as u32);
-            bytes.extend(&value.value);
+            bytes.put_slice(&&value.value);
         }
 
         let deserialized_headers = HashMap::<HeaderKey, HeaderValue>::from_bytes(bytes.freeze());

--- a/sdk/src/models/header.rs
+++ b/sdk/src/models/header.rs
@@ -539,11 +539,11 @@ impl BytesSerializable for HashMap<HeaderKey, HeaderValue> {
         for (key, value) in self {
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(key.0.len() as u32);
-            bytes.put_slice(&key.0.as_bytes());
+            bytes.put_slice(key.0.as_bytes());
             bytes.put_u8(value.kind.as_code());
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(value.value.len() as u32);
-            bytes.put_slice(&&value.value);
+            bytes.put_slice(&value.value);
         }
 
         bytes.freeze()
@@ -873,10 +873,10 @@ mod tests {
         let mut bytes = BytesMut::new();
         for (key, value) in &headers {
             bytes.put_u32_le(key.0.len() as u32);
-            bytes.put_slice(&key.0.as_bytes());
+            bytes.put_slice(key.0.as_bytes());
             bytes.put_u8(value.kind.as_code());
             bytes.put_u32_le(value.value.len() as u32);
-            bytes.put_slice(&&value.value);
+            bytes.put_slice(&value.value);
         }
 
         let deserialized_headers = HashMap::<HeaderKey, HeaderValue>::from_bytes(bytes.freeze());

--- a/sdk/src/models/messages.rs
+++ b/sdk/src/models/messages.rs
@@ -198,11 +198,11 @@ impl Message {
             let headers_bytes = headers.as_bytes();
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(headers_bytes.len() as u32);
-            bytes.extend(&headers_bytes);
+            bytes.put_slice(&headers_bytes);
         } else {
             bytes.put_u32_le(0u32);
         }
         bytes.put_u32_le(self.length);
-        bytes.extend(&self.payload);
+        bytes.put_slice(&self.payload);
     }
 }

--- a/sdk/src/models/messages.rs
+++ b/sdk/src/models/messages.rs
@@ -5,7 +5,7 @@ use crate::models::header;
 use crate::models::header::{HeaderKey, HeaderValue};
 use crate::sizeable::Sizeable;
 use crate::utils::{checksum, timestamp::IggyTimestamp};
-use bytes::{BufMut, Bytes};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use serde_with::base64::Base64;
 use serde_with::serde_as;
@@ -188,7 +188,7 @@ impl Message {
     }
 
     /// Extends the provided bytes with the message.
-    pub fn extend(&self, bytes: &mut Vec<u8>) {
+    pub fn extend(&self, bytes: &mut BytesMut) {
         bytes.put_u64_le(self.offset);
         bytes.put_u8(self.state.as_code());
         bytes.put_u64_le(self.timestamp);

--- a/sdk/src/models/permissions.rs
+++ b/sdk/src/models/permissions.rs
@@ -1,6 +1,6 @@
 use crate::bytes_serializable::BytesSerializable;
 use crate::error::IggyError;
-use bytes::{Buf, BufMut};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
@@ -194,8 +194,8 @@ impl Display for Permissions {
 }
 
 impl BytesSerializable for Permissions {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::new();
         bytes.put_u8(if self.global.manage_servers { 1 } else { 0 });
         bytes.put_u8(if self.global.read_servers { 1 } else { 0 });
         bytes.put_u8(if self.global.manage_users { 1 } else { 0 });
@@ -248,10 +248,10 @@ impl BytesSerializable for Permissions {
         } else {
             bytes.put_u8(0);
         }
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Self, IggyError>
+    fn from_bytes(bytes: Bytes) -> Result<Self, IggyError>
     where
         Self: Sized,
     {
@@ -404,7 +404,7 @@ mod tests {
         };
 
         let bytes = permissions.as_bytes();
-        let deserialized_permissions = Permissions::from_bytes(&bytes).unwrap();
+        let deserialized_permissions = Permissions::from_bytes(bytes).unwrap();
 
         assert_eq!(permissions, deserialized_permissions);
     }

--- a/sdk/src/partitions/create_partitions.rs
+++ b/sdk/src/partitions/create_partitions.rs
@@ -52,8 +52,8 @@ impl BytesSerializable for CreatePartitions {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(self.partitions_count);
         bytes.freeze()
     }
@@ -125,8 +125,8 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(partitions_count);
         let command = CreatePartitions::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/partitions/create_partitions.rs
+++ b/sdk/src/partitions/create_partitions.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::partitions::MAX_PARTITIONS_COUNT;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -48,25 +48,25 @@ impl Validatable<IggyError> for CreatePartitions {
 }
 
 impl BytesSerializable for CreatePartitions {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(self.partitions_count);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<CreatePartitions, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<CreatePartitions, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
         let partitions_count = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let command = CreatePartitions {
@@ -104,9 +104,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
         let partitions_count =
             u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
@@ -124,11 +124,11 @@ mod tests {
         let partitions_count = 3u32;
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(partitions_count);
-        let command = CreatePartitions::from_bytes(&bytes);
+        let command = CreatePartitions::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/partitions/delete_partitions.rs
+++ b/sdk/src/partitions/delete_partitions.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::partitions::MAX_PARTITIONS_COUNT;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -48,25 +48,25 @@ impl Validatable<IggyError> for DeletePartitions {
 }
 
 impl BytesSerializable for DeletePartitions {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(self.partitions_count);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<DeletePartitions, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<DeletePartitions, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         position += topic_id.get_size_bytes() as usize;
         let partitions_count = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let command = DeletePartitions {
@@ -104,9 +104,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
         position += topic_id.get_size_bytes() as usize;
         let partitions_count =
             u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
@@ -124,11 +124,11 @@ mod tests {
         let partitions_count = 3u32;
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
         bytes.put_u32_le(partitions_count);
-        let command = DeletePartitions::from_bytes(&bytes);
+        let command = DeletePartitions::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/partitions/delete_partitions.rs
+++ b/sdk/src/partitions/delete_partitions.rs
@@ -52,8 +52,8 @@ impl BytesSerializable for DeletePartitions {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(self.partitions_count);
         bytes.freeze()
     }
@@ -125,8 +125,8 @@ mod tests {
         let stream_id_bytes = stream_id.as_bytes();
         let topic_id_bytes = topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(4 + stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(partitions_count);
         let command = DeletePartitions::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/personal_access_tokens/create_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/create_personal_access_token.rs
@@ -54,7 +54,7 @@ impl BytesSerializable for CreatePersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.put_u32_le(self.expiry.unwrap_or(0));
         bytes.freeze()
     }
@@ -125,7 +125,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
         bytes.put_u32_le(expiry);
 
         let command = CreatePersonalAccessToken::from_bytes(bytes.freeze());

--- a/sdk/src/personal_access_tokens/create_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/create_personal_access_token.rs
@@ -54,7 +54,7 @@ impl BytesSerializable for CreatePersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.put_u32_le(self.expiry.unwrap_or(0));
         bytes.freeze()
     }
@@ -125,7 +125,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
         bytes.put_u32_le(expiry);
 
         let command = CreatePersonalAccessToken::from_bytes(bytes.freeze());

--- a/sdk/src/personal_access_tokens/create_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/create_personal_access_token.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::users::defaults::*;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::from_utf8;
@@ -50,22 +50,22 @@ impl Validatable<IggyError> for CreatePersonalAccessToken {
 }
 
 impl BytesSerializable for CreatePersonalAccessToken {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(5 + self.name.len());
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
         bytes.extend(self.name.as_bytes());
         bytes.put_u32_le(self.expiry.unwrap_or(0));
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<CreatePersonalAccessToken, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<CreatePersonalAccessToken, IggyError> {
         if bytes.len() < 8 {
             return Err(IggyError::InvalidCommand);
         }
 
         let name_length = bytes[0];
-        let name = from_utf8(&bytes[1..1 + name_length as usize])?.to_string();
+        let name = from_utf8(&bytes.slice(1..1 + name_length as usize))?.to_string();
         if name.len() != name_length as usize {
             return Err(IggyError::InvalidCommand);
         }
@@ -122,13 +122,13 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let name = "test";
         let expiry = 100;
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
         bytes.extend(name.as_bytes());
         bytes.put_u32_le(expiry);
 
-        let command = CreatePersonalAccessToken::from_bytes(&bytes);
+        let command = CreatePersonalAccessToken::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/personal_access_tokens/delete_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/delete_personal_access_token.rs
@@ -50,7 +50,7 @@ impl BytesSerializable for DeletePersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -100,7 +100,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
 
         let command = DeletePersonalAccessToken::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/personal_access_tokens/delete_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/delete_personal_access_token.rs
@@ -50,7 +50,7 @@ impl BytesSerializable for DeletePersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -100,7 +100,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
 
         let command = DeletePersonalAccessToken::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/personal_access_tokens/get_personal_access_tokens.rs
+++ b/sdk/src/personal_access_tokens/get_personal_access_tokens.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetPersonalAccessTokens {
 }
 
 impl BytesSerializable for GetPersonalAccessTokens {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<GetPersonalAccessTokens, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<GetPersonalAccessTokens, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetPersonalAccessTokens::from_bytes(&bytes);
+        let command = GetPersonalAccessTokens::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetPersonalAccessTokens::from_bytes(&bytes);
+        let command = GetPersonalAccessTokens::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/personal_access_tokens/login_with_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/login_with_personal_access_token.rs
@@ -42,7 +42,7 @@ impl BytesSerializable for LoginWithPersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.token.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.token.len() as u8);
-        bytes.put_slice(&self.token.as_bytes());
+        bytes.put_slice(self.token.as_bytes());
         bytes.freeze()
     }
 
@@ -92,7 +92,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(token.len() as u8);
-        bytes.put_slice(&token.as_bytes());
+        bytes.put_slice(token.as_bytes());
 
         let command = LoginWithPersonalAccessToken::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/personal_access_tokens/login_with_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/login_with_personal_access_token.rs
@@ -42,7 +42,7 @@ impl BytesSerializable for LoginWithPersonalAccessToken {
         let mut bytes = BytesMut::with_capacity(5 + self.token.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.token.len() as u8);
-        bytes.extend(self.token.as_bytes());
+        bytes.put_slice(&self.token.as_bytes());
         bytes.freeze()
     }
 
@@ -92,7 +92,7 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(token.len() as u8);
-        bytes.extend(token.as_bytes());
+        bytes.put_slice(&token.as_bytes());
 
         let command = LoginWithPersonalAccessToken::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/quic/client.rs
+++ b/sdk/src/quic/client.rs
@@ -3,7 +3,7 @@ use crate::client::Client;
 use crate::error::IggyError;
 use crate::quic::config::QuicClientConfig;
 use async_trait::async_trait;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes};
 use quinn::{ClientConfig, Connection, Endpoint, IdleTimeout, RecvStream, VarInt};
 use rustls::client::{ServerCertVerified, ServerCertVerifier};
 use rustls::{Certificate, ServerName};
@@ -16,7 +16,6 @@ use tracing::{error, info, trace};
 
 const REQUEST_INITIAL_BYTES_LENGTH: usize = 4;
 const RESPONSE_INITIAL_BYTES_LENGTH: usize = 8;
-const EMPTY_RESPONSE: Vec<u8> = vec![];
 const NAME: &str = "Iggy";
 
 /// QUIC client for interacting with the Iggy API.
@@ -113,7 +112,7 @@ impl BinaryClient for QuicClient {
         *self.state.lock().await = state;
     }
 
-    async fn send_with_response(&self, command: u32, payload: &[u8]) -> Result<Vec<u8>, IggyError> {
+    async fn send_with_response(&self, command: u32, payload: Bytes) -> Result<Bytes, IggyError> {
         if self.get_state().await == ClientState::Disconnected {
             return Err(IggyError::NotConnected);
         }
@@ -186,7 +185,7 @@ impl QuicClient {
         })
     }
 
-    async fn handle_response(&self, recv: &mut RecvStream) -> Result<Vec<u8>, IggyError> {
+    async fn handle_response(&self, recv: &mut RecvStream) -> Result<Bytes, IggyError> {
         let buffer = recv
             .read_to_end(self.config.response_buffer_size as usize)
             .await?;
@@ -208,13 +207,12 @@ impl QuicClient {
             u32::from_le_bytes(buffer[4..RESPONSE_INITIAL_BYTES_LENGTH].try_into().unwrap());
         trace!("Status: OK. Response length: {}", length);
         if length <= 1 {
-            return Ok(EMPTY_RESPONSE);
+            return Ok(Bytes::new());
         }
 
-        Ok(
-            buffer[RESPONSE_INITIAL_BYTES_LENGTH..RESPONSE_INITIAL_BYTES_LENGTH + length as usize]
-                .to_vec(),
-        )
+        Ok(Bytes::copy_from_slice(
+            &buffer[RESPONSE_INITIAL_BYTES_LENGTH..RESPONSE_INITIAL_BYTES_LENGTH + length as usize],
+        ))
     }
 }
 

--- a/sdk/src/streams/create_stream.rs
+++ b/sdk/src/streams/create_stream.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::streams::MAX_NAME_LENGTH;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -53,16 +53,16 @@ impl Validatable<IggyError> for CreateStream {
 }
 
 impl BytesSerializable for CreateStream {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(5 + self.name.len());
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(5 + self.name.len());
         bytes.put_u32_le(self.stream_id.unwrap_or(0));
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
         bytes.extend(self.name.as_bytes());
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<CreateStream, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<CreateStream, IggyError> {
         if bytes.len() < 6 {
             return Err(IggyError::InvalidCommand);
         }
@@ -116,12 +116,12 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = 1u32;
         let name = "test".to_string();
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.put_u32_le(stream_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
         bytes.extend(name.as_bytes());
-        let command = CreateStream::from_bytes(&bytes);
+        let command = CreateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/streams/create_stream.rs
+++ b/sdk/src/streams/create_stream.rs
@@ -58,7 +58,7 @@ impl BytesSerializable for CreateStream {
         bytes.put_u32_le(self.stream_id.unwrap_or(0));
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -120,7 +120,7 @@ mod tests {
         bytes.put_u32_le(stream_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
         let command = CreateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/streams/create_stream.rs
+++ b/sdk/src/streams/create_stream.rs
@@ -58,7 +58,7 @@ impl BytesSerializable for CreateStream {
         bytes.put_u32_le(self.stream_id.unwrap_or(0));
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -120,7 +120,7 @@ mod tests {
         bytes.put_u32_le(stream_id);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
         let command = CreateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/streams/delete_stream.rs
+++ b/sdk/src/streams/delete_stream.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,11 +26,11 @@ impl Validatable<IggyError> for DeleteStream {
 }
 
 impl BytesSerializable for DeleteStream {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         self.stream_id.as_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<DeleteStream, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<DeleteStream, IggyError> {
         if bytes.len() < 3 {
             return Err(IggyError::InvalidCommand);
         }
@@ -58,7 +59,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -68,7 +69,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let bytes = stream_id.as_bytes();
-        let command = DeleteStream::from_bytes(&bytes);
+        let command = DeleteStream::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/streams/get_stream.rs
+++ b/sdk/src/streams/get_stream.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,11 +26,11 @@ impl Validatable<IggyError> for GetStream {
 }
 
 impl BytesSerializable for GetStream {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         self.stream_id.as_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<GetStream, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<GetStream, IggyError> {
         if bytes.len() < 3 {
             return Err(IggyError::InvalidCommand);
         }
@@ -58,7 +59,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -68,7 +69,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let bytes = stream_id.as_bytes();
-        let command = GetStream::from_bytes(&bytes);
+        let command = GetStream::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/streams/get_streams.rs
+++ b/sdk/src/streams/get_streams.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetStreams {
 }
 
 impl BytesSerializable for GetStreams {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<GetStreams, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<GetStreams, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetStreams::from_bytes(&bytes);
+        let command = GetStreams::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetStreams::from_bytes(&bytes);
+        let command = GetStreams::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/streams/purge_stream.rs
+++ b/sdk/src/streams/purge_stream.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -29,7 +29,7 @@ impl BytesSerializable for PurgeStream {
     fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(stream_id_bytes.len());
-        bytes.extend(stream_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
         bytes.freeze()
     }
 

--- a/sdk/src/streams/purge_stream.rs
+++ b/sdk/src/streams/purge_stream.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,14 +26,14 @@ impl Validatable<IggyError> for PurgeStream {
 }
 
 impl BytesSerializable for PurgeStream {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
-        let mut bytes = Vec::with_capacity(stream_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(stream_id_bytes.len());
         bytes.extend(stream_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<PurgeStream, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<PurgeStream, IggyError> {
         if bytes.len() < 5 {
             return Err(IggyError::InvalidCommand);
         }
@@ -61,7 +62,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -71,7 +72,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let bytes = stream_id.as_bytes();
-        let command = PurgeStream::from_bytes(&bytes);
+        let command = PurgeStream::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/streams/update_stream.rs
+++ b/sdk/src/streams/update_stream.rs
@@ -5,7 +5,7 @@ use crate::identifier::Identifier;
 use crate::streams::MAX_NAME_LENGTH;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -49,23 +49,23 @@ impl Validatable<IggyError> for UpdateStream {
 }
 
 impl BytesSerializable for UpdateStream {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
-        let mut bytes = Vec::with_capacity(1 + stream_id_bytes.len() + self.name.len());
+        let mut bytes = BytesMut::with_capacity(1 + stream_id_bytes.len() + self.name.len());
         bytes.extend(stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
         bytes.extend(self.name.as_bytes());
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<UpdateStream, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<UpdateStream, IggyError> {
         if bytes.len() < 5 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
         let name_length = bytes[position];
         let name =
@@ -99,7 +99,7 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
         let name_length = bytes[position];
         let name = from_utf8(&bytes[position + 1..position + 1 + name_length as usize])
@@ -117,12 +117,12 @@ mod tests {
         let name = "test".to_string();
 
         let stream_id_bytes = stream_id.as_bytes();
-        let mut bytes = Vec::with_capacity(1 + stream_id_bytes.len() + name.len());
+        let mut bytes = BytesMut::with_capacity(1 + stream_id_bytes.len() + name.len());
         bytes.extend(stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
         bytes.extend(name.as_bytes());
-        let command = UpdateStream::from_bytes(&bytes);
+        let command = UpdateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/streams/update_stream.rs
+++ b/sdk/src/streams/update_stream.rs
@@ -55,7 +55,7 @@ impl BytesSerializable for UpdateStream {
         bytes.put_slice(&stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -121,7 +121,7 @@ mod tests {
         bytes.put_slice(&stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
         let command = UpdateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/streams/update_stream.rs
+++ b/sdk/src/streams/update_stream.rs
@@ -52,10 +52,10 @@ impl BytesSerializable for UpdateStream {
     fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(1 + stream_id_bytes.len() + self.name.len());
-        bytes.extend(stream_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -118,10 +118,10 @@ mod tests {
 
         let stream_id_bytes = stream_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(1 + stream_id_bytes.len() + name.len());
-        bytes.extend(stream_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
         let command = UpdateStream::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/system/get_clients.rs
+++ b/sdk/src/system/get_clients.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetClients {
 }
 
 impl BytesSerializable for GetClients {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetClients, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetClients, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetClients::from_bytes(&bytes);
+        let command = GetClients::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetClients::from_bytes(&bytes);
+        let command = GetClients::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/system/get_me.rs
+++ b/sdk/src/system/get_me.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetMe {
 }
 
 impl BytesSerializable for GetMe {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetMe, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetMe, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetMe::from_bytes(&bytes);
+        let command = GetMe::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetMe::from_bytes(&bytes);
+        let command = GetMe::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/system/get_stats.rs
+++ b/sdk/src/system/get_stats.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetStats {
 }
 
 impl BytesSerializable for GetStats {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetStats, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetStats, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetStats::from_bytes(&bytes);
+        let command = GetStats::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetStats::from_bytes(&bytes);
+        let command = GetStats::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/system/ping.rs
+++ b/sdk/src/system/ping.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for Ping {
 }
 
 impl BytesSerializable for Ping {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<Ping, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<Ping, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = Ping::from_bytes(&bytes);
+        let command = Ping::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = Ping::from_bytes(&bytes);
+        let command = Ping::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/tcp/client.rs
+++ b/sdk/src/tcp/client.rs
@@ -3,7 +3,7 @@ use crate::client::Client;
 use crate::error::{IggyError, IggyErrorDiscriminants};
 use crate::tcp::config::TcpClientConfig;
 use async_trait::async_trait;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use std::fmt::Debug;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -19,7 +19,6 @@ use tracing::{error, info};
 
 const REQUEST_INITIAL_BYTES_LENGTH: usize = 4;
 const RESPONSE_INITIAL_BYTES_LENGTH: usize = 8;
-const EMPTY_RESPONSE: Vec<u8> = vec![];
 const NAME: &str = "Iggy";
 
 /// TCP client for interacting with the Iggy API.
@@ -199,7 +198,7 @@ impl BinaryClient for TcpClient {
         *self.state.lock().await = state;
     }
 
-    async fn send_with_response(&self, command: u32, payload: &[u8]) -> Result<Vec<u8>, IggyError> {
+    async fn send_with_response(&self, command: u32, payload: Bytes) -> Result<Bytes, IggyError> {
         if self.get_state().await == ClientState::Disconnected {
             return Err(IggyError::NotConnected);
         }
@@ -270,7 +269,7 @@ impl TcpClient {
         status: u32,
         length: u32,
         stream: &mut dyn ConnectionStream,
-    ) -> Result<Vec<u8>, IggyError> {
+    ) -> Result<Bytes, IggyError> {
         if status != 0 {
             // TEMP: See https://github.com/iggy-rs/iggy/pull/604 for context.
             if status == IggyErrorDiscriminants::TopicIdAlreadyExists as u32
@@ -300,11 +299,12 @@ impl TcpClient {
 
         trace!("Status: OK. Response length: {}", length);
         if length <= 1 {
-            return Ok(EMPTY_RESPONSE);
+            return Ok(Bytes::new());
         }
 
-        let mut response_buffer = vec![0u8; length as usize];
+        let mut response_buffer = BytesMut::with_capacity(length as usize);
+        response_buffer.put_bytes(0, length as usize);
         stream.read(&mut response_buffer).await?;
-        Ok(response_buffer)
+        Ok(response_buffer.freeze())
     }
 }

--- a/sdk/src/topics/create_topic.rs
+++ b/sdk/src/topics/create_topic.rs
@@ -102,7 +102,7 @@ impl BytesSerializable for CreateTopic {
         bytes.put_u8(self.replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -236,7 +236,7 @@ mod tests {
         bytes.put_u8(replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
 
         let command = CreateTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/topics/create_topic.rs
+++ b/sdk/src/topics/create_topic.rs
@@ -6,7 +6,7 @@ use crate::topics::{MAX_NAME_LENGTH, MAX_PARTITIONS_COUNT};
 use crate::utils::byte_size::IggyByteSize;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -85,9 +85,9 @@ impl Validatable<IggyError> for CreateTopic {
 }
 
 impl BytesSerializable for CreateTopic {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
-        let mut bytes = Vec::with_capacity(22 + stream_id_bytes.len() + self.name.len());
+        let mut bytes = BytesMut::with_capacity(22 + stream_id_bytes.len() + self.name.len());
         bytes.extend(stream_id_bytes);
         bytes.put_u32_le(self.topic_id.unwrap_or(0));
         bytes.put_u32_le(self.partitions_count);
@@ -103,15 +103,15 @@ impl BytesSerializable for CreateTopic {
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
         bytes.extend(self.name.as_bytes());
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<CreateTopic, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<CreateTopic, IggyError> {
         if bytes.len() < 18 {
             return Err(IggyError::InvalidCommand);
         }
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
         let topic_id = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
         let topic_id = if topic_id == 0 { None } else { Some(topic_id) };
@@ -185,7 +185,7 @@ mod tests {
         };
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
         let topic_id = u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
         let partitions_count =
@@ -227,7 +227,7 @@ mod tests {
         let max_topic_size = IggyByteSize::from(100);
         let replication_factor = 1;
         let stream_id_bytes = stream_id.as_bytes();
-        let mut bytes = Vec::with_capacity(14 + stream_id_bytes.len() + name.len());
+        let mut bytes = BytesMut::with_capacity(14 + stream_id_bytes.len() + name.len());
         bytes.extend(stream_id_bytes);
         bytes.put_u32_le(topic_id);
         bytes.put_u32_le(partitions_count);
@@ -238,7 +238,7 @@ mod tests {
         bytes.put_u8(name.len() as u8);
         bytes.extend(name.as_bytes());
 
-        let command = CreateTopic::from_bytes(&bytes);
+        let command = CreateTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/topics/create_topic.rs
+++ b/sdk/src/topics/create_topic.rs
@@ -88,7 +88,7 @@ impl BytesSerializable for CreateTopic {
     fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(22 + stream_id_bytes.len() + self.name.len());
-        bytes.extend(stream_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
         bytes.put_u32_le(self.topic_id.unwrap_or(0));
         bytes.put_u32_le(self.partitions_count);
         match self.message_expiry {
@@ -102,7 +102,7 @@ impl BytesSerializable for CreateTopic {
         bytes.put_u8(self.replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -228,7 +228,7 @@ mod tests {
         let replication_factor = 1;
         let stream_id_bytes = stream_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(14 + stream_id_bytes.len() + name.len());
-        bytes.extend(stream_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
         bytes.put_u32_le(topic_id);
         bytes.put_u32_le(partitions_count);
         bytes.put_u32_le(message_expiry);
@@ -236,7 +236,7 @@ mod tests {
         bytes.put_u8(replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
 
         let command = CreateTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/topics/delete_topic.rs
+++ b/sdk/src/topics/delete_topic.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -29,24 +30,24 @@ impl Validatable<IggyError> for DeleteTopic {
 }
 
 impl BytesSerializable for DeleteTopic {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<DeleteTopic, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<DeleteTopic, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = DeleteTopic {
             stream_id,
             topic_id,
@@ -64,6 +65,8 @@ impl Display for DeleteTopic {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BufMut;
+
     use super::*;
 
     #[test]
@@ -75,9 +78,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -88,8 +91,10 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let topic_id = Identifier::numeric(2).unwrap();
-        let bytes = [stream_id.as_bytes(), topic_id.as_bytes()].concat();
-        let command = DeleteTopic::from_bytes(&bytes);
+        let mut bytes = BytesMut::new();
+        bytes.put(stream_id.as_bytes());
+        bytes.put(topic_id.as_bytes());
+        let command = DeleteTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/topics/delete_topic.rs
+++ b/sdk/src/topics/delete_topic.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -34,8 +34,8 @@ impl BytesSerializable for DeleteTopic {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.freeze()
     }
 

--- a/sdk/src/topics/get_topic.rs
+++ b/sdk/src/topics/get_topic.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -29,24 +30,24 @@ impl Validatable<IggyError> for GetTopic {
 }
 
 impl BytesSerializable for GetTopic {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<GetTopic, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<GetTopic, IggyError> {
         if bytes.len() < 6 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = GetTopic {
             stream_id,
             topic_id,
@@ -64,6 +65,8 @@ impl Display for GetTopic {
 
 #[cfg(test)]
 mod tests {
+    use bytes::BufMut;
+
     use super::*;
 
     #[test]
@@ -75,9 +78,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -88,8 +91,10 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let topic_id = Identifier::numeric(2).unwrap();
-        let bytes = [stream_id.as_bytes(), topic_id.as_bytes()].concat();
-        let command = GetTopic::from_bytes(&bytes);
+        let mut bytes = BytesMut::new();
+        bytes.put(stream_id.as_bytes());
+        bytes.put(topic_id.as_bytes());
+        let command = GetTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/topics/get_topic.rs
+++ b/sdk/src/topics/get_topic.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -34,8 +34,8 @@ impl BytesSerializable for GetTopic {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.freeze()
     }
 

--- a/sdk/src/topics/get_topics.rs
+++ b/sdk/src/topics/get_topics.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,11 +26,11 @@ impl Validatable<IggyError> for GetTopics {
 }
 
 impl BytesSerializable for GetTopics {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         self.stream_id.as_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> std::result::Result<GetTopics, IggyError> {
+    fn from_bytes(bytes: Bytes) -> std::result::Result<GetTopics, IggyError> {
         if bytes.len() < 3 {
             return Err(IggyError::InvalidCommand);
         }
@@ -58,7 +59,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -68,7 +69,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let bytes = stream_id.as_bytes();
-        let command = GetTopics::from_bytes(&bytes);
+        let command = GetTopics::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/topics/purge_topic.rs
+++ b/sdk/src/topics/purge_topic.rs
@@ -3,7 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
-use bytes::{Bytes, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -34,8 +34,8 @@ impl BytesSerializable for PurgeTopic {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
         let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.freeze()
     }
 
@@ -90,8 +90,8 @@ mod tests {
         let stream_id = Identifier::numeric(1).unwrap();
         let topic_id = Identifier::numeric(2).unwrap();
         let mut bytes = BytesMut::new();
-        bytes.extend(stream_id.as_bytes());
-        bytes.extend(topic_id.as_bytes());
+        bytes.put_slice(&stream_id.as_bytes());
+        bytes.put_slice(&topic_id.as_bytes());
         let command = PurgeTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/topics/purge_topic.rs
+++ b/sdk/src/topics/purge_topic.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -29,24 +30,24 @@ impl Validatable<IggyError> for PurgeTopic {
 }
 
 impl BytesSerializable for PurgeTopic {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let stream_id_bytes = self.stream_id.as_bytes();
         let topic_id_bytes = self.topic_id.as_bytes();
-        let mut bytes = Vec::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
+        let mut bytes = BytesMut::with_capacity(stream_id_bytes.len() + topic_id_bytes.len());
         bytes.extend(stream_id_bytes);
         bytes.extend(topic_id_bytes);
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<PurgeTopic, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<PurgeTopic, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
 
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(bytes)?;
+        let stream_id = Identifier::from_bytes(bytes.clone())?;
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..])?;
+        let topic_id = Identifier::from_bytes(bytes.slice(position..))?;
         let command = PurgeTopic {
             stream_id,
             topic_id,
@@ -75,9 +76,9 @@ mod tests {
 
         let bytes = command.as_bytes();
         let mut position = 0;
-        let stream_id = Identifier::from_bytes(&bytes).unwrap();
+        let stream_id = Identifier::from_bytes(bytes.clone()).unwrap();
         position += stream_id.get_size_bytes() as usize;
-        let topic_id = Identifier::from_bytes(&bytes[position..]).unwrap();
+        let topic_id = Identifier::from_bytes(bytes.slice(position..)).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(stream_id, command.stream_id);
@@ -88,8 +89,10 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let stream_id = Identifier::numeric(1).unwrap();
         let topic_id = Identifier::numeric(2).unwrap();
-        let bytes = [stream_id.as_bytes(), topic_id.as_bytes()].concat();
-        let command = PurgeTopic::from_bytes(&bytes);
+        let mut bytes = BytesMut::new();
+        bytes.extend(stream_id.as_bytes());
+        bytes.extend(topic_id.as_bytes());
+        let command = PurgeTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/topics/update_topic.rs
+++ b/sdk/src/topics/update_topic.rs
@@ -79,8 +79,8 @@ impl BytesSerializable for UpdateTopic {
         let mut bytes = BytesMut::with_capacity(
             13 + stream_id_bytes.len() + topic_id_bytes.len() + self.name.len(),
         );
-        bytes.extend(stream_id_bytes.clone());
-        bytes.extend(topic_id_bytes.clone());
+        bytes.put_slice(&stream_id_bytes.clone());
+        bytes.put_slice(&topic_id_bytes.clone());
         match self.message_expiry {
             Some(message_expiry) => bytes.put_u32_le(message_expiry),
             None => bytes.put_u32_le(0),
@@ -92,7 +92,7 @@ impl BytesSerializable for UpdateTopic {
         bytes.put_u8(self.replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.extend(self.name.as_bytes());
+        bytes.put_slice(&self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -215,15 +215,15 @@ mod tests {
         let topic_id_bytes = topic_id.as_bytes();
         let mut bytes =
             BytesMut::with_capacity(5 + stream_id_bytes.len() + topic_id_bytes.len() + name.len());
-        bytes.extend(stream_id_bytes);
-        bytes.extend(topic_id_bytes);
+        bytes.put_slice(&stream_id_bytes);
+        bytes.put_slice(&topic_id_bytes);
         bytes.put_u32_le(message_expiry);
         bytes.put_u64_le(max_topic_size.as_bytes_u64());
         bytes.put_u8(replication_factor);
 
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.extend(name.as_bytes());
+        bytes.put_slice(&name.as_bytes());
 
         let command = UpdateTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/topics/update_topic.rs
+++ b/sdk/src/topics/update_topic.rs
@@ -92,7 +92,7 @@ impl BytesSerializable for UpdateTopic {
         bytes.put_u8(self.replication_factor);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.name.len() as u8);
-        bytes.put_slice(&self.name.as_bytes());
+        bytes.put_slice(self.name.as_bytes());
         bytes.freeze()
     }
 
@@ -223,7 +223,7 @@ mod tests {
 
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(name.len() as u8);
-        bytes.put_slice(&name.as_bytes());
+        bytes.put_slice(name.as_bytes());
 
         let command = UpdateTopic::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/users/change_password.rs
+++ b/sdk/src/users/change_password.rs
@@ -64,10 +64,10 @@ impl BytesSerializable for ChangePassword {
         bytes.put_slice(&user_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.current_password.len() as u8);
-        bytes.put_slice(&self.current_password.as_bytes());
+        bytes.put_slice(self.current_password.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.new_password.len() as u8);
-        bytes.put_slice(&self.new_password.as_bytes());
+        bytes.put_slice(self.new_password.as_bytes());
         bytes.freeze()
     }
 
@@ -148,10 +148,10 @@ mod tests {
         bytes.put_slice(&user_id.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(current_password.len() as u8);
-        bytes.put_slice(&current_password.as_bytes());
+        bytes.put_slice(current_password.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(new_password.len() as u8);
-        bytes.put_slice(&new_password.as_bytes());
+        bytes.put_slice(new_password.as_bytes());
 
         let command = ChangePassword::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/users/change_password.rs
+++ b/sdk/src/users/change_password.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::users::defaults::*;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -58,9 +58,9 @@ impl Validatable<IggyError> for ChangePassword {
 }
 
 impl BytesSerializable for ChangePassword {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.current_password.len() as u8);
@@ -68,15 +68,15 @@ impl BytesSerializable for ChangePassword {
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.new_password.len() as u8);
         bytes.extend(self.new_password.as_bytes());
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<ChangePassword, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<ChangePassword, IggyError> {
         if bytes.len() < 9 {
             return Err(IggyError::InvalidCommand);
         }
 
-        let user_id = Identifier::from_bytes(bytes)?;
+        let user_id = Identifier::from_bytes(bytes.clone())?;
         let mut position = user_id.get_size_bytes() as usize;
         let current_password_length = bytes[position];
         position += 1;
@@ -121,7 +121,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let user_id = Identifier::from_bytes(&bytes).unwrap();
+        let user_id = Identifier::from_bytes(bytes.clone()).unwrap();
         let mut position = user_id.get_size_bytes() as usize;
         let current_password_length = bytes[position];
         position += 1;
@@ -144,7 +144,7 @@ mod tests {
         let user_id = Identifier::numeric(1).unwrap();
         let current_password = "secret";
         let new_password = "topsecret";
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(current_password.len() as u8);
@@ -153,7 +153,7 @@ mod tests {
         bytes.put_u8(new_password.len() as u8);
         bytes.extend(new_password.as_bytes());
 
-        let command = ChangePassword::from_bytes(&bytes);
+        let command = ChangePassword::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/users/change_password.rs
+++ b/sdk/src/users/change_password.rs
@@ -61,13 +61,13 @@ impl BytesSerializable for ChangePassword {
     fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id_bytes);
+        bytes.put_slice(&user_id_bytes);
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.current_password.len() as u8);
-        bytes.extend(self.current_password.as_bytes());
+        bytes.put_slice(&self.current_password.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.new_password.len() as u8);
-        bytes.extend(self.new_password.as_bytes());
+        bytes.put_slice(&self.new_password.as_bytes());
         bytes.freeze()
     }
 
@@ -145,13 +145,13 @@ mod tests {
         let current_password = "secret";
         let new_password = "topsecret";
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id.as_bytes());
+        bytes.put_slice(&user_id.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(current_password.len() as u8);
-        bytes.extend(current_password.as_bytes());
+        bytes.put_slice(&current_password.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(new_password.len() as u8);
-        bytes.extend(new_password.as_bytes());
+        bytes.put_slice(&new_password.as_bytes());
 
         let command = ChangePassword::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/users/create_user.rs
+++ b/sdk/src/users/create_user.rs
@@ -6,7 +6,7 @@ use crate::models::user_status::UserStatus;
 use crate::users::defaults::*;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -67,8 +67,8 @@ impl Validatable<IggyError> for CreateUser {
 }
 
 impl BytesSerializable for CreateUser {
-    fn as_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(2 + self.username.len() + self.password.len());
+    fn as_bytes(&self) -> Bytes {
+        let mut bytes = BytesMut::with_capacity(2 + self.username.len() + self.password.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.username.len() as u8);
         bytes.extend(self.username.as_bytes());
@@ -85,10 +85,10 @@ impl BytesSerializable for CreateUser {
         } else {
             bytes.put_u8(0);
         }
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<CreateUser, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<CreateUser, IggyError> {
         if bytes.len() < 10 {
             return Err(IggyError::InvalidCommand);
         }
@@ -121,7 +121,7 @@ impl BytesSerializable for CreateUser {
             let permissions_length = u32::from_le_bytes(bytes[position..position + 4].try_into()?);
             position += 4;
             Some(Permissions::from_bytes(
-                &bytes[position..position + permissions_length as usize],
+                bytes.slice(position..position + permissions_length as usize),
             )?)
         } else {
             None
@@ -198,7 +198,7 @@ mod tests {
             u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
         position += 4;
         let permissions =
-            Permissions::from_bytes(&bytes[position..position + permissions_length as usize])
+            Permissions::from_bytes(bytes.slice(position..position + permissions_length as usize))
                 .unwrap();
 
         assert!(!bytes.is_empty());
@@ -230,7 +230,7 @@ mod tests {
             },
             streams: None,
         };
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(username.len() as u8);
         bytes.extend(username.as_bytes());
@@ -244,7 +244,7 @@ mod tests {
         bytes.put_u32_le(permissions_bytes.len() as u32);
         bytes.extend(permissions_bytes);
 
-        let command = CreateUser::from_bytes(&bytes);
+        let command = CreateUser::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/users/create_user.rs
+++ b/sdk/src/users/create_user.rs
@@ -71,17 +71,17 @@ impl BytesSerializable for CreateUser {
         let mut bytes = BytesMut::with_capacity(2 + self.username.len() + self.password.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.username.len() as u8);
-        bytes.extend(self.username.as_bytes());
+        bytes.put_slice(&self.username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.password.len() as u8);
-        bytes.extend(self.password.as_bytes());
+        bytes.put_slice(&self.password.as_bytes());
         bytes.put_u8(self.status.as_code());
         if let Some(permissions) = &self.permissions {
             bytes.put_u8(1);
             let permissions = permissions.as_bytes();
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u32_le(permissions.len() as u32);
-            bytes.extend(permissions);
+            bytes.put_slice(&permissions);
         } else {
             bytes.put_u8(0);
         }
@@ -233,16 +233,16 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(username.len() as u8);
-        bytes.extend(username.as_bytes());
+        bytes.put_slice(&username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(password.len() as u8);
-        bytes.extend(password.as_bytes());
+        bytes.put_slice(&password.as_bytes());
         bytes.put_u8(status.as_code());
         bytes.put_u8(has_permissions);
         let permissions_bytes = permissions.as_bytes();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u32_le(permissions_bytes.len() as u32);
-        bytes.extend(permissions_bytes);
+        bytes.put_slice(&permissions_bytes);
 
         let command = CreateUser::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/users/create_user.rs
+++ b/sdk/src/users/create_user.rs
@@ -71,10 +71,10 @@ impl BytesSerializable for CreateUser {
         let mut bytes = BytesMut::with_capacity(2 + self.username.len() + self.password.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.username.len() as u8);
-        bytes.put_slice(&self.username.as_bytes());
+        bytes.put_slice(self.username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.password.len() as u8);
-        bytes.put_slice(&self.password.as_bytes());
+        bytes.put_slice(self.password.as_bytes());
         bytes.put_u8(self.status.as_code());
         if let Some(permissions) = &self.permissions {
             bytes.put_u8(1);
@@ -233,10 +233,10 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(username.len() as u8);
-        bytes.put_slice(&username.as_bytes());
+        bytes.put_slice(username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(password.len() as u8);
-        bytes.put_slice(&password.as_bytes());
+        bytes.put_slice(password.as_bytes());
         bytes.put_u8(status.as_code());
         bytes.put_u8(has_permissions);
         let permissions_bytes = permissions.as_bytes();

--- a/sdk/src/users/delete_user.rs
+++ b/sdk/src/users/delete_user.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,11 +26,11 @@ impl Validatable<IggyError> for DeleteUser {
 }
 
 impl BytesSerializable for DeleteUser {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         self.user_id.as_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<DeleteUser, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<DeleteUser, IggyError> {
         if bytes.len() < 3 {
             return Err(IggyError::InvalidCommand);
         }
@@ -58,7 +59,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let user_id = Identifier::from_bytes(&bytes).unwrap();
+        let user_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(user_id, command.user_id);
@@ -68,7 +69,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let user_id = Identifier::numeric(1).unwrap();
         let bytes = user_id.as_bytes();
-        let command = DeleteUser::from_bytes(&bytes);
+        let command = DeleteUser::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/users/get_user.rs
+++ b/sdk/src/users/get_user.rs
@@ -3,6 +3,7 @@ use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -25,11 +26,11 @@ impl Validatable<IggyError> for GetUser {
 }
 
 impl BytesSerializable for GetUser {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         self.user_id.as_bytes()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetUser, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetUser, IggyError> {
         if bytes.len() < 3 {
             return Err(IggyError::InvalidCommand);
         }
@@ -58,7 +59,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let user_id = Identifier::from_bytes(&bytes).unwrap();
+        let user_id = Identifier::from_bytes(bytes.clone()).unwrap();
 
         assert!(!bytes.is_empty());
         assert_eq!(user_id, command.user_id);
@@ -68,7 +69,7 @@ mod tests {
     fn should_be_deserialized_from_bytes() {
         let user_id = Identifier::numeric(1).unwrap();
         let bytes = user_id.as_bytes();
-        let command = GetUser::from_bytes(&bytes);
+        let command = GetUser::from_bytes(bytes);
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/users/get_users.rs
+++ b/sdk/src/users/get_users.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for GetUsers {
 }
 
 impl BytesSerializable for GetUsers {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<GetUsers, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<GetUsers, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -42,6 +43,8 @@ impl Display for GetUsers {
 
 #[cfg(test)]
 mod tests {
+    use bytes::Bytes;
+
     use super::*;
 
     #[test]
@@ -53,15 +56,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = GetUsers::from_bytes(&bytes);
+        let command = GetUsers::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = GetUsers::from_bytes(&bytes);
+        let command = GetUsers::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/users/login_user.rs
+++ b/sdk/src/users/login_user.rs
@@ -61,10 +61,10 @@ impl BytesSerializable for LoginUser {
         let mut bytes = BytesMut::with_capacity(2 + self.username.len() + self.password.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.username.len() as u8);
-        bytes.extend(self.username.as_bytes());
+        bytes.put_slice(&self.username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.password.len() as u8);
-        bytes.extend(self.password.as_bytes());
+        bytes.put_slice(&self.password.as_bytes());
         bytes.freeze()
     }
 
@@ -134,10 +134,10 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(username.len() as u8);
-        bytes.extend(username.as_bytes());
+        bytes.put_slice(&username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(password.len() as u8);
-        bytes.extend(password.as_bytes());
+        bytes.put_slice(&password.as_bytes());
         let command = LoginUser::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/users/login_user.rs
+++ b/sdk/src/users/login_user.rs
@@ -61,10 +61,10 @@ impl BytesSerializable for LoginUser {
         let mut bytes = BytesMut::with_capacity(2 + self.username.len() + self.password.len());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.username.len() as u8);
-        bytes.put_slice(&self.username.as_bytes());
+        bytes.put_slice(self.username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(self.password.len() as u8);
-        bytes.put_slice(&self.password.as_bytes());
+        bytes.put_slice(self.password.as_bytes());
         bytes.freeze()
     }
 
@@ -134,10 +134,10 @@ mod tests {
         let mut bytes = BytesMut::new();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(username.len() as u8);
-        bytes.put_slice(&username.as_bytes());
+        bytes.put_slice(username.as_bytes());
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u8(password.len() as u8);
-        bytes.put_slice(&password.as_bytes());
+        bytes.put_slice(password.as_bytes());
         let command = LoginUser::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 

--- a/sdk/src/users/logout_user.rs
+++ b/sdk/src/users/logout_user.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::CommandPayload;
 use crate::error::IggyError;
 use crate::validatable::Validatable;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -19,11 +20,11 @@ impl Validatable<IggyError> for LogoutUser {
 }
 
 impl BytesSerializable for LogoutUser {
-    fn as_bytes(&self) -> Vec<u8> {
-        Vec::with_capacity(0)
+    fn as_bytes(&self) -> Bytes {
+        Bytes::new()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<LogoutUser, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<LogoutUser, IggyError> {
         if !bytes.is_empty() {
             return Err(IggyError::InvalidCommand);
         }
@@ -53,15 +54,13 @@ mod tests {
 
     #[test]
     fn should_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![];
-        let command = LogoutUser::from_bytes(&bytes);
+        let command = LogoutUser::from_bytes(Bytes::new());
         assert!(command.is_ok());
     }
 
     #[test]
     fn should_not_be_deserialized_from_empty_bytes() {
-        let bytes: Vec<u8> = vec![0];
-        let command = LogoutUser::from_bytes(&bytes);
+        let command = LogoutUser::from_bytes(Bytes::from_static(&[0]));
         assert!(command.is_err());
     }
 }

--- a/sdk/src/users/update_permissions.rs
+++ b/sdk/src/users/update_permissions.rs
@@ -33,11 +33,11 @@ impl BytesSerializable for UpdatePermissions {
     fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id_bytes);
+        bytes.put_slice(&user_id_bytes);
         if let Some(permissions) = &self.permissions {
             bytes.put_u8(1);
             bytes.put_u32_le(permissions.as_bytes().len() as u32);
-            bytes.extend(permissions.as_bytes());
+            bytes.put_slice(&permissions.as_bytes());
         } else {
             bytes.put_u8(0);
         }
@@ -125,10 +125,10 @@ mod tests {
         let permissions = get_permissions();
         let permissions_bytes = permissions.as_bytes();
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id.as_bytes());
+        bytes.put_slice(&user_id.as_bytes());
         bytes.put_u8(1);
         bytes.put_u32_le(permissions_bytes.len() as u32);
-        bytes.extend(permissions_bytes);
+        bytes.put_slice(&permissions_bytes);
 
         let command = UpdatePermissions::from_bytes(bytes.freeze());
         assert!(command.is_ok());

--- a/sdk/src/users/update_permissions.rs
+++ b/sdk/src/users/update_permissions.rs
@@ -4,7 +4,7 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::models::permissions::Permissions;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
@@ -30,9 +30,9 @@ impl Validatable<IggyError> for UpdatePermissions {
 }
 
 impl BytesSerializable for UpdatePermissions {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id_bytes);
         if let Some(permissions) = &self.permissions {
             bytes.put_u8(1);
@@ -42,15 +42,15 @@ impl BytesSerializable for UpdatePermissions {
             bytes.put_u8(0);
         }
 
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<UpdatePermissions, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<UpdatePermissions, IggyError> {
         if bytes.len() < 4 {
             return Err(IggyError::InvalidCommand);
         }
 
-        let user_id = Identifier::from_bytes(bytes)?;
+        let user_id = Identifier::from_bytes(bytes.clone())?;
         let mut position = user_id.get_size_bytes() as usize;
         let has_permissions = bytes[position];
         if has_permissions > 1 {
@@ -62,8 +62,9 @@ impl BytesSerializable for UpdatePermissions {
             let permissions_length =
                 u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
             position += 4;
-            let permissions =
-                Permissions::from_bytes(&bytes[position..position + permissions_length as usize])?;
+            let permissions = Permissions::from_bytes(
+                bytes.slice(position..position + permissions_length as usize),
+            )?;
             Some(permissions)
         } else {
             None
@@ -101,7 +102,7 @@ mod tests {
             permissions: Some(get_permissions()),
         };
         let bytes = command.as_bytes();
-        let user_id = Identifier::from_bytes(&bytes).unwrap();
+        let user_id = Identifier::from_bytes(bytes.clone()).unwrap();
         let mut position = user_id.get_size_bytes() as usize;
         let has_permissions = bytes[position];
         position += 1;
@@ -109,7 +110,7 @@ mod tests {
             u32::from_le_bytes(bytes[position..position + 4].try_into().unwrap());
         position += 4;
         let permissions =
-            Permissions::from_bytes(&bytes[position..position + permissions_length as usize])
+            Permissions::from_bytes(bytes.slice(position..position + permissions_length as usize))
                 .unwrap();
 
         assert!(!bytes.is_empty());
@@ -123,13 +124,13 @@ mod tests {
         let user_id = Identifier::numeric(1).unwrap();
         let permissions = get_permissions();
         let permissions_bytes = permissions.as_bytes();
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id.as_bytes());
         bytes.put_u8(1);
         bytes.put_u32_le(permissions_bytes.len() as u32);
         bytes.extend(permissions_bytes);
 
-        let command = UpdatePermissions::from_bytes(&bytes);
+        let command = UpdatePermissions::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/sdk/src/users/update_user.rs
+++ b/sdk/src/users/update_user.rs
@@ -57,7 +57,7 @@ impl BytesSerializable for UpdateUser {
             bytes.put_u8(1);
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u8(username.len() as u8);
-            bytes.put_slice(&username.as_bytes());
+            bytes.put_slice(username.as_bytes());
         } else {
             bytes.put_u8(0);
         }
@@ -171,7 +171,7 @@ mod tests {
         bytes.put_slice(&user_id.as_bytes());
         bytes.put_u8(1);
         bytes.put_u8(username.len() as u8);
-        bytes.put_slice(&username.as_bytes());
+        bytes.put_slice(username.as_bytes());
         bytes.put_u8(1);
         bytes.put_u8(status.as_code());
 

--- a/sdk/src/users/update_user.rs
+++ b/sdk/src/users/update_user.rs
@@ -52,12 +52,12 @@ impl BytesSerializable for UpdateUser {
     fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id_bytes);
+        bytes.put_slice(&user_id_bytes);
         if let Some(username) = &self.username {
             bytes.put_u8(1);
             #[allow(clippy::cast_possible_truncation)]
             bytes.put_u8(username.len() as u8);
-            bytes.extend(username.as_bytes());
+            bytes.put_slice(&username.as_bytes());
         } else {
             bytes.put_u8(0);
         }
@@ -168,10 +168,10 @@ mod tests {
         let username = "user";
         let status = UserStatus::Active;
         let mut bytes = BytesMut::new();
-        bytes.extend(user_id.as_bytes());
+        bytes.put_slice(&user_id.as_bytes());
         bytes.put_u8(1);
         bytes.put_u8(username.len() as u8);
-        bytes.extend(username.as_bytes());
+        bytes.put_slice(&username.as_bytes());
         bytes.put_u8(1);
         bytes.put_u8(status.as_code());
 

--- a/sdk/src/users/update_user.rs
+++ b/sdk/src/users/update_user.rs
@@ -6,7 +6,7 @@ use crate::models::user_status::UserStatus;
 use crate::users::defaults::*;
 use crate::utils::text;
 use crate::validatable::Validatable;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use std::str::from_utf8;
@@ -49,9 +49,9 @@ impl Validatable<IggyError> for UpdateUser {
 }
 
 impl BytesSerializable for UpdateUser {
-    fn as_bytes(&self) -> Vec<u8> {
+    fn as_bytes(&self) -> Bytes {
         let user_id_bytes = self.user_id.as_bytes();
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id_bytes);
         if let Some(username) = &self.username {
             bytes.put_u8(1);
@@ -68,15 +68,15 @@ impl BytesSerializable for UpdateUser {
             bytes.put_u8(0);
         }
 
-        bytes
+        bytes.freeze()
     }
 
-    fn from_bytes(bytes: &[u8]) -> Result<UpdateUser, IggyError> {
+    fn from_bytes(bytes: Bytes) -> Result<UpdateUser, IggyError> {
         if bytes.len() < 5 {
             return Err(IggyError::InvalidCommand);
         }
 
-        let user_id = Identifier::from_bytes(bytes)?;
+        let user_id = Identifier::from_bytes(bytes.clone())?;
         let mut position = user_id.get_size_bytes() as usize;
         let has_username = bytes[position];
         if has_username > 1 {
@@ -142,7 +142,7 @@ mod tests {
         };
 
         let bytes = command.as_bytes();
-        let user_id = Identifier::from_bytes(&bytes).unwrap();
+        let user_id = Identifier::from_bytes(bytes.clone()).unwrap();
         let mut position = user_id.get_size_bytes() as usize;
         let has_username = bytes[position];
         position += 1;
@@ -167,7 +167,7 @@ mod tests {
         let user_id = Identifier::numeric(1).unwrap();
         let username = "user";
         let status = UserStatus::Active;
-        let mut bytes = Vec::new();
+        let mut bytes = BytesMut::new();
         bytes.extend(user_id.as_bytes());
         bytes.put_u8(1);
         bytes.put_u8(username.len() as u8);
@@ -175,7 +175,7 @@ mod tests {
         bytes.put_u8(1);
         bytes.put_u8(status.as_code());
 
-        let command = UpdateUser::from_bytes(&bytes);
+        let command = UpdateUser::from_bytes(bytes.freeze());
         assert!(command.is_ok());
 
         let command = command.unwrap();

--- a/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
@@ -23,6 +23,6 @@ pub async fn handle(
     )?;
     let consumer_group = consumer_group.read().await;
     let consumer_group = mapper::map_consumer_group(&consumer_group).await;
-    sender.send_ok_response(consumer_group.as_slice()).await?;
+    sender.send_ok_response(&consumer_group).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
@@ -18,6 +18,6 @@ pub async fn handle(
     let consumer_groups =
         system.get_consumer_groups(session, &command.stream_id, &command.topic_id)?;
     let consumer_groups = mapper::map_consumer_groups(&consumer_groups).await;
-    sender.send_ok_response(consumer_groups.as_slice()).await?;
+    sender.send_ok_response(&consumer_groups).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
@@ -19,6 +19,6 @@ pub async fn handle(
         .create_personal_access_token(session, &command.name, command.expiry)
         .await?;
     let bytes = mapper::map_raw_pat(&token);
-    sender.send_ok_response(bytes.as_slice()).await?;
+    sender.send_ok_response(&bytes).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
@@ -16,8 +16,6 @@ pub async fn handle(
     let system = system.read();
     let personal_access_tokens = system.get_personal_access_tokens(session).await?;
     let personal_access_tokens = mapper::map_personal_access_tokens(&personal_access_tokens);
-    sender
-        .send_ok_response(personal_access_tokens.as_slice())
-        .await?;
+    sender.send_ok_response(&personal_access_tokens).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
@@ -19,6 +19,6 @@ pub async fn handle(
         .login_with_personal_access_token(&command.token, Some(session))
         .await?;
     let identity_info = mapper::map_identity_info(user.id);
-    sender.send_ok_response(identity_info.as_slice()).await?;
+    sender.send_ok_response(&identity_info).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/streams/get_streams_handler.rs
+++ b/server/src/binary/handlers/streams/get_streams_handler.rs
@@ -17,6 +17,6 @@ pub async fn handle(
     let system = system.read();
     let streams = system.find_streams(session)?;
     let streams = mapper::map_streams(&streams).await;
-    sender.send_ok_response(streams.as_slice()).await?;
+    sender.send_ok_response(&streams).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/system/get_client_handler.rs
+++ b/server/src/binary/handlers/system/get_client_handler.rs
@@ -22,6 +22,6 @@ pub async fn handle(
             bytes = mapper::map_client(&client).await;
         }
     }
-    sender.send_ok_response(bytes.as_slice()).await?;
+    sender.send_ok_response(&bytes).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/system/get_clients_handler.rs
+++ b/server/src/binary/handlers/system/get_clients_handler.rs
@@ -16,6 +16,6 @@ pub async fn handle(
     let system = system.read();
     let clients = system.get_clients(session).await?;
     let clients = mapper::map_clients(&clients).await;
-    sender.send_ok_response(clients.as_slice()).await?;
+    sender.send_ok_response(&clients).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/system/get_me_handler.rs
+++ b/server/src/binary/handlers/system/get_me_handler.rs
@@ -22,6 +22,6 @@ pub async fn handle(
             bytes = mapper::map_client(&client).await;
         }
     }
-    sender.send_ok_response(bytes.as_slice()).await?;
+    sender.send_ok_response(&bytes).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/system/get_stats_handler.rs
+++ b/server/src/binary/handlers/system/get_stats_handler.rs
@@ -16,6 +16,6 @@ pub async fn handle(
     let system = system.read();
     let stats = system.get_stats(session).await?;
     let bytes = mapper::map_stats(&stats);
-    sender.send_ok_response(bytes.as_slice()).await?;
+    sender.send_ok_response(&bytes).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/users/get_user_handler.rs
+++ b/server/src/binary/handlers/users/get_user_handler.rs
@@ -16,6 +16,6 @@ pub async fn handle(
     let system = system.read();
     let user = system.find_user(session, &command.user_id).await?;
     let bytes = mapper::map_user(&user);
-    sender.send_ok_response(bytes.as_slice()).await?;
+    sender.send_ok_response(&bytes).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/users/get_users_handler.rs
+++ b/server/src/binary/handlers/users/get_users_handler.rs
@@ -16,6 +16,6 @@ pub async fn handle(
     let system = system.read();
     let users = system.get_users(session).await?;
     let users = mapper::map_users(&users);
-    sender.send_ok_response(users.as_slice()).await?;
+    sender.send_ok_response(&users).await?;
     Ok(())
 }

--- a/server/src/binary/handlers/users/login_user_handler.rs
+++ b/server/src/binary/handlers/users/login_user_handler.rs
@@ -19,6 +19,6 @@ pub async fn handle(
         .login_user(&command.username, &command.password, Some(session))
         .await?;
     let identity_info = mapper::map_identity_info(user.id);
-    sender.send_ok_response(identity_info.as_slice()).await?;
+    sender.send_ok_response(&identity_info).await?;
     Ok(())
 }

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -6,7 +6,7 @@ use crate::streaming::streams::stream::Stream;
 use crate::streaming::topics::consumer_group::ConsumerGroup;
 use crate::streaming::topics::topic::Topic;
 use crate::streaming::users::user::User;
-use bytes::BufMut;
+use bytes::{BufMut, Bytes, BytesMut};
 use iggy::bytes_serializable::BytesSerializable;
 use iggy::models::consumer_offset_info::ConsumerOffsetInfo;
 use iggy::models::stats::Stats;
@@ -14,8 +14,8 @@ use iggy::models::user_info::UserId;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub fn map_stats(stats: &Stats) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(104);
+pub fn map_stats(stats: &Stats) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(104);
     bytes.put_u32_le(stats.process_id);
     bytes.put_f32_le(stats.cpu_usage);
     bytes.put_u64_le(stats.memory_usage.as_bytes_u64());
@@ -41,39 +41,39 @@ pub fn map_stats(stats: &Stats) -> Vec<u8> {
     bytes.extend(stats.os_version.as_bytes());
     bytes.put_u32_le(stats.kernel_version.len() as u32);
     bytes.extend(stats.kernel_version.as_bytes());
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_consumer_offset(offset: &ConsumerOffsetInfo) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(20);
+pub fn map_consumer_offset(offset: &ConsumerOffsetInfo) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(20);
     bytes.put_u32_le(offset.partition_id);
     bytes.put_u64_le(offset.current_offset);
     bytes.put_u64_le(offset.stored_offset);
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_client(client: &Client) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_client(client: &Client) -> Bytes {
+    let mut bytes = BytesMut::new();
     extend_client(client, &mut bytes);
     for consumer_group in &client.consumer_groups {
         bytes.put_u32_le(consumer_group.stream_id);
         bytes.put_u32_le(consumer_group.topic_id);
         bytes.put_u32_le(consumer_group.consumer_group_id);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_clients(clients: &[Arc<RwLock<Client>>]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_clients(clients: &[Arc<RwLock<Client>>]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for client in clients {
         let client = client.read().await;
         extend_client(&client, &mut bytes);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_user(user: &User) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub fn map_user(user: &User) -> Bytes {
+    let mut bytes = BytesMut::new();
     extend_user(user, &mut bytes);
     if let Some(permissions) = &user.permissions {
         bytes.put_u8(1);
@@ -84,39 +84,39 @@ pub fn map_user(user: &User) -> Vec<u8> {
     } else {
         bytes.put_u32_le(0);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_users(users: &[User]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub fn map_users(users: &[User]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for user in users {
         extend_user(user, &mut bytes);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_identity_info(user_id: UserId) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(4);
+pub fn map_identity_info(user_id: UserId) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(4);
     bytes.put_u32_le(user_id);
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_raw_pat(token: &str) -> Vec<u8> {
-    let mut bytes = Vec::with_capacity(1 + token.len());
+pub fn map_raw_pat(token: &str) -> Bytes {
+    let mut bytes = BytesMut::with_capacity(1 + token.len());
     bytes.put_u8(token.len() as u8);
     bytes.extend(token.as_bytes());
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_personal_access_tokens(personal_access_tokens: &[PersonalAccessToken]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub fn map_personal_access_tokens(personal_access_tokens: &[PersonalAccessToken]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for personal_access_token in personal_access_tokens {
         extend_pat(personal_access_token, &mut bytes);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub fn map_polled_messages(polled_messages: &PolledMessages) -> Vec<u8> {
+pub fn map_polled_messages(polled_messages: &PolledMessages) -> Bytes {
     let messages_count = polled_messages.messages.len() as u32;
     let messages_size = polled_messages
         .messages
@@ -124,7 +124,7 @@ pub fn map_polled_messages(polled_messages: &PolledMessages) -> Vec<u8> {
         .map(|message| message.get_size_bytes())
         .sum::<u32>();
 
-    let mut bytes = Vec::with_capacity(20 + messages_size as usize);
+    let mut bytes = BytesMut::with_capacity(20 + messages_size as usize);
     bytes.put_u32_le(polled_messages.partition_id);
     bytes.put_u64_le(polled_messages.current_offset);
     bytes.put_u32_le(messages_count);
@@ -132,46 +132,46 @@ pub fn map_polled_messages(polled_messages: &PolledMessages) -> Vec<u8> {
         message.extend(&mut bytes);
     }
 
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_stream(stream: &Stream) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_stream(stream: &Stream) -> Bytes {
+    let mut bytes = BytesMut::new();
     extend_stream(stream, &mut bytes).await;
     for topic in stream.get_topics() {
         extend_topic(topic, &mut bytes).await;
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_streams(streams: &[&Stream]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_streams(streams: &[&Stream]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for stream in streams {
         extend_stream(stream, &mut bytes).await;
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_topics(topics: &[&Topic]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_topics(topics: &[&Topic]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for topic in topics {
         extend_topic(topic, &mut bytes).await;
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_topic(topic: &Topic) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_topic(topic: &Topic) -> Bytes {
+    let mut bytes = BytesMut::new();
     extend_topic(topic, &mut bytes).await;
     for partition in topic.get_partitions() {
         let partition = partition.read().await;
         extend_partition(&partition, &mut bytes);
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_consumer_group(consumer_group: &ConsumerGroup) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_consumer_group(consumer_group: &ConsumerGroup) -> Bytes {
+    let mut bytes = BytesMut::new();
     extend_consumer_group(consumer_group, &mut bytes);
     let members = consumer_group.get_members();
     for member in members {
@@ -183,19 +183,19 @@ pub async fn map_consumer_group(consumer_group: &ConsumerGroup) -> Vec<u8> {
             bytes.put_u32_le(partition);
         }
     }
-    bytes
+    bytes.freeze()
 }
 
-pub async fn map_consumer_groups(consumer_groups: &[&RwLock<ConsumerGroup>]) -> Vec<u8> {
-    let mut bytes = Vec::new();
+pub async fn map_consumer_groups(consumer_groups: &[&RwLock<ConsumerGroup>]) -> Bytes {
+    let mut bytes = BytesMut::new();
     for consumer_group in consumer_groups {
         let consumer_group = consumer_group.read().await;
         extend_consumer_group(&consumer_group, &mut bytes);
     }
-    bytes
+    bytes.freeze()
 }
 
-async fn extend_stream(stream: &Stream, bytes: &mut Vec<u8>) {
+async fn extend_stream(stream: &Stream, bytes: &mut BytesMut) {
     bytes.put_u32_le(stream.stream_id);
     bytes.put_u64_le(stream.created_at);
     bytes.put_u32_le(stream.get_topics().len() as u32);
@@ -205,7 +205,7 @@ async fn extend_stream(stream: &Stream, bytes: &mut Vec<u8>) {
     bytes.extend(stream.name.as_bytes());
 }
 
-async fn extend_topic(topic: &Topic, bytes: &mut Vec<u8>) {
+async fn extend_topic(topic: &Topic, bytes: &mut BytesMut) {
     bytes.put_u32_le(topic.topic_id);
     bytes.put_u64_le(topic.created_at);
     bytes.put_u32_le(topic.get_partitions().len() as u32);
@@ -224,7 +224,7 @@ async fn extend_topic(topic: &Topic, bytes: &mut Vec<u8>) {
     bytes.extend(topic.name.as_bytes());
 }
 
-fn extend_partition(partition: &Partition, bytes: &mut Vec<u8>) {
+fn extend_partition(partition: &Partition, bytes: &mut BytesMut) {
     bytes.put_u32_le(partition.partition_id);
     bytes.put_u64_le(partition.created_at);
     bytes.put_u32_le(partition.get_segments().len() as u32);
@@ -233,7 +233,7 @@ fn extend_partition(partition: &Partition, bytes: &mut Vec<u8>) {
     bytes.put_u64_le(partition.get_messages_count());
 }
 
-fn extend_consumer_group(consumer_group: &ConsumerGroup, bytes: &mut Vec<u8>) {
+fn extend_consumer_group(consumer_group: &ConsumerGroup, bytes: &mut BytesMut) {
     bytes.put_u32_le(consumer_group.consumer_group_id);
     bytes.put_u32_le(consumer_group.partitions_count);
     bytes.put_u32_le(consumer_group.get_members().len() as u32);
@@ -241,7 +241,7 @@ fn extend_consumer_group(consumer_group: &ConsumerGroup, bytes: &mut Vec<u8>) {
     bytes.extend(consumer_group.name.as_bytes());
 }
 
-fn extend_client(client: &Client, bytes: &mut Vec<u8>) {
+fn extend_client(client: &Client, bytes: &mut BytesMut) {
     bytes.put_u32_le(client.client_id);
     bytes.put_u32_le(client.user_id.unwrap_or(0));
     let transport: u8 = match client.transport {
@@ -255,7 +255,7 @@ fn extend_client(client: &Client, bytes: &mut Vec<u8>) {
     bytes.put_u32_le(client.consumer_groups.len() as u32);
 }
 
-fn extend_user(user: &User, bytes: &mut Vec<u8>) {
+fn extend_user(user: &User, bytes: &mut BytesMut) {
     bytes.put_u32_le(user.id);
     bytes.put_u64_le(user.created_at);
     bytes.put_u8(user.status.as_code());
@@ -263,7 +263,7 @@ fn extend_user(user: &User, bytes: &mut Vec<u8>) {
     bytes.extend(user.username.as_bytes());
 }
 
-fn extend_pat(personal_access_token: &PersonalAccessToken, bytes: &mut Vec<u8>) {
+fn extend_pat(personal_access_token: &PersonalAccessToken, bytes: &mut BytesMut) {
     bytes.put_u8(personal_access_token.name.len() as u8);
     bytes.extend(personal_access_token.name.as_bytes());
     bytes.put_u64_le(personal_access_token.expiry.unwrap_or(0));

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -34,13 +34,13 @@ pub fn map_stats(stats: &Stats) -> Bytes {
     bytes.put_u32_le(stats.clients_count);
     bytes.put_u32_le(stats.consumer_groups_count);
     bytes.put_u32_le(stats.hostname.len() as u32);
-    bytes.put_slice(&stats.hostname.as_bytes());
+    bytes.put_slice(stats.hostname.as_bytes());
     bytes.put_u32_le(stats.os_name.len() as u32);
-    bytes.put_slice(&stats.os_name.as_bytes());
+    bytes.put_slice(stats.os_name.as_bytes());
     bytes.put_u32_le(stats.os_version.len() as u32);
-    bytes.put_slice(&stats.os_version.as_bytes());
+    bytes.put_slice(stats.os_version.as_bytes());
     bytes.put_u32_le(stats.kernel_version.len() as u32);
-    bytes.put_slice(&stats.kernel_version.as_bytes());
+    bytes.put_slice(stats.kernel_version.as_bytes());
     bytes.freeze()
 }
 
@@ -104,7 +104,7 @@ pub fn map_identity_info(user_id: UserId) -> Bytes {
 pub fn map_raw_pat(token: &str) -> Bytes {
     let mut bytes = BytesMut::with_capacity(1 + token.len());
     bytes.put_u8(token.len() as u8);
-    bytes.put_slice(&token.as_bytes());
+    bytes.put_slice(token.as_bytes());
     bytes.freeze()
 }
 
@@ -202,7 +202,7 @@ async fn extend_stream(stream: &Stream, bytes: &mut BytesMut) {
     bytes.put_u64_le(stream.get_size().await.as_bytes_u64());
     bytes.put_u64_le(stream.get_messages_count().await);
     bytes.put_u8(stream.name.len() as u8);
-    bytes.put_slice(&stream.name.as_bytes());
+    bytes.put_slice(stream.name.as_bytes());
 }
 
 async fn extend_topic(topic: &Topic, bytes: &mut BytesMut) {
@@ -221,7 +221,7 @@ async fn extend_topic(topic: &Topic, bytes: &mut BytesMut) {
     bytes.put_u64_le(topic.get_size().await.as_bytes_u64());
     bytes.put_u64_le(topic.get_messages_count().await);
     bytes.put_u8(topic.name.len() as u8);
-    bytes.put_slice(&topic.name.as_bytes());
+    bytes.put_slice(topic.name.as_bytes());
 }
 
 fn extend_partition(partition: &Partition, bytes: &mut BytesMut) {
@@ -238,7 +238,7 @@ fn extend_consumer_group(consumer_group: &ConsumerGroup, bytes: &mut BytesMut) {
     bytes.put_u32_le(consumer_group.partitions_count);
     bytes.put_u32_le(consumer_group.get_members().len() as u32);
     bytes.put_u8(consumer_group.name.len() as u8);
-    bytes.put_slice(&consumer_group.name.as_bytes());
+    bytes.put_slice(consumer_group.name.as_bytes());
 }
 
 fn extend_client(client: &Client, bytes: &mut BytesMut) {
@@ -251,7 +251,7 @@ fn extend_client(client: &Client, bytes: &mut BytesMut) {
     bytes.put_u8(transport);
     let address = client.address.to_string();
     bytes.put_u32_le(address.len() as u32);
-    bytes.put_slice(&address.as_bytes());
+    bytes.put_slice(address.as_bytes());
     bytes.put_u32_le(client.consumer_groups.len() as u32);
 }
 
@@ -260,11 +260,11 @@ fn extend_user(user: &User, bytes: &mut BytesMut) {
     bytes.put_u64_le(user.created_at);
     bytes.put_u8(user.status.as_code());
     bytes.put_u8(user.username.len() as u8);
-    bytes.put_slice(&user.username.as_bytes());
+    bytes.put_slice(user.username.as_bytes());
 }
 
 fn extend_pat(personal_access_token: &PersonalAccessToken, bytes: &mut BytesMut) {
     bytes.put_u8(personal_access_token.name.len() as u8);
-    bytes.put_slice(&personal_access_token.name.as_bytes());
+    bytes.put_slice(personal_access_token.name.as_bytes());
     bytes.put_u64_le(personal_access_token.expiry.unwrap_or(0));
 }

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -34,13 +34,13 @@ pub fn map_stats(stats: &Stats) -> Bytes {
     bytes.put_u32_le(stats.clients_count);
     bytes.put_u32_le(stats.consumer_groups_count);
     bytes.put_u32_le(stats.hostname.len() as u32);
-    bytes.extend(stats.hostname.as_bytes());
+    bytes.put_slice(&stats.hostname.as_bytes());
     bytes.put_u32_le(stats.os_name.len() as u32);
-    bytes.extend(stats.os_name.as_bytes());
+    bytes.put_slice(&stats.os_name.as_bytes());
     bytes.put_u32_le(stats.os_version.len() as u32);
-    bytes.extend(stats.os_version.as_bytes());
+    bytes.put_slice(&stats.os_version.as_bytes());
     bytes.put_u32_le(stats.kernel_version.len() as u32);
-    bytes.extend(stats.kernel_version.as_bytes());
+    bytes.put_slice(&stats.kernel_version.as_bytes());
     bytes.freeze()
 }
 
@@ -80,7 +80,7 @@ pub fn map_user(user: &User) -> Bytes {
         let permissions = permissions.as_bytes();
         #[allow(clippy::cast_possible_truncation)]
         bytes.put_u32_le(permissions.len() as u32);
-        bytes.extend(permissions);
+        bytes.put_slice(&permissions);
     } else {
         bytes.put_u32_le(0);
     }
@@ -104,7 +104,7 @@ pub fn map_identity_info(user_id: UserId) -> Bytes {
 pub fn map_raw_pat(token: &str) -> Bytes {
     let mut bytes = BytesMut::with_capacity(1 + token.len());
     bytes.put_u8(token.len() as u8);
-    bytes.extend(token.as_bytes());
+    bytes.put_slice(&token.as_bytes());
     bytes.freeze()
 }
 
@@ -202,7 +202,7 @@ async fn extend_stream(stream: &Stream, bytes: &mut BytesMut) {
     bytes.put_u64_le(stream.get_size().await.as_bytes_u64());
     bytes.put_u64_le(stream.get_messages_count().await);
     bytes.put_u8(stream.name.len() as u8);
-    bytes.extend(stream.name.as_bytes());
+    bytes.put_slice(&stream.name.as_bytes());
 }
 
 async fn extend_topic(topic: &Topic, bytes: &mut BytesMut) {
@@ -221,7 +221,7 @@ async fn extend_topic(topic: &Topic, bytes: &mut BytesMut) {
     bytes.put_u64_le(topic.get_size().await.as_bytes_u64());
     bytes.put_u64_le(topic.get_messages_count().await);
     bytes.put_u8(topic.name.len() as u8);
-    bytes.extend(topic.name.as_bytes());
+    bytes.put_slice(&topic.name.as_bytes());
 }
 
 fn extend_partition(partition: &Partition, bytes: &mut BytesMut) {
@@ -238,7 +238,7 @@ fn extend_consumer_group(consumer_group: &ConsumerGroup, bytes: &mut BytesMut) {
     bytes.put_u32_le(consumer_group.partitions_count);
     bytes.put_u32_le(consumer_group.get_members().len() as u32);
     bytes.put_u8(consumer_group.name.len() as u8);
-    bytes.extend(consumer_group.name.as_bytes());
+    bytes.put_slice(&consumer_group.name.as_bytes());
 }
 
 fn extend_client(client: &Client, bytes: &mut BytesMut) {
@@ -251,7 +251,7 @@ fn extend_client(client: &Client, bytes: &mut BytesMut) {
     bytes.put_u8(transport);
     let address = client.address.to_string();
     bytes.put_u32_le(address.len() as u32);
-    bytes.extend(address.as_bytes());
+    bytes.put_slice(&address.as_bytes());
     bytes.put_u32_le(client.consumer_groups.len() as u32);
 }
 
@@ -260,11 +260,11 @@ fn extend_user(user: &User, bytes: &mut BytesMut) {
     bytes.put_u64_le(user.created_at);
     bytes.put_u8(user.status.as_code());
     bytes.put_u8(user.username.len() as u8);
-    bytes.extend(user.username.as_bytes());
+    bytes.put_slice(&user.username.as_bytes());
 }
 
 fn extend_pat(personal_access_token: &PersonalAccessToken, bytes: &mut BytesMut) {
     bytes.put_u8(personal_access_token.name.len() as u8);
-    bytes.extend(personal_access_token.name.as_bytes());
+    bytes.put_slice(&personal_access_token.name.as_bytes());
     bytes.put_u64_le(personal_access_token.expiry.unwrap_or(0));
 }


### PR DESCRIPTION
When using &[u8], it's hard to avoid memory copying due to lifetime issues. Replacing &[u8] with Bytes can effectively reduce memory copying.
