### PR TITLE
Improve IggyClientBuilder: speficic underlying client creation

### DIFF
--- a/bench/src/benchmarks/benchmark.rs
+++ b/bench/src/benchmarks/benchmark.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use futures::Future;
 use iggy::{
     client::{StreamClient, TopicClient},
-    clients::client::{IggyClient, IggyClientConfig},
+    clients::client::{IggyClient, IggyClientBackgroundConfig},
     error::IggyError,
     identifier::Identifier,
     streams::{create_stream::CreateStream, get_streams::GetStreams},
@@ -63,7 +63,13 @@ pub trait Benchmarkable {
         let topic_id: u32 = 1;
         let partitions_count: u32 = 1;
         let client = self.client_factory().create_client().await;
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
         login_root(&client).await;
         let streams = client.get_streams(&GetStreams {}).await?;
         for i in 1..=number_of_streams {
@@ -103,7 +109,13 @@ pub trait Benchmarkable {
         let start_stream_id = self.args().start_stream_id();
         let number_of_streams = self.args().number_of_streams();
         let client = self.client_factory().create_client().await;
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
         login_root(&client).await;
         let streams = client.get_streams(&GetStreams {}).await?;
         for i in 1..=number_of_streams {

--- a/bench/src/consumer.rs
+++ b/bench/src/consumer.rs
@@ -1,7 +1,7 @@
 use crate::args::simple::BenchmarkKind;
 use crate::benchmark_result::BenchmarkResult;
 use iggy::client::MessageClient;
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer::Consumer as IggyConsumer;
 use iggy::error::IggyError;
 use iggy::identifier::Identifier;
@@ -42,7 +42,13 @@ impl Consumer {
         let partition_id: u32 = 1;
         let total_messages = (self.messages_per_batch * self.message_batches) as u64;
         let client = self.client_factory.create_client().await;
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
         login_root(&client).await;
         info!(
             "Consumer #{} → preparing the test messages...",

--- a/bench/src/producer.rs
+++ b/bench/src/producer.rs
@@ -1,7 +1,7 @@
 use crate::args::simple::BenchmarkKind;
 use crate::benchmark_result::BenchmarkResult;
 use iggy::client::MessageClient;
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::error::IggyError;
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
@@ -45,7 +45,13 @@ impl Producer {
         let partition_id: u32 = 1;
         let total_messages = (self.messages_per_batch * self.message_batches) as u64;
         let client = self.client_factory.create_client().await;
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
         login_root(&client).await;
         info!(
             "Producer #{} → preparing the test messages...",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,7 +62,7 @@ use iggy::cli::{
 };
 use iggy::cli_command::{CliCommand, PRINT_TARGET};
 use iggy::client_provider::{self, ClientProviderConfig};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
 use std::sync::Arc;
 use tracing::{event, Level};
@@ -319,7 +319,13 @@ async fn main() -> Result<(), IggyCmdError> {
     let client =
         client_provider::get_raw_client(client_provider_config, command.connection_required())
             .await?;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, encryptor);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        encryptor,
+    );
 
     credentials.set_iggy_client(&client);
     credentials.login_user().await?;

--- a/examples/src/getting-started/consumer/main.rs
+++ b/examples/src/getting-started/consumer/main.rs
@@ -1,10 +1,9 @@
 use iggy::client::{Client, UserClient};
-use iggy::clients::client::{IggyClientBuilder, TcpClientConfig};
+use iggy::clients::client::IggyClientBuilder;
 use iggy::consumer::Consumer;
 use iggy::identifier::Identifier;
 use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
 use iggy::models::messages::Message;
-use iggy::tcp::config::TcpClientConfigBuilder;
 use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;
 use std::env;
@@ -21,11 +20,9 @@ const BATCHES_LIMIT: u32 = 5;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
-    let tcp_client_config = TcpClientConfigBuilder::new()
-        .with_server_address(get_tcp_server_addr())
-        .build();
     let client = IggyClientBuilder::new()
-        .with_tcp_config(tcp_client_config)
+        .with_tcp()
+        .with_server_address(get_tcp_server_addr())
         .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy

--- a/examples/src/getting-started/consumer/main.rs
+++ b/examples/src/getting-started/consumer/main.rs
@@ -1,10 +1,9 @@
 use iggy::client::{Client, UserClient};
-use iggy::clients::client::{IggyClientBuilder, IggyClientConfig};
+use iggy::clients::client::{IggyClientBuilder, TcpClientConfig};
 use iggy::consumer::Consumer;
 use iggy::identifier::Identifier;
 use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
 use iggy::models::messages::Message;
-use iggy::tcp::config::TcpClientConfig;
 use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;
 use std::env;

--- a/examples/src/getting-started/consumer/main.rs
+++ b/examples/src/getting-started/consumer/main.rs
@@ -1,16 +1,14 @@
 use iggy::client::{Client, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClientBuilder, IggyClientConfig};
 use iggy::consumer::Consumer;
 use iggy::identifier::Identifier;
 use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
 use iggy::models::messages::Message;
-use iggy::tcp::client::TcpClient;
 use iggy::tcp::config::TcpClientConfig;
 use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;
 use std::env;
 use std::error::Error;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::info;
@@ -27,8 +25,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         server_address: get_tcp_server_addr(),
         ..TcpClientConfig::default()
     };
-    let tcp_client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
-    let client = IggyClient::create(tcp_client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClientBuilder::new()
+        .with_config(IggyClientConfig::Tcp(tcp_client_config))
+        .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy
     // TCP client with default config (default server address for TCP is 127.0.0.1:8090):

--- a/examples/src/getting-started/consumer/main.rs
+++ b/examples/src/getting-started/consumer/main.rs
@@ -4,6 +4,7 @@ use iggy::consumer::Consumer;
 use iggy::identifier::Identifier;
 use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
 use iggy::models::messages::Message;
+use iggy::tcp::config::TcpClientConfigBuilder;
 use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;
 use std::env;
@@ -20,10 +21,9 @@ const BATCHES_LIMIT: u32 = 5;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
-    let tcp_client_config = TcpClientConfig {
-        server_address: get_tcp_server_addr(),
-        ..TcpClientConfig::default()
-    };
+    let tcp_client_config = TcpClientConfigBuilder::new()
+        .with_server_address(get_tcp_server_addr())
+        .build();
     let client = IggyClientBuilder::new()
         .with_tcp_config(tcp_client_config)
         .build()?;

--- a/examples/src/getting-started/consumer/main.rs
+++ b/examples/src/getting-started/consumer/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ..TcpClientConfig::default()
     };
     let client = IggyClientBuilder::new()
-        .with_config(IggyClientConfig::Tcp(tcp_client_config))
+        .with_tcp_config(tcp_client_config)
         .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -1,9 +1,8 @@
 use iggy::client::{Client, StreamClient, TopicClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBuilder, IggyClientConfig};
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
 use iggy::streams::create_stream::CreateStream;
-use iggy::tcp::client::TcpClient;
 use iggy::tcp::config::TcpClientConfig;
 use iggy::topics::create_topic::CreateTopic;
 use iggy::users::defaults::*;
@@ -11,7 +10,6 @@ use iggy::users::login_user::LoginUser;
 use std::env;
 use std::error::Error;
 use std::str::FromStr;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{info, warn};
@@ -29,8 +27,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         server_address: get_tcp_server_addr(),
         ..TcpClientConfig::default()
     };
-    let tcp_client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
-    let client = IggyClient::create(tcp_client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClientBuilder::new()
+        .with_config(IggyClientConfig::Tcp(tcp_client_config))
+        .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy
     // TCP client with default config (default server address for TCP is 127.0.0.1:8090):

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -1,5 +1,5 @@
 use iggy::client::{Client, StreamClient, TopicClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientBuilder, TcpClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBuilder, TcpClientConfigBuilder};
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
 use iggy::streams::create_stream::CreateStream;
@@ -22,10 +22,9 @@ const BATCHES_LIMIT: u32 = 5;
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
-    let tcp_client_config = TcpClientConfig {
-        server_address: get_tcp_server_addr(),
-        ..TcpClientConfig::default()
-    };
+    let tcp_client_config = TcpClientConfigBuilder::new()
+        .with_server_address(get_tcp_server_addr())
+        .build();
     let client = IggyClientBuilder::new()
         .with_tcp_config(tcp_client_config)
         .build()?;

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -1,5 +1,5 @@
 use iggy::client::{Client, StreamClient, TopicClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientBuilder, TcpClientConfigBuilder};
+use iggy::clients::client::{IggyClient, IggyClientBuilder};
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
 use iggy::streams::create_stream::CreateStream;
@@ -22,11 +22,9 @@ const BATCHES_LIMIT: u32 = 5;
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
 
-    let tcp_client_config = TcpClientConfigBuilder::new()
-        .with_server_address(get_tcp_server_addr())
-        .build();
     let client = IggyClientBuilder::new()
-        .with_tcp_config(tcp_client_config)
+        .with_tcp()
+        .with_server_address(get_tcp_server_addr())
         .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         ..TcpClientConfig::default()
     };
     let client = IggyClientBuilder::new()
-        .with_config(IggyClientConfig::Tcp(tcp_client_config))
+        .with_tcp_config(tcp_client_config)
         .build()?;
 
     // Or, instead of above lines, you can just use below code, which will create a Iggy

--- a/examples/src/getting-started/producer/main.rs
+++ b/examples/src/getting-started/producer/main.rs
@@ -1,9 +1,8 @@
 use iggy::client::{Client, StreamClient, TopicClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientBuilder, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBuilder, TcpClientConfig};
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
 use iggy::streams::create_stream::CreateStream;
-use iggy::tcp::config::TcpClientConfig;
 use iggy::topics::create_topic::CreateTopic;
 use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;

--- a/examples/src/message-envelope/consumer/main.rs
+++ b/examples/src/message-envelope/consumer/main.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use clap::Parser;
 use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
-use iggy::clients::client::{IggyClient, IggyClientConfig, PollMessagesConfig, StoreOffsetKind};
+use iggy::clients::client::{
+    IggyClient, IggyClientBackgroundConfig, PollMessagesConfig, StoreOffsetKind,
+};
 use iggy::models::messages::Message;
 use iggy_examples::shared::args::Args;
 use iggy_examples::shared::messages::*;
@@ -21,15 +23,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     let client_provider_config = Arc::new(ClientProviderConfig::from_args(args.to_sdk_args())?);
     let client = client_provider::get_raw_connected_client(client_provider_config).await?;
-    let client = IggyClient::builder(client)
-        .with_config(IggyClientConfig {
+    let client = IggyClient::builder()
+        .with_background_config(IggyClientBackgroundConfig {
             poll_messages: PollMessagesConfig {
                 interval: args.interval,
                 store_offset_kind: StoreOffsetKind::WhenMessagesAreProcessed,
             },
             ..Default::default()
         })
-        .build();
+        .with_client(client)
+        .build()?;
     system::login_root(&client).await;
     system::init_by_consumer(&args, &client).await;
     system::consume_messages(&args, &client, &handle_message).await

--- a/examples/src/message-envelope/producer/main.rs
+++ b/examples/src/message-envelope/producer/main.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     let client_provider_config = Arc::new(ClientProviderConfig::from_args(args.to_sdk_args())?);
     let client = client_provider::get_raw_connected_client(client_provider_config).await?;
-    let client = IggyClient::builder(client).build();
+    let client = IggyClient::builder().with_client(client).build()?;
     system::login_root(&client).await;
     system::init_by_producer(&args, &client).await?;
     produce_messages(&args, &client).await

--- a/examples/src/message-headers/consumer/main.rs
+++ b/examples/src/message-headers/consumer/main.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use clap::Parser;
 use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
-use iggy::clients::client::{IggyClient, IggyClientConfig, PollMessagesConfig, StoreOffsetKind};
+use iggy::clients::client::{
+    IggyClient, IggyClientBackgroundConfig, PollMessagesConfig, StoreOffsetKind,
+};
 use iggy::models::header::HeaderKey;
 use iggy::models::messages::Message;
 use iggy_examples::shared::args::Args;
@@ -22,15 +24,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     let client_provider_config = Arc::new(ClientProviderConfig::from_args(args.to_sdk_args())?);
     let client = client_provider::get_raw_connected_client(client_provider_config).await?;
-    let client = IggyClient::builder(client)
-        .with_config(IggyClientConfig {
+    let client = IggyClient::builder()
+        .with_background_config(IggyClientBackgroundConfig {
             poll_messages: PollMessagesConfig {
                 interval: args.interval,
                 store_offset_kind: StoreOffsetKind::WhenMessagesAreProcessed,
             },
             ..Default::default()
         })
-        .build();
+        .with_client(client)
+        .build()?;
     system::login_root(&client).await;
     system::init_by_consumer(&args, &client).await;
     system::consume_messages(&args, &client, &handle_message).await

--- a/examples/src/message-headers/producer/main.rs
+++ b/examples/src/message-headers/producer/main.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     );
     let client_provider_config = Arc::new(ClientProviderConfig::from_args(args.to_sdk_args())?);
     let client = client_provider::get_raw_connected_client(client_provider_config).await?;
-    let client = IggyClient::builder(client).build();
+    let client = IggyClient::builder().with_client(client).build()?;
     system::login_root(&client).await;
     system::init_by_producer(&args, &client).await?;
     produce_messages(&args, &client).await

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -7,7 +7,7 @@ use assert_cmd::prelude::CommandCargoExt;
 use async_trait::async_trait;
 use iggy::client::Client;
 use iggy::client::{SystemClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::system::ping::Ping;
 use iggy::tcp::client::TcpClient;
 use iggy::tcp::config::TcpClientConfig;
@@ -93,7 +93,13 @@ impl IggyCmdTest {
             ..TcpClientConfig::default()
         };
         let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
 
         Self { server, client }
     }

--- a/integration/tests/examples/mod.rs
+++ b/integration/tests/examples/mod.rs
@@ -11,7 +11,7 @@ use iggy::client::SystemClient;
 use iggy::client::TopicClient;
 use iggy::client::UserClient;
 use iggy::clients::client::IggyClient;
-use iggy::clients::client::IggyClientConfig;
+use iggy::clients::client::IggyClientBackgroundConfig;
 use iggy::identifier::Identifier;
 use iggy::streams::create_stream::CreateStream;
 use iggy::system::ping::Ping;
@@ -99,7 +99,13 @@ impl<'a> IggyExampleTest<'a> {
             ..TcpClientConfig::default()
         };
         let client = Box::new(TcpClient::create(Arc::new(tcp_client_config)).unwrap());
-        let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+        let client = IggyClient::create(
+            client,
+            IggyClientBackgroundConfig::default(),
+            None,
+            None,
+            None,
+        );
 
         Self {
             server,

--- a/integration/tests/server/scenarios/consumer_group_join_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_join_scenario.rs
@@ -1,5 +1,5 @@
 use iggy::client::{ConsumerGroupClient, StreamClient, SystemClient, TopicClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
 use iggy::consumer_groups::get_consumer_group::GetConsumerGroup;
 use iggy::consumer_groups::join_consumer_group::JoinConsumerGroup;
@@ -172,7 +172,13 @@ async fn get_consumer_group_and_validate_members(
 
 async fn create_client(client_factory: &dyn ClientFactory) -> IggyClient {
     let client = client_factory.create_client().await;
-    IggyClient::create(client, IggyClientConfig::default(), None, None, None)
+    IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    )
 }
 
 async fn cleanup(system_client: &IggyClient) {

--- a/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_multiple_clients_polling_messages_scenario.rs
@@ -1,5 +1,5 @@
 use iggy::client::{ConsumerGroupClient, MessageClient, StreamClient, SystemClient, TopicClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer::Consumer;
 use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
 use iggy::consumer_groups::get_consumer_group::GetConsumerGroup;
@@ -46,7 +46,13 @@ pub async fn run(client_factory: &dyn ClientFactory) {
 
 async fn create_client(client_factory: &dyn ClientFactory) -> IggyClient {
     let client = client_factory.create_client().await;
-    IggyClient::create(client, IggyClientConfig::default(), None, None, None)
+    IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    )
 }
 
 async fn init_system(

--- a/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
+++ b/integration/tests/server/scenarios/consumer_group_with_single_client_polling_messages_scenario.rs
@@ -1,5 +1,5 @@
 use iggy::client::{ConsumerGroupClient, MessageClient, StreamClient, SystemClient, TopicClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer::Consumer;
 use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
 use iggy::consumer_groups::get_consumer_group::GetConsumerGroup;
@@ -25,7 +25,13 @@ const MESSAGES_COUNT: u32 = 500;
 
 pub async fn run(client_factory: &dyn ClientFactory) {
     let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
 
     login_root(&client).await;
     init_system(&client).await;

--- a/integration/tests/server/scenarios/message_headers_scenario.rs
+++ b/integration/tests/server/scenarios/message_headers_scenario.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use iggy::client::{MessageClient, StreamClient, TopicClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer::Consumer;
 use iggy::identifier::Identifier;
 use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
@@ -23,7 +23,13 @@ const PARTITION_ID: u32 = 1;
 
 pub async fn run(client_factory: &dyn ClientFactory) {
     let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
 
     login_root(&client).await;
     init_system(&client).await;

--- a/integration/tests/server/scenarios/stream_size_validation_scenario.rs
+++ b/integration/tests/server/scenarios/stream_size_validation_scenario.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use iggy::client::{MessageClient, StreamClient, SystemClient, TopicClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::identifier::Identifier;
 use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
 use iggy::streams::create_stream::CreateStream;
@@ -33,7 +33,13 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     let _ = tracing_subscriber::fmt::try_init();
 
     let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
 
     // 0. Ping server, login as root user and ensure that streams do not exist
     ping_login_and_validate(&client).await;

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -3,7 +3,7 @@ use iggy::client::{
     ConsumerGroupClient, ConsumerOffsetClient, MessageClient, PartitionClient, StreamClient,
     SystemClient, TopicClient, UserClient,
 };
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::consumer::{Consumer, ConsumerKind};
 use iggy::consumer_groups::create_consumer_group::CreateConsumerGroup;
 use iggy::consumer_groups::delete_consumer_group::DeleteConsumerGroup;
@@ -54,7 +54,13 @@ const MESSAGES_COUNT: u32 = 1000;
 
 pub async fn run(client_factory: &dyn ClientFactory) {
     let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
 
     // 0. Ping server
     let ping = Ping {};

--- a/integration/tests/server/scenarios/user_scenario.rs
+++ b/integration/tests/server/scenarios/user_scenario.rs
@@ -1,5 +1,5 @@
 use iggy::client::{PersonalAccessTokenClient, SystemClient, UserClient};
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::identifier::Identifier;
 use iggy::models::permissions::{GlobalPermissions, Permissions};
 use iggy::models::user_status::UserStatus;
@@ -22,7 +22,13 @@ use integration::test_server::{assert_clean_system, ClientFactory};
 
 pub async fn run(client_factory: &dyn ClientFactory) {
     let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, None);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
 
     // 1. Ping should be allowed for unauthenticated users
     client.ping(&Ping {}).await.unwrap();

--- a/sdk/src/client_provider.rs
+++ b/sdk/src/client_provider.rs
@@ -101,7 +101,7 @@ pub async fn get_default_client() -> Result<IggyClient, ClientError> {
 /// Create a `IggyClient` for the specific transport based on the provided configuration.
 pub async fn get_client(config: Arc<ClientProviderConfig>) -> Result<IggyClient, ClientError> {
     let client = get_raw_connected_client(config).await?;
-    Ok(IggyClient::builder(client).build())
+    Ok(IggyClient::builder().with_client(client).build()?)
 }
 
 /// Create a `Client` for the specific transport based on the provided configuration.

--- a/sdk/src/clients/builder.rs
+++ b/sdk/src/clients/builder.rs
@@ -1,0 +1,222 @@
+use std::sync::Arc;
+
+use crate::{
+    client::Client,
+    error::IggyError,
+    http::{client::HttpClient, config::HttpClientConfigBuilder},
+    message_handler::MessageHandler,
+    partitioner::Partitioner,
+    quic::{client::QuicClient, config::QuicClientConfigBuilder},
+    tcp::{client::TcpClient, config::TcpClientConfigBuilder},
+    utils::crypto::Encryptor,
+};
+
+use super::client::{IggyClient, IggyClientBackgroundConfig};
+use tracing::error;
+
+/// The builder for the `IggyClient` instance, which allows to configure and provide custom implementations for the partitioner, encryptor or message handler.
+#[derive(Debug, Default)]
+pub struct IggyClientBuilder {
+    client: Option<Box<dyn Client>>,
+    background_config: Option<IggyClientBackgroundConfig>,
+    partitioner: Option<Box<dyn Partitioner>>,
+    encryptor: Option<Box<dyn Encryptor>>,
+    message_handler: Option<Box<dyn MessageHandler>>,
+}
+
+impl IggyClientBuilder {
+    /// Creates a new `IggyClientBuilder`.
+    /// This is not enough to build the `IggyClient` instance. You need to provide the client configuration or the client implementation for the specific transport.
+    #[must_use]
+    pub fn new() -> Self {
+        IggyClientBuilder::default()
+    }
+
+    /// Apply the provided client implementation for the specific transport. Setting client clears the client config.
+    pub fn with_client(mut self, client: Box<dyn Client>) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    /// Use the the custom partitioner implementation.
+    pub fn with_partitioner(mut self, partitioner: Box<dyn Partitioner>) -> Self {
+        self.partitioner = Some(partitioner);
+        self
+    }
+
+    /// Apply the provided background configuration.
+    pub fn with_background_config(mut self, background_config: IggyClientBackgroundConfig) -> Self {
+        self.background_config = Some(background_config);
+        self
+    }
+
+    /// Use the the custom encryptor implementation.
+    pub fn with_encryptor(mut self, encryptor: Box<dyn Encryptor>) -> Self {
+        self.encryptor = Some(encryptor);
+        self
+    }
+
+    /// Use the the custom message handler implementation. This handler will be used only for `start_polling_messages` method, if neither `subscribe_to_polled_messages` (which returns the receiver for the messages channel) is called nor `on_message` closure is provided.
+    pub fn with_message_handler(mut self, message_handler: Box<dyn MessageHandler>) -> Self {
+        self.message_handler = Some(message_handler);
+        self
+    }
+
+    /// This method provides fluent API for the TCP client configuration.
+    /// It returns the `TcpClientBuilder` instance, which allows to configure the TCP client with custom settings or using defaults.
+    /// This should be called after the non-protocol specific methods, such as `with_partitioner`, `with_encryptor` or `with_message_handler`.
+    pub fn with_tcp(self) -> TcpClientBuilder {
+        TcpClientBuilder {
+            config: TcpClientConfigBuilder::default(),
+            parent_builder: self,
+        }
+    }
+
+    /// This method provides fluent API for the QUIC client configuration.
+    /// It returns the `QuicClientBuilder` instance, which allows to configure the QUIC client with custom settings or using defaults.
+    /// This should be called after the non-protocol specific methods, such as `with_partitioner`, `with_encryptor` or `with_message_handler`.
+    pub fn with_quic(self) -> QuicClientBuilder {
+        QuicClientBuilder {
+            config: QuicClientConfigBuilder::default(),
+            parent_builder: self,
+        }
+    }
+
+    /// This method provides fluent API for the HTTP client configuration.
+    /// It returns the `HttpClientBuilder` instance, which allows to configure the HTTP client with custom settings or using defaults.
+    /// This should be called after the non-protocol specific methods, such as `with_partitioner`, `with_encryptor` or `with_message_handler`.
+    pub fn with_http(self) -> HttpClientBuilder {
+        HttpClientBuilder {
+            config: HttpClientConfigBuilder::default(),
+            parent_builder: self,
+        }
+    }
+
+    /// Build the `IggyClient` instance.
+    /// This method returns an error if the client is not provided.
+    /// If the client is provided, it creates the `IggyClient` instance with the provided configuration.
+    /// To provide the client configuration, use the `with_tcp`, `with_quic` or `with_http` methods.
+    pub fn build(self) -> Result<IggyClient, IggyError> {
+        let Some(client) = self.client else {
+            error!("Client is not provided");
+            return Err(IggyError::InvalidConfiguration);
+        };
+
+        Ok(IggyClient::create(
+            client,
+            self.background_config.unwrap_or_default(),
+            self.message_handler,
+            self.partitioner,
+            self.encryptor,
+        ))
+    }
+}
+
+pub struct TcpClientBuilder {
+    config: TcpClientConfigBuilder,
+    parent_builder: IggyClientBuilder,
+}
+
+impl TcpClientBuilder {
+    /// Sets the server address for the TCP client.
+    pub fn with_server_address(mut self, server_address: String) -> Self {
+        self.config = self.config.with_server_address(server_address);
+        self
+    }
+
+    /// Sets the number of retries when connecting to the server.
+    pub fn with_reconnection_retries(mut self, reconnection_retries: u32) -> Self {
+        self.config = self.config.with_reconnection_retries(reconnection_retries);
+        self
+    }
+
+    /// Sets the interval between retries when connecting to the server.
+    pub fn with_reconnection_interval(mut self, reconnection_interval: u64) -> Self {
+        self.config = self
+            .config
+            .with_reconnection_interval(reconnection_interval);
+        self
+    }
+
+    /// Sets whether to use TLS when connecting to the server.
+    pub fn with_tls_enabled(mut self, tls_enabled: bool) -> Self {
+        self.config = self.config.with_tls_enabled(tls_enabled);
+        self
+    }
+
+    /// Sets the domain to use for TLS when connecting to the server.
+    pub fn with_tls_domain(mut self, tls_domain: String) -> Self {
+        self.config = self.config.with_tls_domain(tls_domain);
+        self
+    }
+
+    /// Builds the parent `IggyClient` with TCP configuration.
+    pub fn build(self) -> Result<IggyClient, IggyError> {
+        let client = TcpClient::create(Arc::new(self.config.build()))?;
+        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+    }
+}
+
+pub struct QuicClientBuilder {
+    config: QuicClientConfigBuilder,
+    parent_builder: IggyClientBuilder,
+}
+
+impl QuicClientBuilder {
+    /// Sets the server address for the QUIC client.
+    pub fn with_server_address(mut self, server_address: String) -> Self {
+        self.config = self.config.with_server_address(server_address);
+        self
+    }
+
+    /// Sets the number of retries when connecting to the server.
+    pub fn with_reconnection_retries(mut self, reconnection_retries: u32) -> Self {
+        self.config = self.config.with_reconnection_retries(reconnection_retries);
+        self
+    }
+
+    /// Sets the interval between retries when connecting to the server.
+    pub fn with_reconnection_interval(mut self, reconnection_interval: u64) -> Self {
+        self.config = self
+            .config
+            .with_reconnection_interval(reconnection_interval);
+        self
+    }
+
+    /// Sets the server name for the QUIC client.
+    pub fn with_server_name(mut self, server_name: String) -> Self {
+        self.config = self.config.with_server_name(server_name);
+        self
+    }
+
+    /// Builds the parent `IggyClient` with QUIC configuration.
+    pub fn build(self) -> Result<IggyClient, IggyError> {
+        let client = QuicClient::create(Arc::new(self.config.build()))?;
+        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+    }
+}
+
+pub struct HttpClientBuilder {
+    config: HttpClientConfigBuilder,
+    parent_builder: IggyClientBuilder,
+}
+
+impl HttpClientBuilder {
+    /// Sets the server address for the HTTP client.
+    pub fn with_api_url(mut self, api_url: String) -> Self {
+        self.config = self.config.with_api_url(api_url);
+        self
+    }
+
+    /// Sets the number of retries for the HTTP client.
+    pub fn with_retries(mut self, retries: u32) -> Self {
+        self.config = self.config.with_retries(retries);
+        self
+    }
+
+    /// Builds the parent `IggyClient` with HTTP configuration.
+    pub fn build(self) -> Result<IggyClient, IggyError> {
+        let client = HttpClient::create(Arc::new(self.config.build()))?;
+        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+    }
+}

--- a/sdk/src/clients/builder.rs
+++ b/sdk/src/clients/builder.rs
@@ -153,7 +153,8 @@ impl TcpClientBuilder {
     /// Builds the parent `IggyClient` with TCP configuration.
     pub fn build(self) -> Result<IggyClient, IggyError> {
         let client = TcpClient::create(Arc::new(self.config.build()))?;
-        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+        let client = self.parent_builder.with_client(Box::new(client)).build()?;
+        Ok(client)
     }
 }
 
@@ -192,7 +193,8 @@ impl QuicClientBuilder {
     /// Builds the parent `IggyClient` with QUIC configuration.
     pub fn build(self) -> Result<IggyClient, IggyError> {
         let client = QuicClient::create(Arc::new(self.config.build()))?;
-        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+        let client = self.parent_builder.with_client(Box::new(client)).build()?;
+        Ok(client)
     }
 }
 
@@ -217,6 +219,7 @@ impl HttpClientBuilder {
     /// Builds the parent `IggyClient` with HTTP configuration.
     pub fn build(self) -> Result<IggyClient, IggyError> {
         let client = HttpClient::create(Arc::new(self.config.build()))?;
-        Ok(self.parent_builder.with_client(Box::new(client)).build()?)
+        let client = self.parent_builder.with_client(Box::new(client)).build()?;
+        Ok(client)
     }
 }

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -13,7 +13,6 @@ use crate::consumer_offsets::get_consumer_offset::GetConsumerOffset;
 use crate::consumer_offsets::store_consumer_offset::StoreConsumerOffset;
 use crate::error::IggyError;
 use crate::http::client::HttpClient;
-use crate::http::config::HttpClientConfig;
 use crate::identifier::Identifier;
 use crate::locking::IggySharedMut;
 use crate::locking::IggySharedMutFn;
@@ -38,7 +37,6 @@ use crate::personal_access_tokens::delete_personal_access_token::DeletePersonalA
 use crate::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
 use crate::personal_access_tokens::login_with_personal_access_token::LoginWithPersonalAccessToken;
 use crate::quic::client::QuicClient;
-use crate::quic::config::QuicClientConfig;
 use crate::streams::create_stream::CreateStream;
 use crate::streams::delete_stream::DeleteStream;
 use crate::streams::get_stream::GetStream;
@@ -51,7 +49,6 @@ use crate::system::get_me::GetMe;
 use crate::system::get_stats::GetStats;
 use crate::system::ping::Ping;
 use crate::tcp::client::TcpClient;
-use crate::tcp::config::TcpClientConfig;
 use crate::topics::create_topic::CreateTopic;
 use crate::topics::delete_topic::DeleteTopic;
 use crate::topics::get_topic::GetTopic;
@@ -191,6 +188,10 @@ impl IggyClientBuilder {
         ))
     }
 }
+
+pub use crate::http::config::HttpClientConfig;
+pub use crate::quic::config::QuicClientConfig;
+pub use crate::tcp::config::TcpClientConfig;
 
 #[derive(Debug)]
 pub enum IggyClientConfig {

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -103,8 +103,8 @@ pub struct IggyClientBuilder {
 }
 
 impl IggyClientBuilder {
-    /// Creates a new `IggyClientBuilder` with the provided client implementation for the specific transport.
-    /// The client implementation must be provided directly or via the client configuration.
+    /// Creates a new `IggyClientBuilder`.
+    /// This is not enough to build the `IggyClient` instance. You need to provide the client configuration or the client implementation for the specific transport.
     #[must_use]
     pub fn new() -> Self {
         IggyClientBuilder::default()
@@ -190,11 +190,14 @@ impl IggyClientBuilder {
 }
 
 pub use crate::http::config::HttpClientConfig;
+pub use crate::http::config::HttpClientConfigBuilder;
 pub use crate::quic::config::QuicClientConfig;
+pub use crate::quic::config::QuicClientConfigBuilder;
 pub use crate::tcp::config::TcpClientConfig;
+pub use crate::tcp::config::TcpClientConfigBuilder;
 
 #[derive(Debug)]
-pub enum IggyClientConfig {
+enum IggyClientConfig {
     Tcp(TcpClientConfig),
     Quic(QuicClientConfig),
     Http(HttpClientConfig),

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -113,10 +113,21 @@ impl IggyClientBuilder {
         IggyClientBuilder::default()
     }
 
-    /// Apply the provided client configuration. Setting client config clears the client.
-    pub fn with_config(mut self, config: IggyClientConfig) -> Self {
-        self.client_config = Some(config);
-        self.client = None;
+    /// Apply the provided client configuration for the tcp transport.
+    pub fn with_tcp_config(mut self, tcp_config: TcpClientConfig) -> Self {
+        self.client_config = Some(IggyClientConfig::Tcp(tcp_config));
+        self
+    }
+
+    /// Apply the provided client configuration for the quic transport.
+    pub fn with_quic_config(mut self, quic_config: QuicClientConfig) -> Self {
+        self.client_config = Some(IggyClientConfig::Quic(quic_config));
+        self
+    }
+
+    /// Apply the provided client configuration for the http transport.
+    pub fn with_http_config(mut self, http_config: HttpClientConfig) -> Self {
+        self.client_config = Some(IggyClientConfig::Http(http_config));
         self
     }
 

--- a/sdk/src/clients/mod.rs
+++ b/sdk/src/clients/mod.rs
@@ -1,1 +1,2 @@
+mod builder;
 pub mod client;

--- a/sdk/src/http/config.rs
+++ b/sdk/src/http/config.rs
@@ -20,6 +20,7 @@ impl Default for HttpClientConfig {
 /// Allows configuring the HTTP client with custom settings or using defaults:
 /// - `api_url`: Default is "http://127.0.0.1:3000"
 /// - `retries`: Default is 3.
+#[derive(Default)]
 pub struct HttpClientConfigBuilder {
     config: HttpClientConfig,
 }
@@ -27,9 +28,7 @@ pub struct HttpClientConfigBuilder {
 impl HttpClientConfigBuilder {
     /// Create a new `HttpClientConfigBuilder` with default settings.
     pub fn new() -> Self {
-        HttpClientConfigBuilder {
-            config: HttpClientConfig::default(),
-        }
+        HttpClientConfigBuilder::default()
     }
 
     /// Sets the API URL for the HTTP client.

--- a/sdk/src/http/config.rs
+++ b/sdk/src/http/config.rs
@@ -15,3 +15,37 @@ impl Default for HttpClientConfig {
         }
     }
 }
+
+/// The builder for the `HttpClientConfig` configuration.
+/// Allows configuring the HTTP client with custom settings or using defaults:
+/// - `api_url`: Default is "http://127.0.0.1:3000"
+/// - `retries`: Default is 3.
+pub struct HttpClientConfigBuilder {
+    config: HttpClientConfig,
+}
+
+impl HttpClientConfigBuilder {
+    /// Create a new `HttpClientConfigBuilder` with default settings.
+    pub fn new() -> Self {
+        HttpClientConfigBuilder {
+            config: HttpClientConfig::default(),
+        }
+    }
+
+    /// Sets the API URL for the HTTP client.
+    pub fn with_api_url(mut self, url: String) -> Self {
+        self.config.api_url = url;
+        self
+    }
+
+    /// Sets the number of retries for the HTTP client.
+    pub fn with_retries(mut self, retries: u32) -> Self {
+        self.config.retries = retries;
+        self
+    }
+
+    /// Builds the `HttpClientConfig` instance.
+    pub fn build(self) -> HttpClientConfig {
+        self.config
+    }
+}

--- a/sdk/src/quic/config.rs
+++ b/sdk/src/quic/config.rs
@@ -69,6 +69,7 @@ impl Default for QuicClientConfig {
 /// - `keep_alive_interval`: Default is 5000 milliseconds.
 /// - `max_idle_timeout`: Default is 10,000 milliseconds.
 /// - `validate_certificate`: Default is false (certificate validation is disabled).
+#[derive(Default)]
 pub struct QuicClientConfigBuilder {
     config: QuicClientConfig,
 }
@@ -76,9 +77,7 @@ pub struct QuicClientConfigBuilder {
 impl QuicClientConfigBuilder {
     /// Creates a new builder instance with default configuration values.
     pub fn new() -> Self {
-        QuicClientConfigBuilder {
-            config: QuicClientConfig::default(),
-        }
+        QuicClientConfigBuilder::default()
     }
 
     /// Sets the client address. Defaults to "127.0.0.1:0".

--- a/sdk/src/quic/config.rs
+++ b/sdk/src/quic/config.rs
@@ -51,3 +51,122 @@ impl Default for QuicClientConfig {
         }
     }
 }
+
+/// Builder for the QUIC client configuration.
+///
+/// Allows configuring the QUIC client with custom settings or using defaults:
+/// - `client_address`: Default is "127.0.0.1:0" (binds to any available port).
+/// - `server_address`: Default is "127.0.0.1:8080".
+/// - `server_name`: Default is "localhost".
+/// - `reconnection_retries`: Default is 3 attempts.
+/// - `reconnection_interval`: Default is 1000 milliseconds.
+/// - `response_buffer_size`: Default is 10MB (10,000,000 bytes).
+/// - `max_concurrent_bidi_streams`: Default is 10,000 streams.
+/// - `datagram_send_buffer_size`: Default is 100,000 bytes.
+/// - `initial_mtu`: Default is 1200 bytes.
+/// - `send_window`: Default is 100,000 bytes.
+/// - `receive_window`: Default is 100,000 bytes.
+/// - `keep_alive_interval`: Default is 5000 milliseconds.
+/// - `max_idle_timeout`: Default is 10,000 milliseconds.
+/// - `validate_certificate`: Default is false (certificate validation is disabled).
+pub struct QuicClientConfigBuilder {
+    config: QuicClientConfig,
+}
+
+impl QuicClientConfigBuilder {
+    /// Creates a new builder instance with default configuration values.
+    pub fn new() -> Self {
+        QuicClientConfigBuilder {
+            config: QuicClientConfig::default(),
+        }
+    }
+
+    /// Sets the client address. Defaults to "127.0.0.1:0".
+    pub fn with_client_address(mut self, client_address: String) -> Self {
+        self.config.client_address = client_address;
+        self
+    }
+
+    /// Sets the server address. Defaults to "127.0.0.1:8080".
+    pub fn with_server_address(mut self, server_address: String) -> Self {
+        self.config.server_address = server_address;
+        self
+    }
+
+    /// Sets the server name. Defaults to "localhost".
+    pub fn with_server_name(mut self, server_name: String) -> Self {
+        self.config.server_name = server_name;
+        self
+    }
+
+    /// Sets the number of reconnection retries. Defaults to 3.
+    pub fn with_reconnection_retries(mut self, reconnection_retries: u32) -> Self {
+        self.config.reconnection_retries = reconnection_retries;
+        self
+    }
+
+    /// Sets the reconnection interval in milliseconds. Defaults to 1000ms.
+    pub fn with_reconnection_interval(mut self, reconnection_interval: u64) -> Self {
+        self.config.reconnection_interval = reconnection_interval;
+        self
+    }
+
+    /// Sets the response buffer size in bytes. Defaults to 10MB (10,000,000 bytes).
+    pub fn with_response_buffer_size(mut self, response_buffer_size: u64) -> Self {
+        self.config.response_buffer_size = response_buffer_size;
+        self
+    }
+
+    /// Sets the maximum number of concurrent bidirectional streams. Defaults to 10,000.
+    pub fn with_max_concurrent_bidi_streams(mut self, max_concurrent_bidi_streams: u64) -> Self {
+        self.config.max_concurrent_bidi_streams = max_concurrent_bidi_streams;
+        self
+    }
+
+    /// Sets the datagram send buffer size in bytes. Defaults to 100,000 bytes.
+    pub fn with_datagram_send_buffer_size(mut self, datagram_send_buffer_size: u64) -> Self {
+        self.config.datagram_send_buffer_size = datagram_send_buffer_size;
+        self
+    }
+
+    /// Sets the initial MTU (Maximum Transmission Unit) in bytes. Defaults to 1200 bytes.
+    pub fn with_initial_mtu(mut self, initial_mtu: u16) -> Self {
+        self.config.initial_mtu = initial_mtu;
+        self
+    }
+
+    /// Sets the send window size in bytes. Defaults to 100,000 bytes.
+    pub fn with_send_window(mut self, send_window: u64) -> Self {
+        self.config.send_window = send_window;
+        self
+    }
+
+    /// Sets the receive window size in bytes. Defaults to 100,000 bytes.
+    pub fn with_receive_window(mut self, receive_window: u64) -> Self {
+        self.config.receive_window = receive_window;
+        self
+    }
+
+    /// Sets the keep-alive interval in milliseconds. Defaults to 5000ms.
+    pub fn with_keep_alive_interval(mut self, keep_alive_interval: u64) -> Self {
+        self.config.keep_alive_interval = keep_alive_interval;
+        self
+    }
+
+    /// Sets the maximum idle timeout in milliseconds. Defaults to 10,000ms.
+    pub fn with_max_idle_timeout(mut self, max_idle_timeout: u64) -> Self {
+        self.config.max_idle_timeout = max_idle_timeout;
+        self
+    }
+
+    /// Enables or disables certificate validation. Defaults to false (disabled).
+    pub fn with_validate_certificate(mut self, validate_certificate: bool) -> Self {
+        self.config.validate_certificate = validate_certificate;
+        self
+    }
+
+    /// Finalizes the builder and returns the `QuicClientConfig`.
+    pub fn build(self) -> QuicClientConfig {
+        self.config
+    }
+}

--- a/sdk/src/tcp/config.rs
+++ b/sdk/src/tcp/config.rs
@@ -24,3 +24,57 @@ impl Default for TcpClientConfig {
         }
     }
 }
+
+/// Builder for the TCP client configuration.
+/// Allows configuring the TCP client with custom settings or using defaults:
+/// - `server_address`: Default is "127.0.0.1:8090"
+/// - `reconnection_retries`: Default is 3.
+/// - `reconnection_interval`: Default is 1000 ms.
+/// - `tls_enabled`: Default is false.
+/// - `tls_domain`: Default is "localhost".
+pub struct TcpClientConfigBuilder {
+    config: TcpClientConfig,
+}
+
+impl TcpClientConfigBuilder {
+    pub fn new() -> Self {
+        TcpClientConfigBuilder {
+            config: TcpClientConfig::default(),
+        }
+    }
+
+    /// Sets the server address for the TCP client.
+    pub fn with_server_address(mut self, server_address: String) -> Self {
+        self.config.server_address = server_address;
+        self
+    }
+
+    /// Sets the number of retries when connecting to the server.
+    pub fn with_reconnection_retries(mut self, reconnection_retries: u32) -> Self {
+        self.config.reconnection_retries = reconnection_retries;
+        self
+    }
+
+    /// Sets the interval between retries when connecting to the server.
+    pub fn with_reconnection_interval(mut self, reconnection_interval: u64) -> Self {
+        self.config.reconnection_interval = reconnection_interval;
+        self
+    }
+
+    /// Sets whether to use TLS when connecting to the server.
+    pub fn with_tls_enabled(mut self, tls_enabled: bool) -> Self {
+        self.config.tls_enabled = tls_enabled;
+        self
+    }
+
+    /// Sets the domain to use for TLS when connecting to the server.
+    pub fn with_tls_domain(mut self, tls_domain: String) -> Self {
+        self.config.tls_domain = tls_domain;
+        self
+    }
+
+    /// Builds the TCP client configuration.
+    pub fn build(self) -> TcpClientConfig {
+        self.config
+    }
+}

--- a/sdk/src/tcp/config.rs
+++ b/sdk/src/tcp/config.rs
@@ -32,15 +32,14 @@ impl Default for TcpClientConfig {
 /// - `reconnection_interval`: Default is 1000 ms.
 /// - `tls_enabled`: Default is false.
 /// - `tls_domain`: Default is "localhost".
+#[derive(Default)]
 pub struct TcpClientConfigBuilder {
     config: TcpClientConfig,
 }
 
 impl TcpClientConfigBuilder {
     pub fn new() -> Self {
-        TcpClientConfigBuilder {
-            config: TcpClientConfig::default(),
-        }
+        TcpClientConfigBuilder::default()
     }
 
     /// Sets the server address for the TCP client.

--- a/tools/src/data-seeder/main.rs
+++ b/tools/src/data-seeder/main.rs
@@ -6,7 +6,7 @@ use iggy::args::{Args, ArgsOptional};
 use iggy::client::UserClient;
 use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
-use iggy::clients::client::{IggyClient, IggyClientConfig};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
 use iggy::users::login_user::LoginUser;
 use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
 use std::error::Error;
@@ -43,7 +43,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let password = args.password.clone();
     let client_provider_config = Arc::new(ClientProviderConfig::from_args(iggy_args)?);
     let client = client_provider::get_raw_connected_client(client_provider_config).await?;
-    let client = IggyClient::create(client, IggyClientConfig::default(), None, None, encryptor);
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        encryptor,
+    );
     client
         .login_user(&LoginUser { username, password })
         .await


### PR DESCRIPTION
This is related to https://github.com/iggy-rs/iggy/issues/528.

I could not find a way to make config a trait in a nice way. So I was deciding with either single `with_config` where the configs be wrapped in an enum, or multiple with methods. The latter seemed more natural to me.

This is a way to construct a client with tcp now:
```
let tcp_client_config = TcpClientConfig {
        server_address: get_tcp_server_addr(),
        ..TcpClientConfig::default()
    };
    let client = IggyClientBuilder::new()
        .with_tcp_config(tcp_client_config)
        .build()?;
```

To consider:
- should  `TCP, QUICK, HTTP` client configs be abstracted as well (or at least re export them), so the users don't have to include `iggy::tcp::config` for example? 