### PR TITLE
Add login and logout commands to Iggy CLI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,5 @@
+[[profile.default.overrides]]
+# This is a solution (or actually a workaround) for the problem that nextest does not support
+# #[serial] macro which shall enfroce sequential execution of the test case.
+filter = 'package(integration) and test(cli::system::test_cli_session_scenario::should_be_successful)'
+threads-required = "num-cpus"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cli"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cli/src/args/mod.rs
+++ b/cli/src/args/mod.rs
@@ -14,10 +14,16 @@ pub(crate) mod user;
 
 use self::user::UserAction;
 use crate::args::{
-    client::ClientAction, consumer_group::ConsumerGroupAction,
-    consumer_offset::ConsumerOffsetAction, context::ContextAction, message::MessageAction,
-    partition::PartitionAction, personal_access_token::PersonalAccessTokenAction,
-    stream::StreamAction, system::PingArgs, topic::TopicAction,
+    client::ClientAction,
+    consumer_group::ConsumerGroupAction,
+    consumer_offset::ConsumerOffsetAction,
+    context::ContextAction,
+    message::MessageAction,
+    partition::PartitionAction,
+    personal_access_token::PersonalAccessTokenAction,
+    stream::StreamAction,
+    system::{LoginArgs, PingArgs},
+    topic::TopicAction,
 };
 use clap::{Args, Command as ClapCommand};
 use clap::{Parser, Subcommand};
