### PR TITLE
Refactor tests to use IggyCmdTest::help_message for help tests

### DIFF
--- a/integration/tests/cli/client/test_client_get_command.rs
+++ b/integration/tests/cli/client/test_client_get_command.rs
@@ -67,7 +67,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/client/test_client_list_command.rs
+++ b/integration/tests/cli/client/test_client_list_command.rs
@@ -75,7 +75,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -81,9 +81,11 @@ pub(crate) struct IggyCmdTest {
 }
 
 impl IggyCmdTest {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(start_server: bool) -> Self {
         let mut server = TestServer::default();
-        server.start();
+        if start_server {
+            server.start();
+        }
         let tcp_client_config = TcpClientConfig {
             server_address: server.get_raw_tcp_addr().unwrap(),
             ..TcpClientConfig::default()
@@ -92,6 +94,10 @@ impl IggyCmdTest {
         let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
 
         Self { server, client }
+    }
+
+    pub(crate) fn help_message() -> Self {
+        Self::new(false)
     }
 
     pub(crate) async fn setup(&mut self) {
@@ -232,6 +238,6 @@ impl IggyCmdTest {
 
 impl Default for IggyCmdTest {
     fn default() -> Self {
-        Self::new()
+        Self::new(true)
     }
 }

--- a/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_create_command.rs
@@ -205,7 +205,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(
@@ -253,7 +253,7 @@ Options:
 #[tokio::test]
 #[parallel]
 pub async fn should_short_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_delete_command.rs
@@ -234,7 +234,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_get_command.rs
@@ -245,7 +245,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/consumer_group/test_consumer_group_help_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
+++ b/integration/tests/cli/consumer_group/test_consumer_group_list_command.rs
@@ -242,7 +242,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/general/test_help_command.rs
+++ b/integration/tests/cli/general/test_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/general/test_overview_command.rs
+++ b/integration/tests/cli/general/test_overview_command.rs
@@ -7,7 +7,7 @@ const FIGLET_FILL: &str = "                         ";
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
     let no_arg: Vec<String> = vec![];
 
     iggy_cmd_test

--- a/integration/tests/cli/message/test_message_help_command.rs
+++ b/integration/tests/cli/message/test_message_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/message/test_message_poll_command.rs
+++ b/integration/tests/cli/message/test_message_poll_command.rs
@@ -295,7 +295,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/message/test_message_send_command.rs
+++ b/integration/tests/cli/message/test_message_send_command.rs
@@ -338,7 +338,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/partition/test_partition_create_command.rs
+++ b/integration/tests/cli/partition/test_partition_create_command.rs
@@ -213,7 +213,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/partition/test_partition_delete_command.rs
+++ b/integration/tests/cli/partition/test_partition_delete_command.rs
@@ -217,7 +217,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/partition/test_partition_help_command.rs
+++ b/integration/tests/cli/partition/test_partition_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/personal_access_token/test_pat_create_command.rs
+++ b/integration/tests/cli/personal_access_token/test_pat_create_command.rs
@@ -111,7 +111,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/personal_access_token/test_pat_delete_command.rs
+++ b/integration/tests/cli/personal_access_token/test_pat_delete_command.rs
@@ -78,7 +78,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/personal_access_token/test_pat_help_command.rs
+++ b/integration/tests/cli/personal_access_token/test_pat_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/personal_access_token/test_pat_list_command.rs
+++ b/integration/tests/cli/personal_access_token/test_pat_list_command.rs
@@ -100,7 +100,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_create_command.rs
+++ b/integration/tests/cli/stream/test_stream_create_command.rs
@@ -98,7 +98,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_delete_command.rs
+++ b/integration/tests/cli/stream/test_stream_delete_command.rs
@@ -101,7 +101,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_get_command.rs
+++ b/integration/tests/cli/stream/test_stream_get_command.rs
@@ -99,7 +99,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_help_command.rs
+++ b/integration/tests/cli/stream/test_stream_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_list_command.rs
+++ b/integration/tests/cli/stream/test_stream_list_command.rs
@@ -94,7 +94,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_purge_command.rs
+++ b/integration/tests/cli/stream/test_stream_purge_command.rs
@@ -157,7 +157,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/stream/test_stream_update_command.rs
+++ b/integration/tests/cli/stream/test_stream_update_command.rs
@@ -105,7 +105,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/system/test_me_command.rs
+++ b/integration/tests/cli/system/test_me_command.rs
@@ -116,7 +116,7 @@ pub async fn should_be_successful_using_transport_quic() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(
@@ -140,7 +140,7 @@ Options:
 #[tokio::test]
 #[parallel]
 pub async fn should_short_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/system/test_ping_command.rs
+++ b/integration/tests/cli/system/test_ping_command.rs
@@ -61,7 +61,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/system/test_stats_command.rs
+++ b/integration/tests/cli/system/test_stats_command.rs
@@ -67,7 +67,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_create_command.rs
+++ b/integration/tests/cli/topic/test_topic_create_command.rs
@@ -245,7 +245,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_delete_command.rs
+++ b/integration/tests/cli/topic/test_topic_delete_command.rs
@@ -170,7 +170,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_get_command.rs
+++ b/integration/tests/cli/topic/test_topic_get_command.rs
@@ -188,7 +188,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_help_command.rs
+++ b/integration/tests/cli/topic/test_topic_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_list_command.rs
+++ b/integration/tests/cli/topic/test_topic_list_command.rs
@@ -159,7 +159,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_purge_command.rs
+++ b/integration/tests/cli/topic/test_topic_purge_command.rs
@@ -212,7 +212,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/topic/test_topic_update_command.rs
+++ b/integration/tests/cli/topic/test_topic_update_command.rs
@@ -344,7 +344,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_create_command.rs
+++ b/integration/tests/cli/user/test_user_create_command.rs
@@ -257,7 +257,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_delete_command.rs
+++ b/integration/tests/cli/user/test_user_delete_command.rs
@@ -118,7 +118,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_get_command.rs
+++ b/integration/tests/cli/user/test_user_get_command.rs
@@ -234,7 +234,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_help_command.rs
+++ b/integration/tests/cli/user/test_user_help_command.rs
@@ -4,7 +4,7 @@ use serial_test::parallel;
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_list_command.rs
+++ b/integration/tests/cli/user/test_user_list_command.rs
@@ -96,7 +96,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_name_command.rs
+++ b/integration/tests/cli/user/test_user_name_command.rs
@@ -124,7 +124,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_password_command.rs
+++ b/integration/tests/cli/user/test_user_password_command.rs
@@ -175,7 +175,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_permissions_command.rs
+++ b/integration/tests/cli/user/test_user_permissions_command.rs
@@ -225,7 +225,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(

--- a/integration/tests/cli/user/test_user_status_command.rs
+++ b/integration/tests/cli/user/test_user_status_command.rs
@@ -143,7 +143,7 @@ pub async fn should_be_successful() {
 #[tokio::test]
 #[parallel]
 pub async fn should_help_match() {
-    let mut iggy_cmd_test = IggyCmdTest::default();
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
 
     iggy_cmd_test
         .execute_test_for_help_command(TestHelpCmd::new(


### PR DESCRIPTION
This commit updates the integration tests to use the new
IggyCmdTest::help_message method instead of the default constructor
when initializing IggyCmdTest instances for help command tests. This
change ensures that the server is not started unnecessarily, which
optimizes the test setup for help command scenarios.
