### PR TITLE
Add I/O profiling support to profiling scripts

### DIFF
--- a/justfile
+++ b/justfile
@@ -11,8 +11,10 @@ alias c  := tests
 alias n  := nextest
 alias s  := nextests
 alias rb := run-benches
-alias ps := profile-server
-alias pc := profile-client
+alias pcs := profile-cpu-server
+alias pcc := profile-cpu-client
+alias pis := profile-io-server
+alias pic := profile-io-client
 
 build:
   cargo build
@@ -38,8 +40,14 @@ build-tokio-console:
 run-benches:
   ./scripts/run-benches.sh
 
-profile-server:
-  ./scripts/profile.sh iggy-server
+profile-cpu-server:
+  ./scripts/profile.sh iggy-server cpu
 
-profile-client:
-  ./scripts/profile.sh iggy-bench
+profile-cpu-client:
+  ./scripts/profile.sh iggy-bench cpu
+
+profile-io-server:
+  ./scripts/profile.sh iggy-server io
+
+profile-io-client:
+  ./scripts/profile.sh iggy-bench io

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -12,21 +12,41 @@ trap on_exit_profile SIGINT
 trap on_exit_profile EXIT
 
 PROFILED_APP_NAME=$1
+PROFILING_MODE=$2
 
-if [[ -z "${PROFILED_APP_NAME}" ]]; then
-    echo "Usage: $0 <app_name>"
+# Check if the script is being run with the correct arguments
+if [[ -z "${PROFILED_APP_NAME}" || -z "${PROFILING_MODE}" ]]; then
+    echo "Usage: $0 <app_name> <profiling_mode>"
     exit 1
 fi
 
+# Check if the app name and profiling mode are valid
 if [[ "${PROFILED_APP_NAME}" != "iggy-bench" ]] && [[ "${PROFILED_APP_NAME}" != "iggy-server" ]]; then
     echo "Invalid app name. Please use 'iggy-bench' or 'iggy-server'."
     exit 1
+fi
+
+# Check if the profiling mode is valid
+if [[ "${PROFILING_MODE}" != "cpu" ]] && [[ "${PROFILING_MODE}" != "io" ]]; then
+    echo "Invalid profiling mode. Please use 'cpu' or 'io'."
+    exit 1
+fi
+
+# Clone FlameGraph repository to /tmp if it doesn't exist
+if [[ "$PROFILING_MODE" == "io" ]]; then
+    if [[ -d /tmp/FlameGraph ]]; then
+        echo "FlameGraph repository exists in /tmp/FlameGraph"
+    else
+        echo "Cloning FlameGraph repository to /tmp/FlameGraph..."
+        git clone https://github.com/brendangregg/FlameGraph.git /tmp/FlameGraph
+    fi
 fi
 
 # Check system settings for perf
 paranoid=$(cat /proc/sys/kernel/perf_event_paranoid)
 restrict=$(cat /proc/sys/kernel/kptr_restrict)
 
+# Check if the system settings for perf are configured correctly
 if [[ "${paranoid}" -ne -1 ]] || [[ "${restrict}" -ne 0 ]]; then
     echo "System settings for perf are not configured correctly."
     echo "Please run the following commands"
@@ -46,7 +66,7 @@ done
 # Validate addr2line version
 addr2line_version=$(addr2line --version)
 if [[ ! "${addr2line_version}" == *"0.21.0"* ]]; then
-    echo "Incompatible addr2line version. Please install the correct version."
+    echo "Incompatible addr2line version. Please install the correct version from https://github.com/gimli-rs/addr2line"
     exit 1
 fi
 
@@ -66,8 +86,8 @@ GIT_INFO=$(get_git_info)
 SERVER_LOG_FILE="profiling_server_${GIT_INFO}.log"
 BENCH_SEND_LOG_FILE="profiling_bench_send_${GIT_INFO}.log"
 BENCH_POLL_LOG_FILE="profiling_bench_poll_${GIT_INFO}.log"
-FLAMEGRAPH_SEND_SVG="flamegraph_send_${PROFILED_APP_NAME}_${GIT_INFO}.svg"
-FLAMEGRAPH_POLL_SVG="flamegraph_poll_${PROFILED_APP_NAME}_${GIT_INFO}.svg"
+FLAMEGRAPH_SEND_SVG="flamegraph_send_${PROFILING_MODE}_${PROFILED_APP_NAME}_${GIT_INFO}.svg"
+FLAMEGRAPH_POLL_SVG="flamegraph_poll_${PROFILING_MODE}_${PROFILED_APP_NAME}_${GIT_INFO}.svg"
 
 # Start iggy-server and capture its PID
 echo "Running iggy-server, log will be in ${SERVER_LOG_FILE}..."
@@ -79,18 +99,37 @@ echo "Running iggy-bench send tcp..."
 if [[ "${PROFILED_APP_NAME}" == "iggy-server" ]]; then
     # Start flamegraph for iggy-server (send)
     echo "Starting flamegraph (send) on iggy-server..."
-    flamegraph -o "${FLAMEGRAPH_SEND_SVG}" --pid "$(pgrep iggy-server)" 2>&1 &
+
+    if [[ "${PROFILING_MODE}" == "cpu" ]]; then
+        flamegraph -o "${FLAMEGRAPH_SEND_SVG}" --pid "$(pgrep iggy-server)" 2>&1 &
+    else
+        perf record -a -g -p "$(pgrep iggy-server)" -o perf_server_send.data -- sleep 30 2>&1 &
+    fi
     sleep 1