@@ -109,16 +115,19 @@ pub(crate) enum Command {
     /// ping iggy server
     ///
     /// Check if iggy server is up and running and what's the response ping response time
+    #[clap(verbatim_doc_comment)]
     Ping(PingArgs),
     /// get current client info
     ///
     /// Command connects to Iggy server and collects client info like client ID, user ID
     /// server address and protocol type.
+    #[clap(verbatim_doc_comment)]
     Me,
     /// get iggy server statistics
     ///
     /// Collect basic Iggy server statistics like number of streams, topics, partitions, etc.
     /// Server OS name, version, etc. are also collected.
+    #[clap(verbatim_doc_comment)]
     Stats,
     /// personal access token operations
     #[command(subcommand)]
@@ -141,6 +150,20 @@ pub(crate) enum Command {
     /// context operations
     #[command(subcommand, visible_alias = "ctx")]
     Context(ContextAction),
+    /// login to Iggy server
+    ///
+    /// Command logs in to Iggy server using provided credentials and stores session token
+    /// in platform-specific secure storage. Session token is used for authentication in
+    /// subsequent commands until logout command is executed.
+    #[clap(verbatim_doc_comment, visible_alias = "li")]
+    Login(LoginArgs),
+    /// logout from Iggy server
+    ///
+    /// Command logs out from Iggy server and removes session token from platform-specific
+    /// secure storage. After logout command is executed, user needs to log in again to
+    /// execute any command that requires authentication.
+    #[clap(verbatim_doc_comment, visible_alias = "lo")]
+    Logout,
 }
 
 impl IggyConsoleArgs {

--- a/cli/src/args/system.rs
+++ b/cli/src/args/system.rs
@@ -1,8 +1,20 @@
 use clap::Args;
+use iggy::cli::utils::login_session_expiry::LoginSessionExpiry;
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct PingArgs {
     /// Stop after sending count Ping packets
     #[arg(short, long, default_value_t = 1)]
     pub(crate) count: u32,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct LoginArgs {
+    /// Login session expiry time in human-readable format
+    ///
+    /// Expiry time must be expressed in human-readable format like 1hour 15min 2s.
+    /// If not set default value 15minutes is used. Using "none" disables session expiry time.
+    #[clap(verbatim_doc_comment)]
+    #[arg(value_parser = clap::value_parser!(LoginSessionExpiry), group = "store")]
+    pub(crate) expiry: Option<Vec<LoginSessionExpiry>>,
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -21,6 +21,7 @@ use clap::Parser;
 use iggy::args::Args;
 use iggy::cli::context::common::ContextManager;
 use iggy::cli::context::use_context::UseContextCmd;
+use iggy::cli::utils::login_session_expiry::LoginSessionExpiry;
 use iggy::cli::{
     client::{get_client::GetClientCmd, get_clients::GetClientsCmd},
     consumer_group::{
@@ -43,7 +44,7 @@ use iggy::cli::{
         create_stream::CreateStreamCmd, delete_stream::DeleteStreamCmd, get_stream::GetStreamCmd,
         get_streams::GetStreamsCmd, purge_stream::PurgeStreamCmd, update_stream::UpdateStreamCmd,
     },
-    system::{me::GetMeCmd, ping::PingCmd, stats::GetStatsCmd},
+    system::{login::LoginCmd, logout::LogoutCmd, me::GetMeCmd, ping::PingCmd, stats::GetStatsCmd},
     topics::{
         create_topic::CreateTopicCmd, delete_topic::DeleteTopicCmd, get_topic::GetTopicCmd,
         get_topics::GetTopicsCmd, purge_topic::PurgeTopicCmd, update_topic::UpdateTopicCmd,
@@ -267,6 +268,11 @@ fn get_command(
                 Box::new(UseContextCmd::new(use_args.context_name.clone()))
             }
         },
+        Command::Login(login_args) => Box::new(LoginCmd::new(
+            iggy_args.get_server_address().unwrap(),
+            LoginSessionExpiry::new(login_args.expiry.clone()),
+        )),
+        Command::Logout => Box::new(LogoutCmd::new(iggy_args.get_server_address().unwrap())),
     }
 }
 

--- a/integration/src/test_server.rs
+++ b/integration/src/test_server.rs
@@ -397,6 +397,23 @@ impl TestServer {
         }
         None
     }
+
+    pub fn get_server_ip_addr(&self) -> Option<String> {
+        if let Some(server_address) = self
+            .get_raw_tcp_addr()
+            .or_else(|| self.get_http_api_addr())
+            .or_else(|| self.get_quic_udp_addr())
+        {
+            server_address
+                .split(':')
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>()
+                .first()
+                .cloned()
+        } else {
+            None
+        }
+    }
 }
 
 impl Drop for TestServer {

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -232,9 +232,14 @@ impl IggyCmdTest {
         );
 
         // Execute test command
+
         let assert = command.args(command_args.get_opts_and_args()).assert();
         // Verify command output, exit code, etc in the test (if needed)
         test_case.verify_command(assert);
+    }
+
+    pub(crate) fn get_sever_ip_address(&self) -> Option<String> {
+        self.server.get_server_ip_addr()
     }
 }
 

--- a/integration/tests/cli/general/test_help_command.rs
+++ b/integration/tests/cli/general/test_help_command.rs
@@ -28,6 +28,8 @@ Commands:
   consumer-offset  consumer offset operations [aliases: o]
   message          message operations [aliases: m]
   context          context operations [aliases: ctx]
+  login            login to Iggy server [aliases: li]
+  logout           logout from Iggy server [aliases: lo]
   help             Print this message or the help of the given subcommand(s)
 
 Options:

--- a/integration/tests/cli/general/test_overview_command.rs
+++ b/integration/tests/cli/general/test_overview_command.rs
@@ -39,6 +39,8 @@ Commands:
   consumer-offset  consumer offset operations [aliases: o]
   message          message operations [aliases: m]
   context          context operations [aliases: ctx]
+  login            login to Iggy server [aliases: li]
+  logout           logout from Iggy server [aliases: lo]
   help             Print this message or the help of the given subcommand(s)
 
 

--- a/integration/tests/cli/system/mod.rs
+++ b/integration/tests/cli/system/mod.rs
@@ -1,3 +1,9 @@
+#[cfg(not(any(target_arch = "aarch64", target_arch = "arm")))]
+mod test_cli_session_scenario;
+mod test_login_cmd;
+mod test_login_command;
+mod test_logout_cmd;
+mod test_logout_command;
 mod test_me_command;
 mod test_ping_command;
 mod test_stats_command;

--- a/integration/tests/cli/system/test_cli_session_scenario.rs
+++ b/integration/tests/cli/system/test_cli_session_scenario.rs
@@ -1,0 +1,24 @@
+use crate::cli::common::IggyCmdTest;
+use crate::cli::system::test_login_cmd::TestLoginCmd;
+use crate::cli::system::test_logout_cmd::TestLogoutCmd;
+use crate::cli::system::test_me_command::TestMeCmd;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test.setup().await;
+    let server_address = iggy_cmd_test.get_sever_ip_address();
+    assert!(server_address.is_some());
+    let server_address = server_address.unwrap();
+
+    iggy_cmd_test
+        .execute_test(TestLoginCmd::new(server_address.clone()))
+        .await;
+    iggy_cmd_test.execute_test(TestMeCmd::default()).await;
+    iggy_cmd_test
+        .execute_test(TestLogoutCmd::new(server_address))
+        .await;
+}

