### PR TITLE
Add WriteTo trait and implement it for Message struct

### DIFF
--- a/sdk/src/binary/binary_client.rs
+++ b/sdk/src/binary/binary_client.rs
@@ -1,5 +1,6 @@
 use crate::client::Client;
 use crate::error::IggyError;
+use crate::write_to::WriteTo;
 use async_trait::async_trait;
 use bytes::Bytes;
 
@@ -16,11 +17,25 @@ pub enum ClientState {
 
 /// A client that can send and receive binary messages.
 #[async_trait]
-pub trait BinaryClient: Client {
+pub(crate) trait BinaryClient: Client {
     /// Gets the state of the client.
     async fn get_state(&self) -> ClientState;
     /// Sets the state of the client.
     async fn set_state(&self, state: ClientState);
     /// Sends a command and returns the response.
-    async fn send_with_response(&self, command: u32, payload: Bytes) -> Result<Bytes, IggyError>;
+    async fn send_with_response(
+        &self,
+        command_code: u32,
+        payload: Bytes,
+    ) -> Result<Bytes, IggyError>;
+    /// Sends a command and returns the response.
+    ///
+    /// No additional memory allocation is required, and the Command is serialized directly into the transmission stream.
+    async fn send_with_response_v2(
+        &self,
+        _command_code: u32,
+        _command: &(dyn WriteTo + Send + Sync),
+    ) -> Result<Bytes, IggyError> {
+        unimplemented!("send_with_response_v2 is not implemented!")
+    }
 }

--- a/sdk/src/binary/messages.rs
+++ b/sdk/src/binary/messages.rs
@@ -20,7 +20,7 @@ impl<B: BinaryClient> MessageClient for B {
 
     async fn send_messages(&self, command: &mut SendMessages) -> Result<(), IggyError> {
         fail_if_not_authenticated(self).await?;
-        self.send_with_response(SEND_MESSAGES_CODE, command.as_bytes())
+        self.send_with_response_v2(SEND_MESSAGES_CODE, command)
             .await?;
         Ok(())
     }

--- a/sdk/src/bytes_serializable.rs
+++ b/sdk/src/bytes_serializable.rs
@@ -11,4 +11,9 @@ pub trait BytesSerializable {
     fn from_bytes(bytes: Bytes) -> Result<Self, IggyError>
     where
         Self: Sized;
+
+    /// Computes the size of the struct in bytes.
+    fn size(&self) -> usize {
+        unimplemented!("size")
+    }
 }

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -169,6 +169,10 @@ impl Identifier {
 }
 
 impl BytesSerializable for Identifier {
+    fn size(&self) -> usize {
+        2 + self.length as usize
+    }
+
     fn as_bytes(&self) -> Bytes {
         let mut bytes = BytesMut::with_capacity(2 + self.length as usize);
         bytes.put_u8(self.kind.as_code());

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -31,3 +31,4 @@ pub mod topics;
 pub mod users;
 pub mod utils;
 pub mod validatable;
+pub mod write_to;

--- a/sdk/src/write_to.rs
+++ b/sdk/src/write_to.rs
@@ -1,0 +1,12 @@
+use async_trait::async_trait;
+
+use crate::{
+    bytes_serializable::BytesSerializable, error::IggyError, tcp::client::ConnectionStream,
+};
+
+/// The trait for serializing a struct into a stream.
+#[async_trait]
+pub(crate) trait WriteTo: BytesSerializable {
+    /// Serialize the struct into the stream.
+    async fn write_to(&self, stream: &mut dyn ConnectionStream) -> Result<(), IggyError>;
+}


### PR DESCRIPTION
As we talked in https://github.com/iggy-rs/iggy/pull/650#pullrequestreview-1862058157

Write SendMessages directly to the stream to avoid unnecessary memory copies.

I compared the BenchMark results and found that the performance did not improve. I haven't figured out why yet.

Before:
```
send-and-poll
2024-02-09T08:33:58.789986Z  INFO iggy_bench::benchmark_runner: Producer results: total throughput: 2961.25 MB/s, 2961249 messages/s, average latency: 3.38 ms, average throughput: 148.06 MB/s, total duration: 3.38 s, Consumer results: total throughput: 3029.55 MB/s, 2899094 messages/s, average latency: 3.30 ms, average  throughput: 151.48 MB/s, total duration: 3.45 s
2024-02-09T08:33:58.789989Z  INFO iggy_bench::benchmark_runner: Results: total throughput: 2995.76 MB/s, 2929842 messages/s, average latency: 6.68 ms, average  throughput: 149.79 MB/s, total duration: 6.83 s
```
After:
```
send-and-poll
2024-02-09T08:56:44.146056Z  INFO iggy_bench::benchmark_runner: Producer results: total throughput: 3617.91 MB/s, 3617908 messages/s, average latency: 2.76 ms, average throughput: 180.90 MB/s, total duration: 2.76 s, Consumer results: total throughput: 2355.45 MB/s, 2254022 messages/s, average latency: 3.80 ms, average  throughput: 117.77 MB/s, total duration: 4.44 s
2024-02-09T08:56:44.146059Z  INFO iggy_bench::benchmark_runner: Results: total throughput: 2840.06 MB/s, 2777568 messages/s, average latency: 6.56 ms, average  throughput: 142.00 MB/s, total duration: 7.20 s
```
  