### PR TITLE
Add consumer offset management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -897,7 +897,7 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "cli"
-version = "0.17.1"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cli/src/args/consumer_offset.rs
+++ b/cli/src/args/consumer_offset.rs
@@ -1,0 +1,87 @@
+use clap::{Args, Subcommand};
+use iggy::identifier::Identifier;
+
+#[derive(Debug, Clone, Subcommand)]
+pub(crate) enum ConsumerOffsetAction {
+    /// Retrieve the offset of a consumer for a given partition from the server
+    ///
+    /// Consumer ID can be specified as a consumer name or ID
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-offset get 1 3 5 1
+    ///  iggy consumer-offset get consumer stream 5 1
+    ///  iggy consumer-offset get 1 3 topic 1
+    ///  iggy consumer-offset get consumer stream 5 1
+    ///  iggy consumer-offset get consumer 3 topic 1
+    ///  iggy consumer-offset get 1 stream topic 1
+    ///  iggy consumer-offset get consumer stream topic 1
+    #[clap(verbatim_doc_comment, visible_alias = "g")]
+    Get(ConsumerOffsetGetArgs),
+    /// Set the offset of a consumer for a given partition on the server
+    ///
+    /// Consumer ID can be specified as a consumer name or ID
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples:
+    ///  iggy consumer-offset set 1 3 5 1 100
+    ///  iggy consumer-offset set consumer 3 5 1 100
+    ///  iggy consumer-offset set 1 stream 5 1 100
+    ///  iggy consumer-offset set 1 3 topic 1 100
+    ///  iggy consumer-offset set consumer stream 5 1 100
+    ///  iggy consumer-offset set consumer 3 topic 1 100
+    ///  iggy consumer-offset set 1 stream topic 1 100
+    ///  iggy consumer-offset set consumer stream topic 1 100
+    #[clap(verbatim_doc_comment, visible_alias = "s")]
+    Set(ConsumerOffsetSetArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerOffsetGetArgs {
+    /// Regular consumer for which the offset is retrieved
+    ///
+    /// Consumer ID can be specified as a consumer name or ID
+    #[clap(verbatim_doc_comment)]
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) consumer_id: Identifier,
+    /// Stream ID for which consumer offset is retrieved
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID for which consumer offset is retrieved
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Partitions ID for which consumer offset is retrieved
+    #[arg(value_parser = clap::value_parser!(u32).range(1..))]
+    pub(crate) partition_id: u32,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct ConsumerOffsetSetArgs {
+    /// Regular consumer for which the offset is set
+    ///
+    /// Consumer ID can be specified as a consumer name or ID
+    #[clap(verbatim_doc_comment)]
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) consumer_id: Identifier,
+    /// Stream ID for which consumer offset is set
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// Topic ID for which consumer offset is set
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Partitions ID for which consumer offset is set
+    #[arg(value_parser = clap::value_parser!(u32).range(1..))]
+    pub(crate) partition_id: u32,
+    /// Offset to set
+    pub(crate) offset: u64,
+}

--- a/cli/src/args/mod.rs
+++ b/cli/src/args/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod client;
 pub(crate) mod common;
 pub(crate) mod consumer_group;
+pub(crate) mod consumer_offset;
 pub(crate) mod message;
 pub(crate) mod partition;
 pub(crate) mod permissions;
@@ -12,9 +13,10 @@ pub(crate) mod user;
 
 use self::user::UserAction;
 use crate::args::{
-    client::ClientAction, consumer_group::ConsumerGroupAction, message::MessageAction,
-    partition::PartitionAction, personal_access_token::PersonalAccessTokenAction,
-    stream::StreamAction, system::PingArgs, topic::TopicAction,
+    client::ClientAction, consumer_group::ConsumerGroupAction,
+    consumer_offset::ConsumerOffsetAction, message::MessageAction, partition::PartitionAction,
+    personal_access_token::PersonalAccessTokenAction, stream::StreamAction, system::PingArgs,
+    topic::TopicAction,
 };
 use clap::{Args, Command as ClapCommand};
 use clap::{Parser, Subcommand};
@@ -125,6 +127,9 @@ pub(crate) enum Command {
     /// consumer group operations
     #[command(subcommand, visible_alias = "g")]
     ConsumerGroup(ConsumerGroupAction),
+    /// consumer offset operations
+    #[command(subcommand, visible_alias = "o")]
+    ConsumerOffset(ConsumerOffsetAction),
     /// message operations
     #[command(subcommand, visible_alias = "m")]
     Message(MessageAction),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,8 @@ mod error;
 mod logging;
 
 use crate::args::{
-    client::ClientAction, consumer_group::ConsumerGroupAction, permissions::PermissionsArgs,
+    client::ClientAction, consumer_group::ConsumerGroupAction,
+    consumer_offset::ConsumerOffsetAction, permissions::PermissionsArgs,
     personal_access_token::PersonalAccessTokenAction, stream::StreamAction, topic::TopicAction,
     Command, IggyConsoleArgs,
 };
@@ -21,6 +22,9 @@ use iggy::cli::{
         create_consumer_group::CreateConsumerGroupCmd,
         delete_consumer_group::DeleteConsumerGroupCmd, get_consumer_group::GetConsumerGroupCmd,
         get_consumer_groups::GetConsumerGroupsCmd,
+    },
+    consumer_offset::{
+        get_consumer_offset::GetConsumerOffsetCmd, set_consumer_offset::SetConsumerOffsetCmd,
     },
     message::{poll_messages::PollMessagesCmd, send_messages::SendMessagesCmd},
     partitions::{create_partitions::CreatePartitionsCmd, delete_partitions::DeletePartitionsCmd},
@@ -228,6 +232,21 @@ fn get_command(command: Command, args: &IggyConsoleArgs) -> Box<dyn CliCommand> 
                 poll_args.last,
                 poll_args.next,
                 poll_args.consumer.clone(),
+            )),
+        },
+        Command::ConsumerOffset(command) => match command {
+            ConsumerOffsetAction::Get(get_args) => Box::new(GetConsumerOffsetCmd::new(
+                get_args.consumer_id.clone(),
+                get_args.stream_id.clone(),
+                get_args.topic_id.clone(),
+                get_args.partition_id,
+            )),
+            ConsumerOffsetAction::Set(set_args) => Box::new(SetConsumerOffsetCmd::new(
+                set_args.consumer_id.clone(),
+                set_args.stream_id.clone(),
+                set_args.topic_id.clone(),
+                set_args.partition_id,
+                set_args.offset,
             )),
         },
     }

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -32,6 +32,8 @@ pub(crate) type TestUserId = TestIdentifier;
 
 pub(crate) type TestConsumerGroupId = TestIdentifier;
 