--- a/integration/tests/cli/system/test_login_cmd.rs
+++ b/integration/tests/cli/system/test_login_cmd.rs
@@ -1,0 +1,66 @@
+use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::cli::system::session::ServerSession;
+use iggy::client::Client;
+use iggy::personal_access_tokens::delete_personal_access_token::DeletePersonalAccessToken;
+use iggy::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
+use predicates::str::diff;
+
+#[derive(Debug)]
+pub(super) struct TestLoginCmd {
+    server_address: String,
+}
+
+impl TestLoginCmd {
+    pub(super) fn new(server_address: String) -> Self {
+        Self { server_address }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestLoginCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let login_session = ServerSession::new(self.server_address.clone());
+        assert!(!login_session.is_active());
+
+        let pats = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await
+            .unwrap();
+        assert_eq!(pats.len(), 0);
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new().with_env_credentials().arg("login")
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state.success().stdout(diff(format!(
+            "Executing login command\nSuccessfully logged into Iggy server {}\n",
+            self.server_address
+        )));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let login_session = ServerSession::new(self.server_address.clone());
+        assert!(login_session.is_active());
+
+        let pats = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await
+            .unwrap();
+        assert_eq!(pats.len(), 1);
+        assert_eq!(pats[0].name, login_session.get_token_name());
+
+        let cleanup_session = login_session.delete();
+        assert!(cleanup_session.is_ok());
+
+        let token_cleanup = client
+            .delete_personal_access_token(&DeletePersonalAccessToken {
+                name: login_session.get_token_name(),
+            })
+            .await;
+        assert!(token_cleanup.is_ok());
+    }
+}

