### PR TITLE
Update error handling to include detailed messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/cli/src/credentials.rs
+++ b/cli/src/credentials.rs
@@ -157,7 +157,7 @@ impl<'a> IggyCredentials<'a> {
                             .await;
                         if let Err(err) = login_result {
                             match err {
-                                IggyError::InvalidResponse(code) => {
+                                IggyError::InvalidResponse(code, _, _) => {
                                     // Check what does the code means and if that's one of the cases
                                     // when we should delete the session and inform user to try login again
                                     // TODO: improve this part when we have more information about the codes

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.4"
+version = "0.2.5"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -116,8 +116,8 @@ pub enum IggyError {
     CannotCreateEndpoint = 302,
     #[error("Cannot parse URL")]
     CannotParseUrl = 303,
-    #[error("Invalid response: {0}")]
-    InvalidResponse(u32) = 304,
+    #[error("Invalid response: {0}: {2})")]
+    InvalidResponse(u32, u32, String) = 304,
     #[error("Empty response")]
     EmptyResponse = 305,
     #[error("Cannot parse address")]

--- a/sdk/src/quic/client.rs
+++ b/sdk/src/quic/client.rs
@@ -200,7 +200,16 @@ impl QuicClient {
                 status,
                 IggyError::from_code_as_string(status)
             );
-            return Err(IggyError::InvalidResponse(status));
+
+            let length =
+                u32::from_le_bytes(buffer[4..RESPONSE_INITIAL_BYTES_LENGTH].try_into().unwrap());
+            let error_message = String::from_utf8_lossy(
+                &buffer[RESPONSE_INITIAL_BYTES_LENGTH + 4
+                    ..RESPONSE_INITIAL_BYTES_LENGTH + length as usize],
+            )
+            .to_string();
+
+            return Err(IggyError::InvalidResponse(status, length, error_message));
         }
 
         let length =

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
This commit enhances InvalidResponse error enum by adding detailed error
string and its length in order to be able to send it over the wire.
Corresponding changes have been made in the QUIC and TCP client to
rebuild detailed error responses on client side. This will improve
debugging and user feedback when errors occur.

This fixes #686
