### PR TITLE
Print only first and last 20 bytes in Message payloads

### DIFF
--- a/sdk/src/messages/send_messages.rs
+++ b/sdk/src/messages/send_messages.rs
@@ -288,7 +288,19 @@ impl Default for Message {
 
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}|{}", self.id, String::from_utf8_lossy(&self.payload))
+        let len = self.payload.len();
+
+        if len > 40 {
+            write!(
+                f,
+                "{}|{}...{}",
+                self.id,
+                String::from_utf8_lossy(&self.payload[..20]),
+                String::from_utf8_lossy(&self.payload[len - 20..])
+            )
+        } else {
+            write!(f, "{}|{}", self.id, String::from_utf8_lossy(&self.payload))
+        }
     }
 }
 


### PR DESCRIPTION
This PR relates to https://github.com/iggy-rs/iggy/issues/657.

As discussed on Discord I tried to shorten only the user message content. My reasoning was to shorten each payload, but to still show each message (alternative would be to shorten the whole `Vec<Messages>` in `SendMessages`. 

This is my first contribution attempt so any feedback is welcome!