--- a/integration/tests/cli/system/test_login_command.rs
+++ b/integration/tests/cli/system/test_login_command.rs
@@ -1,0 +1,59 @@
+use crate::cli::common::{IggyCmdTest, TestHelpCmd, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["login", "--help"],
+            format!(
+                r#"login to Iggy server
+
+Command logs in to Iggy server using provided credentials and stores session token
+in platform-specific secure storage. Session token is used for authentication in
+subsequent commands until logout command is executed.
+
+{USAGE_PREFIX} login [EXPIRY]...
+
+Arguments:
+  [EXPIRY]...
+          Login session expiry time in human-readable format
+          
+          Expiry time must be expressed in human-readable format like 1hour 15min 2s.
+          If not set default value 15minutes is used. Using "none" disables session expiry time.
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["login", "-h"],
+            format!(
+                r#"login to Iggy server
+
+{USAGE_PREFIX} login [EXPIRY]...
+
+Arguments:
+  [EXPIRY]...  Login session expiry time in human-readable format
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/system/test_logout_cmd.rs
+++ b/integration/tests/cli/system/test_logout_cmd.rs
@@ -1,0 +1,61 @@
+use crate::cli::common::{IggyCmdCommand, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::cli::system::session::ServerSession;
+use iggy::client::Client;
+use iggy::personal_access_tokens::create_personal_access_token::CreatePersonalAccessToken;
+use iggy::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
+use predicates::str::diff;
+
+#[derive(Debug)]
+pub(super) struct TestLogoutCmd {
+    server_address: String,
+}
+
+impl TestLogoutCmd {
+    pub(super) fn new(server_address: String) -> Self {
+        Self { server_address }
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestLogoutCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let login_session = ServerSession::new(self.server_address.clone());
+        assert!(!login_session.is_active());
+
+        let token = client
+            .create_personal_access_token(&CreatePersonalAccessToken {
+                name: login_session.get_token_name(),
+                expiry: None,
+            })
+            .await;
+        assert!(token.is_ok());
+
+        let token = token.unwrap();
+        login_session.store(&token.token).unwrap();
+        assert!(login_session.is_active());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new().arg("logout")
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        command_state.success().stdout(diff(format!(
+            "Executing logout command\nSuccessfully logged out from Iggy server {}\n",
+            self.server_address
+        )));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let login_session = ServerSession::new(self.server_address.clone());
+        assert!(!login_session.is_active());
+
+        let pats = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await
+            .unwrap();
+        assert_eq!(pats.len(), 0);
+    }
+}

--- a/integration/tests/cli/system/test_logout_command.rs
+++ b/integration/tests/cli/system/test_logout_command.rs
@@ -1,0 +1,49 @@
+use crate::cli::common::{IggyCmdTest, TestHelpCmd, USAGE_PREFIX};
+use serial_test::parallel;
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["logout", "--help"],
+            format!(
+                r#"logout from Iggy server
+
+Command logs out from Iggy server and removes session token from platform-specific
+secure storage. After logout command is executed, user needs to log in again to
+execute any command that requires authentication.
+
+{USAGE_PREFIX} logout
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["logout", "-h"],
+            format!(
+                r#"logout from Iggy server
+
+{USAGE_PREFIX} logout
+
+Options:
+  -h, --help  Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/system/test_me_command.rs
+++ b/integration/tests/cli/system/test_me_command.rs
@@ -38,7 +38,7 @@ impl Display for Protocol {
 }
 
 #[derive(Debug, Default)]
-struct TestMeCmd {
+pub(super) struct TestMeCmd {
     protocol: Protocol,
 }
 
@@ -124,7 +124,8 @@ pub async fn should_help_match() {
             format!(
                 r#"get current client info
 
-Command connects to Iggy server and collects client info like client ID, user ID server address and protocol type.
+Command connects to Iggy server and collects client info like client ID, user ID
+server address and protocol type.
 
 {USAGE_PREFIX} me
 

--- a/integration/tests/cli/system/test_stats_command.rs
+++ b/integration/tests/cli/system/test_stats_command.rs
@@ -75,7 +75,8 @@ pub async fn should_help_match() {
             format!(
                 r#"get iggy server statistics
 
-Collect basic Iggy server statistics like number of streams, topics, partitions, etc. Server OS name, version, etc. are also collected.
+Collect basic Iggy server statistics like number of streams, topics, partitions, etc.
+Server OS name, version, etc. are also collected.
 
 {USAGE_PREFIX} stats
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.3"
+version = "0.2.4"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/cli/system/login.rs
+++ b/sdk/src/cli/system/login.rs
@@ -1,0 +1,82 @@
+use crate::cli::system::session::ServerSession;
+use crate::cli::utils::login_session_expiry::LoginSessionExpiry;
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::personal_access_tokens::create_personal_access_token::CreatePersonalAccessToken;
+use crate::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+const DEFAULT_LOGIN_SESSION_TIMEOUT: u32 = 15 * 60;
+
+pub struct LoginCmd {
+    server_session: ServerSession,
+    login_session_expiry: Option<LoginSessionExpiry>,
+}
+
+impl LoginCmd {
+    pub fn new(server_address: String, login_session_expiry: Option<LoginSessionExpiry>) -> Self {
+        Self {
+            server_session: ServerSession::new(server_address),
+            login_session_expiry,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for LoginCmd {
+    fn explain(&self) -> String {
+        "login command".to_owned()
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        if self.server_session.is_active() {
+            event!(target: PRINT_TARGET, Level::INFO, "Already logged into Iggy server {}", self.server_session.get_server_address());
+            return Ok(());
+        }
+
+        let tokens = client
+            .get_personal_access_tokens(&GetPersonalAccessTokens {})
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem getting personal access tokens from server: {}",
+                    self.server_session.get_server_address()
+                )
+            })?;
+
+        if tokens
+            .iter()
+            .any(|pat| pat.name == self.server_session.get_token_name())
+        {
+            event!(target: PRINT_TARGET, Level::INFO, "Already logged into Iggy server {}", self.server_session.get_server_address());
+            return Ok(());
+        }
+
+        let token = client
+            .create_personal_access_token(&CreatePersonalAccessToken {
+                name: self.server_session.get_token_name(),
+                expiry: match &self.login_session_expiry {
+                    None => Some(DEFAULT_LOGIN_SESSION_TIMEOUT),
+                    Some(value) => value.into(),
+                },
+            })
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem creating personal access token with name: {}",
+                    self.server_session.get_token_name()
+                )
+            })?;
+
+        self.server_session.store(&token.token)?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Successfully logged into Iggy server {}",
+            self.server_session.get_server_address(),
+        );
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/system/logout.rs
+++ b/sdk/src/cli/system/logout.rs
@@ -1,0 +1,47 @@
+use crate::cli::system::session::ServerSession;
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::personal_access_tokens::delete_personal_access_token::DeletePersonalAccessToken;
+use anyhow::Context;
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct LogoutCmd {
+    server_session: ServerSession,
+}
+
+impl LogoutCmd {
+    pub fn new(server_address: String) -> Self {
+        Self {
+            server_session: ServerSession::new(server_address),
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for LogoutCmd {
+    fn explain(&self) -> String {
+        "logout command".to_owned()
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), anyhow::Error> {
+        if self.server_session.is_active() {
+            client
+                .delete_personal_access_token(&DeletePersonalAccessToken {
+                    name: self.server_session.get_token_name(),
+                })
+                .await
+                .with_context(|| {
+                    format!(
+                        "Problem deleting personal access token with name: {}",
+                        self.server_session.get_token_name()
+                    )
+                })?;
+
+            self.server_session.delete()?;
+        }
+        event!(target: PRINT_TARGET, Level::INFO, "Successfully logged out from Iggy server {}", self.server_session.get_server_address());
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/system/mod.rs
+++ b/sdk/src/cli/system/mod.rs
@@ -1,3 +1,6 @@
+pub mod login;
+pub mod logout;
 pub mod me;
 pub mod ping;
+pub mod session;
 pub mod stats;

--- a/sdk/src/cli/system/session.rs
+++ b/sdk/src/cli/system/session.rs
@@ -1,0 +1,55 @@
+use keyring::{Entry, Result};
+
+const SESSION_TOKEN_NAME: &str = "iggy-cli-session";
+const SESSION_KEYRING_SERVICE_NAME: &str = "iggy-cli-session";
+
+pub struct ServerSession {
+    server_address: String,
+}
+
+impl ServerSession {
+    pub fn new(server_address: String) -> Self {
+        Self { server_address }
+    }
+
+    pub fn get_server_address(&self) -> &str {
+        &self.server_address
+    }
+
+    fn get_service_name(&self) -> String {
+        format!("{SESSION_KEYRING_SERVICE_NAME}:{}", self.server_address)
+    }
+
+    pub fn get_token_name(&self) -> String {
+        String::from(SESSION_TOKEN_NAME)
+    }
+
+    pub fn is_active(&self) -> bool {
+        if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name()) {
+            return entry.get_password().is_ok();
+        }
+
+        false
+    }
+
+    pub fn store(&self, token: &str) -> Result<()> {
+        let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
+        entry.set_password(token)?;
+        Ok(())
+    }
+
+    pub fn get_token(&self) -> Option<String> {
+        if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name()) {
+            if let Ok(token) = entry.get_password() {
+                return Some(token);
+            }
+        }
+
+        None
+    }
+
+    pub fn delete(&self) -> Result<()> {
+        let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
+        entry.delete_password()
+    }
+}

--- a/sdk/src/cli/utils/login_session_expiry.rs
+++ b/sdk/src/cli/utils/login_session_expiry.rs
@@ -1,0 +1,3 @@
+use crate::cli::utils::message_expiry::MessageExpiry;
+
+pub type LoginSessionExpiry = MessageExpiry;

--- a/sdk/src/cli/utils/mod.rs
+++ b/sdk/src/cli/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod login_session_expiry;
 pub mod message_expiry;
 pub mod personal_access_token_expiry;


### PR DESCRIPTION
This commit introduces the ability to handle authenticated session
for Iggy CLI. Two new commands, Login and Logout, have been added
to the command list. The IggyCredentials struct has been updated
to support token retrieval from a ServerSession. Login command
use system's keyring service to store PAT which is created after
successful authentication during Login command. Logout command
removes dedicated PAT and cleans keyring data. In case of PAT
removal on Iggy Server Iggy CLI does cleanup in system's keyring
service and informs user that server session has been terminated.
Adding integration tests which verify Iggy CLI Login and Logout.

Updating Ping, Me and Stats help messages and corresponding tests.

Adding nextest config with requirement that login/logout test
scenario must run individualy, not concurrently with others.