+
     target/release/iggy-bench send tcp > "${BENCH_SEND_LOG_FILE}"
 
     # Trigger flamegraph (send) completion
     send_signal "perf" "TERM"
+
+    # Wait for perf to finish
     wait_for_process "perf" 10
 
+    # Process perf data
+    if [[ "${PROFILING_MODE}" == "io" ]]; then
+        perf script --header -i perf_server_send.data > perf_server_send.stacks
+        rm perf_server_send.data
+        /tmp/FlameGraph/stackcollapse-perf.pl < perf_server_send.stacks | /tmp/FlameGraph/flamegraph.pl --color=io \
+            --title="iggy-server send I/O Flame Graph" --countname="I/O" > "${FLAMEGRAPH_SEND_SVG}"
+    fi
 
     # Start flamegraph for iggy-server (poll)
     echo "Starting flamegraph (poll)..."
-    flamegraph -o "${FLAMEGRAPH_POLL_SVG}" --pid "$(pgrep iggy-server)" 2>&1 &
+    if [[ "${PROFILING_MODE}" == "cpu" ]]; then
+        flamegraph -o "${FLAMEGRAPH_POLL_SVG}" --pid "$(pgrep iggy-server)" 2>&1 &
+    else
+        perf record -a -g -p "$(pgrep iggy-server)" -o perf_server_poll.data -- sleep 30 2>&1 &
+    fi
     sleep 1
 
     # Run iggy-bench poll tcp
@@ -100,13 +139,38 @@ if [[ "${PROFILED_APP_NAME}" == "iggy-server" ]]; then
     # Trigger flamegraph (poll) completion
     send_signal "perf" "TERM"
 
+    # Wait for perf to finish
     wait_for_process "perf" 10
+
+    # Process perf data
+    if [[ "${PROFILING_MODE}" == "io" ]]; then
+        perf script --header -i perf_server_poll.data > perf_server_poll.stacks
+        rm perf_server_poll.data
+        /tmp/FlameGraph/stackcollapse-perf.pl < perf_server_poll.stacks | /tmp/FlameGraph/flamegraph.pl --color=io \
+            --title="iggy-server poll I/O Flame Graph" --countname="I/O" > "${FLAMEGRAPH_POLL_SVG}"
+    fi
 else
     echo "Starting flamegraph (send) on iggy-bench..."
-    cargo flamegraph --bin iggy-bench -o "${FLAMEGRAPH_SEND_SVG}" -- send tcp > "${BENCH_SEND_LOG_FILE}"
+    if [[ "${PROFILING_MODE}" == "cpu" ]]; then
+        cargo flamegraph --bin iggy-bench -o "${FLAMEGRAPH_SEND_SVG}" -- send tcp > "${BENCH_SEND_LOG_FILE}"
+    else
+        perf record -a -g -o perf_bench_send.data -- target/release/iggy-bench send tcp > "${BENCH_SEND_LOG_FILE}"
+        perf script --header -i perf_bench_send.data > perf_bench_send.stacks
+        /tmp/FlameGraph/stackcollapse-perf.pl < perf_bench_send.stacks | /tmp/FlameGraph/flamegraph.pl --color=io \
+            --title="iggy client send I/O Flame Graph" --countname="I/O" > "${FLAMEGRAPH_SEND_SVG}"
+    fi
+
     sleep 1
+
     echo "Starting flamegraph (poll) on iggy-bench..."
-    cargo flamegraph --bin iggy-bench -o "${FLAMEGRAPH_POLL_SVG}" -- poll tcp > "${BENCH_POLL_LOG_FILE}"
+    if [[ "${PROFILING_MODE}" == "cpu" ]]; then
+        cargo flamegraph --bin iggy-bench -o "${FLAMEGRAPH_POLL_SVG}" -- poll tcp > "${BENCH_POLL_LOG_FILE}"
+    else
+        perf record -a -g -o perf_bench_poll.data -- target/release/iggy-bench poll tcp > "${BENCH_POLL_LOG_FILE}"
+        perf script --header -i perf_bench_poll.data > perf_bench_poll.stacks
+        /tmp/FlameGraph/stackcollapse-perf.pl < perf_bench_poll.stacks | /tmp/FlameGraph/flamegraph.pl --color=io \
+            --title="iggy client poll I/O Flame Graph" --countname="I/O" > "${FLAMEGRAPH_POLL_SVG}"
+    fi
 fi
 
 # Gracefully stop the server


### PR DESCRIPTION
This commit introduces the ability to perform I/O profiling for both the
server (`iggy-server`) and the client (`iggy-bench`). The `profile.sh`
script has been updated to accept a second argument specifying the
profiling mode, which can be either 'cpu' or 'io'.

The justfile aliases `ps` and `pc` have been renamed to `pcs` and `pcc`
to reflect CPU profiling, and new aliases `pis` and `pic` have been
added for I/O profiling.

Additionally, the commit ensures that the FlameGraph repository is
cloned to `/tmp` if it's not already present when I/O profiling is
selected. The script also checks for the correct system settings for
perf and provides instructions to the user if adjustments are needed.

Flamegraph SVG filenames now include the profiling mode to distinguish
between CPU and I/O profiling results.

For I/O profiling, `perf` is used to record the data, which is then
processed using the FlameGraph toolchain to generate the final SVG
flamegraphs.

Overall, this enhancement to the profiling infrastructure allows for
more comprehensive performance analysis by including I/O operations,
which are critical for understanding the full spectrum of application
behavior under load.