+pub(crate) type TestConsumerId = TestIdentifier;
+
 pub(crate) enum OutputFormat {
     Default,
     List,

--- a/integration/tests/cli/consumer_offset/mod.rs
+++ b/integration/tests/cli/consumer_offset/mod.rs
@@ -1,0 +1,2 @@
+mod test_consumer_offset_get_command;
+mod test_consumer_offset_set_command;

--- a/integration/tests/cli/consumer_offset/test_consumer_offset_get_command.rs
+++ b/integration/tests/cli/consumer_offset/test_consumer_offset_get_command.rs
@@ -1,0 +1,355 @@
+use crate::cli::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestConsumerId, TestHelpCmd, TestStreamId,
+    TestTopicId, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::consumer::{Consumer, ConsumerKind};
+use iggy::consumer_offsets::store_consumer_offset::StoreConsumerOffset;
+use iggy::identifier::Identifier;
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use predicates::str::{contains, starts_with};
+use serial_test::parallel;
+use std::str::FromStr;
+
+struct TestConsumerOffsetGetCmd {
+    consumer_id: u32,
+    consumer_name: String,
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    partition_id: u32,
+    using_consumer_id: TestConsumerId,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    messages_count: u32,
+    stored_offset: u64,
+}
+
+impl TestConsumerOffsetGetCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        consumer_id: u32,
+        consumer_name: String,
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        partition_id: u32,
+        using_consumer_id: TestConsumerId,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+    ) -> Self {
+        Self {
+            consumer_id,
+            consumer_name,
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            partition_id,
+            using_consumer_id,
+            using_stream_id,
+            using_topic_id,
+            messages_count: 100,
+            stored_offset: 66,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_consumer_id {
+            TestStreamId::Numeric => vec![format!("{}", self.consumer_id)],
+            TestStreamId::Named => vec![self.consumer_name.clone()],
+        };
+
+        command.push(match self.using_stream_id {
+            TestTopicId::Numeric => format!("{}", self.stream_id),
+            TestTopicId::Named => self.stream_name.clone(),
+        });
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(format!("{}", self.partition_id));
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerOffsetGetCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: Some(self.stream_id),
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Some(self.topic_id),
+                partitions_count: 1,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let messages = (1..=self.messages_count)
+            .filter_map(|id| Message::from_str(format!("Test message {id}").as_str()).ok())
+            .collect::<Vec<_>>();
+
+        let send_status = client
+            .send_messages(&mut SendMessages {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partitioning: Partitioning::partition_id(self.partition_id),
+                messages,
+            })
+            .await;
+        assert!(send_status.is_ok());
+
+        let offset = client
+            .store_consumer_offset(&StoreConsumerOffset {
+                consumer: Consumer {
+                    kind: ConsumerKind::Consumer,
+                    id: match self.using_consumer_id {
+                        TestConsumerId::Numeric => Identifier::numeric(self.consumer_id),
+                        TestConsumerId::Named => Identifier::named(self.consumer_name.as_str()),
+                    }
+                    .unwrap(),
+                },
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partition_id: Some(self.partition_id),
+                offset: self.stored_offset,
+            })
+            .await;
+        assert!(offset.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-offset")
+            .arg("get")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let consumer_id = match self.using_consumer_id {
+            TestConsumerId::Numeric => format!("{}", self.consumer_id),
+            TestConsumerId::Named => self.consumer_name.clone(),
+        };
+
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let message = format!(
+            "Executing get consumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {}",
+            consumer_id,
+            stream_id,
+            topic_id,
+            self.partition_id,
+        );
+
+        command_state
+            .success()
+            .stdout(starts_with(message))
+            .stdout(contains(format!("Stored offset  | {}", self.stored_offset)))
+            .stdout(contains(format!(
+                "Current offset | {}",
+                self.messages_count - 1
+            )));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters = vec![
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, using_consumer_id) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestConsumerOffsetGetCmd::new(
+                1,
+                String::from("consumer"),
+                2,
+                String::from("stream"),
+                3,
+                String::from("topic"),
+                1,
+                using_consumer_id,
+                using_stream_id,
+                using_topic_id,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-offset", "get", "--help"],
+            format!(
+                r#"Retrieve the offset of a consumer for a given partition from the server
+
+Consumer ID can be specified as a consumer name or ID
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples:
+ iggy consumer-offset get 1 3 5 1
+ iggy consumer-offset get consumer stream 5 1
+ iggy consumer-offset get 1 3 topic 1
+ iggy consumer-offset get consumer stream 5 1
+ iggy consumer-offset get consumer 3 topic 1
+ iggy consumer-offset get 1 stream topic 1
+ iggy consumer-offset get consumer stream topic 1
+
+{USAGE_PREFIX} consumer-offset get <CONSUMER_ID> <STREAM_ID> <TOPIC_ID> <PARTITION_ID>
+
+Arguments:
+  <CONSUMER_ID>
+          Regular consumer for which the offset is retrieved
+{CLAP_INDENT}
+          Consumer ID can be specified as a consumer name or ID
+
+  <STREAM_ID>
+          Stream ID for which consumer offset is retrieved
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID for which consumer offset is retrieved
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <PARTITION_ID>
+          Partitions ID for which consumer offset is retrieved
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-offset", "get", "-h"],
+            format!(
+                r#"Retrieve the offset of a consumer for a given partition from the server
+
+{USAGE_PREFIX} consumer-offset get <CONSUMER_ID> <STREAM_ID> <TOPIC_ID> <PARTITION_ID>
+
+Arguments:
+  <CONSUMER_ID>   Regular consumer for which the offset is retrieved
+  <STREAM_ID>     Stream ID for which consumer offset is retrieved
+  <TOPIC_ID>      Topic ID for which consumer offset is retrieved
+  <PARTITION_ID>  Partitions ID for which consumer offset is retrieved
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/consumer_offset/test_consumer_offset_set_command.rs
+++ b/integration/tests/cli/consumer_offset/test_consumer_offset_set_command.rs
@@ -1,0 +1,365 @@
+use crate::cli::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestConsumerId, TestHelpCmd, TestStreamId,
+    TestTopicId, CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::consumer::{Consumer, ConsumerKind};
+use iggy::consumer_offsets::get_consumer_offset::GetConsumerOffset;
+use iggy::identifier::Identifier;
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use iggy::topics::delete_topic::DeleteTopic;
+use predicates::str::diff;
+use serial_test::parallel;
+use std::str::FromStr;
+
+struct TestConsumerOffsetSetCmd {
+    consumer_id: u32,
+    consumer_name: String,
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    partition_id: u32,
+    using_consumer_id: TestConsumerId,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    stored_offset: u64,
+}
+
+impl TestConsumerOffsetSetCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        consumer_id: u32,
+        consumer_name: String,
+        stream_id: u32,
+        stream_name: String,
+        topic_id: u32,
+        topic_name: String,
+        partition_id: u32,
+        using_consumer_id: TestConsumerId,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+        stored_offset: u64,
+    ) -> Self {
+        Self {
+            consumer_id,
+            consumer_name,
+            stream_id,
+            stream_name,
+            topic_id,
+            topic_name,
+            partition_id,
+            using_consumer_id,
+            using_stream_id,
+            using_topic_id,
+            stored_offset,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.using_consumer_id {
+            TestStreamId::Numeric => vec![format!("{}", self.consumer_id)],
+            TestStreamId::Named => vec![self.consumer_name.clone()],
+        };
+
+        command.push(match self.using_stream_id {
+            TestTopicId::Numeric => format!("{}", self.stream_id),
+            TestTopicId::Named => self.stream_name.clone(),
+        });
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(format!("{}", self.partition_id));
+        command.push(format!("{}", self.stored_offset));
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestConsumerOffsetSetCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client
+            .create_stream(&CreateStream {
+                stream_id: Some(self.stream_id),
+                name: self.stream_name.clone(),
+            })
+            .await;
+        assert!(stream.is_ok());
+
+        let topic = client
+            .create_topic(&CreateTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Some(self.topic_id),
+                partitions_count: 1,
+                name: self.topic_name.clone(),
+                message_expiry: None,
+                max_topic_size: None,
+                replication_factor: 1,
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let messages = (1..=self.stored_offset + 1)
+            .filter_map(|id| Message::from_str(format!("Test message {id}").as_str()).ok())
+            .collect::<Vec<_>>();
+
+        let send_status = client
+            .send_messages(&mut SendMessages {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partitioning: Partitioning::partition_id(self.partition_id),
+                messages,
+            })
+            .await;
+        assert!(send_status.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("consumer-offset")
+            .arg("set")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let consumer_id = match self.using_consumer_id {
+            TestConsumerId::Numeric => format!("{}", self.consumer_id),
+            TestConsumerId::Named => self.consumer_name.clone(),
+        };
+
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let message = format!(
+            "Executing set consumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {} to {}\nConsumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {} set to {}\n",
+            consumer_id,
+            stream_id,
+            topic_id,
+            self.partition_id,
+            self.stored_offset,
+            consumer_id,
+            stream_id,
+            topic_id,
+            self.partition_id,
+            self.stored_offset
+        );
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let consumer = match self.using_consumer_id {
+            TestConsumerId::Numeric => Consumer {
+                kind: ConsumerKind::Consumer,
+                id: Identifier::numeric(self.consumer_id).unwrap(),
+            },
+            TestConsumerId::Named => Consumer {
+                kind: ConsumerKind::Consumer,
+                id: Identifier::named(self.consumer_name.as_str()).unwrap(),
+            },
+        };
+
+        let offset = client
+            .get_consumer_offset(&GetConsumerOffset {
+                consumer,
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+                partition_id: Some(self.partition_id),
+            })
+            .await;
+        assert!(offset.is_ok());
+        let offset = offset.unwrap();
+        assert_eq!(offset.stored_offset, self.stored_offset);
+
+        let topic = client
+            .delete_topic(&DeleteTopic {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+                topic_id: Identifier::numeric(self.topic_id).unwrap(),
+            })
+            .await;
+        assert!(topic.is_ok());
+
+        let stream = client
+            .delete_stream(&DeleteStream {
+                stream_id: Identifier::numeric(self.stream_id).unwrap(),
+            })
+            .await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters = vec![
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Named,
+            TestTopicId::Numeric,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Numeric,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Named,
+            TestStreamId::Named,
+            TestTopicId::Named,
+        ),
+        (
+            TestConsumerId::Numeric,
+            TestStreamId::Numeric,
+            TestTopicId::Numeric,
+        ),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, using_consumer_id) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestConsumerOffsetSetCmd::new(
+                1,
+                String::from("consumer"),
+                2,
+                String::from("stream"),
+                3,
+                String::from("topic"),
+                1,
+                using_consumer_id,
+                using_stream_id,
+                using_topic_id,
+                100,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-offset", "set", "--help"],
+            format!(
+                r#"Set the offset of a consumer for a given partition on the server
+
+Consumer ID can be specified as a consumer name or ID
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples:
+ iggy consumer-offset set 1 3 5 1 100
+ iggy consumer-offset set consumer 3 5 1 100
+ iggy consumer-offset set 1 stream 5 1 100
+ iggy consumer-offset set 1 3 topic 1 100
+ iggy consumer-offset set consumer stream 5 1 100
+ iggy consumer-offset set consumer 3 topic 1 100
+ iggy consumer-offset set 1 stream topic 1 100
+ iggy consumer-offset set consumer stream topic 1 100
+
+{USAGE_PREFIX} consumer-offset set <CONSUMER_ID> <STREAM_ID> <TOPIC_ID> <PARTITION_ID> <OFFSET>
+
+Arguments:
+  <CONSUMER_ID>
+          Regular consumer for which the offset is set
+{CLAP_INDENT}
+          Consumer ID can be specified as a consumer name or ID
+
+  <STREAM_ID>
+          Stream ID for which consumer offset is set
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          Topic ID for which consumer offset is set
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <PARTITION_ID>
+          Partitions ID for which consumer offset is set
+
+  <OFFSET>
+          Offset to set
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["consumer-offset", "set", "-h"],
+            format!(
+                r#"Set the offset of a consumer for a given partition on the server
+
+{USAGE_PREFIX} consumer-offset set <CONSUMER_ID> <STREAM_ID> <TOPIC_ID> <PARTITION_ID> <OFFSET>
+
+Arguments:
+  <CONSUMER_ID>   Regular consumer for which the offset is set
+  <STREAM_ID>     Stream ID for which consumer offset is set
+  <TOPIC_ID>      Topic ID for which consumer offset is set
+  <PARTITION_ID>  Partitions ID for which consumer offset is set
+  <OFFSET>        Offset to set
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/general/test_help_command.rs
+++ b/integration/tests/cli/general/test_help_command.rs
@@ -15,18 +15,19 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} [OPTIONS] [COMMAND]
 
 Commands:
-  stream          stream operations [aliases: s]
-  topic           topic operations [aliases: t]
-  partition       partition operations [aliases: p]
-  ping            ping iggy server
-  me              get current client info
-  stats           get iggy server statistics
-  pat             personal access token operations
-  user            user operations [aliases: u]
-  client          client operations [aliases: c]
-  consumer-group  consumer group operations [aliases: g]
-  message         message operations [aliases: m]
-  help            Print this message or the help of the given subcommand(s)
+  stream           stream operations [aliases: s]
+  topic            topic operations [aliases: t]
+  partition        partition operations [aliases: p]
+  ping             ping iggy server
+  me               get current client info
+  stats            get iggy server statistics
+  pat              personal access token operations
+  user             user operations [aliases: u]
+  client           client operations [aliases: c]
+  consumer-group   consumer group operations [aliases: g]
+  consumer-offset  consumer offset operations [aliases: o]
+  message          message operations [aliases: m]
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
       --transport <TRANSPORT>

--- a/integration/tests/cli/general/test_overview_command.rs
+++ b/integration/tests/cli/general/test_overview_command.rs
@@ -26,18 +26,19 @@ Iggy is the persistent message streaming platform written in Rust, supporting QU
 Usage: iggy [OPTIONS] [COMMAND]
 
 Commands:
-  stream          stream operations [aliases: s]
-  topic           topic operations [aliases: t]
-  partition       partition operations [aliases: p]
-  ping            ping iggy server
-  me              get current client info
-  stats           get iggy server statistics
-  pat             personal access token operations
-  user            user operations [aliases: u]
-  client          client operations [aliases: c]
-  consumer-group  consumer group operations [aliases: g]
-  message         message operations [aliases: m]
-  help            Print this message or the help of the given subcommand(s)
+  stream           stream operations [aliases: s]
+  topic            topic operations [aliases: t]
+  partition        partition operations [aliases: p]
+  ping             ping iggy server
+  me               get current client info
+  stats            get iggy server statistics
+  pat              personal access token operations
+  user             user operations [aliases: u]
+  client           client operations [aliases: c]
+  consumer-group   consumer group operations [aliases: g]
+  consumer-offset  consumer offset operations [aliases: o]
+  message          message operations [aliases: m]
+  help             Print this message or the help of the given subcommand(s)
 
 
 Run 'iggy --help' for full help message.

--- a/integration/tests/cli/mod.rs
+++ b/integration/tests/cli/mod.rs
@@ -1,6 +1,7 @@
 mod client;
 mod common;
 mod consumer_group;
+mod consumer_offset;
 mod general;
 mod message;
 mod partition;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.2"
+version = "0.2.3"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/cli/consumer_offset/get_consumer_offset.rs
+++ b/sdk/src/cli/consumer_offset/get_consumer_offset.rs
@@ -1,0 +1,100 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer::{Consumer, ConsumerKind};
+use crate::consumer_offsets::get_consumer_offset::GetConsumerOffset;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use comfy_table::Table;
+use tracing::{event, Level};
+
+pub struct GetConsumerOffsetCmd {
+    get_consumer_offset: GetConsumerOffset,
+}
+
+impl GetConsumerOffsetCmd {
+    pub fn new(
+        consumer_id: Identifier,
+        stream_id: Identifier,
+        topic_id: Identifier,
+        partition_id: u32,
+    ) -> Self {
+        Self {
+            get_consumer_offset: GetConsumerOffset {
+                consumer: Consumer {
+                    kind: ConsumerKind::Consumer,
+                    id: consumer_id,
+                },
+                stream_id,
+                topic_id,
+                partition_id: Some(partition_id),
+            },
+        }
+    }
+
+    pub fn get_consumer_info(&self) -> String {
+        match self.get_consumer_offset.consumer.kind {
+            ConsumerKind::Consumer => {
+                format!("consumer with ID: {}", self.get_consumer_offset.consumer.id)
+            }
+            ConsumerKind::ConsumerGroup => format!(
+                "consumer group with ID: {}",
+                self.get_consumer_offset.consumer.id
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for GetConsumerOffsetCmd {
+    fn explain(&self) -> String {
+        format!(
+            "get consumer offset for {} for stream with ID: {} and topic with ID: {} and partition with ID: {}",
+            self.get_consumer_info(),
+            self.get_consumer_offset.stream_id,
+            self.get_consumer_offset.topic_id,
+            self.get_consumer_offset.partition_id.unwrap(),
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        let consumer_offset = client.get_consumer_offset(&self.get_consumer_offset).await.with_context(|| {
+            format!(
+                "Problem getting consumer offset for {} for stream with ID: {} and topic with ID: {} and partition with ID: {}",
+                self.get_consumer_info(), self.get_consumer_offset.stream_id, self.get_consumer_offset.topic_id, self.get_consumer_offset.partition_id.unwrap()
+            )
+        })?;
+
+        let mut table = Table::new();
+
+        table.set_header(vec!["Property", "Value"]);
+        table.add_row(vec![
+            "Consumer ID",
+            format!("{}", self.get_consumer_offset.consumer.id).as_str(),
+        ]);
+        table.add_row(vec![
+            "Stream ID",
+            format!("{}", self.get_consumer_offset.stream_id).as_str(),
+        ]);
+        table.add_row(vec![
+            "Topic ID",
+            format!("{}", self.get_consumer_offset.topic_id).as_str(),
+        ]);
+        table.add_row(vec![
+            "Partition ID",
+            format!("{}", consumer_offset.partition_id).as_str(),
+        ]);
+        table.add_row(vec![
+            "Current offset",
+            format!("{}", consumer_offset.current_offset).as_str(),
+        ]);
+        table.add_row(vec![
+            "Stored offset",
+            format!("{}", consumer_offset.stored_offset).as_str(),
+        ]);
+
+        event!(target: PRINT_TARGET, Level::INFO, "{table}");
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/consumer_offset/mod.rs
+++ b/sdk/src/cli/consumer_offset/mod.rs
@@ -1,0 +1,2 @@
+pub mod get_consumer_offset;
+pub mod set_consumer_offset;

--- a/sdk/src/cli/consumer_offset/set_consumer_offset.rs
+++ b/sdk/src/cli/consumer_offset/set_consumer_offset.rs
@@ -1,0 +1,72 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::consumer::{Consumer, ConsumerKind};
+use crate::consumer_offsets::store_consumer_offset::StoreConsumerOffset;
+use crate::identifier::Identifier;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct SetConsumerOffsetCmd {
+    set_consumer_offset: StoreConsumerOffset,
+}
+
+impl SetConsumerOffsetCmd {
+    pub fn new(
+        consumer_id: Identifier,
+        stream_id: Identifier,
+        topic_id: Identifier,
+        partition_id: u32,
+        offset: u64,
+    ) -> Self {
+        Self {
+            set_consumer_offset: StoreConsumerOffset {
+                consumer: Consumer {
+                    kind: ConsumerKind::Consumer,
+                    id: consumer_id,
+                },
+                stream_id,
+                topic_id,
+                partition_id: Some(partition_id),
+                offset,
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for SetConsumerOffsetCmd {
+    fn explain(&self) -> String {
+        format!(
+            "set consumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {} to {}",
+            self.set_consumer_offset.consumer.id,
+            self.set_consumer_offset.stream_id,
+            self.set_consumer_offset.topic_id,
+            self.set_consumer_offset.partition_id.unwrap(),
+            self.set_consumer_offset.offset,
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        client
+            .store_consumer_offset(&self.set_consumer_offset)
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem setting consumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {}",
+                    self.set_consumer_offset.consumer.id, self.set_consumer_offset.stream_id, self.set_consumer_offset.topic_id, self.set_consumer_offset.partition_id.unwrap()
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Consumer offset for consumer with ID: {} for stream with ID: {} and topic with ID: {} and partition with ID: {} set to {}",
+            self.set_consumer_offset.consumer.id,
+            self.set_consumer_offset.stream_id,
+            self.set_consumer_offset.topic_id,
+            self.set_consumer_offset.partition_id.unwrap(),
+            self.set_consumer_offset.offset,
+        );
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/mod.rs
+++ b/sdk/src/cli/mod.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod consumer_group;
+pub mod consumer_offset;
 pub mod message;
 pub mod partitions;
 pub mod personal_access_tokens;


### PR DESCRIPTION
This commit introduces new CLI commands for managing consumer offsets.
The `consumer-offset get` command retrieves the offset of a consumer for
a given partition from the server, while the `consumer-offset set`
command allows setting the offset of a consumer for a given partition on
the server. The changes include updates to the CLI interface, integration
tests, and the SDK to support these new functionalities.

Close #545
