### PR TITLE
Add system info logging and refine message persistence

### DIFF
--- a/configs/server.json
+++ b/configs/server.json
@@ -101,7 +101,8 @@
       "path": "logs",
       "level": "info",
       "max_size": "512MB",
-      "retention": "7 days"
+      "retention": "7 days",
+      "sysinfo_print_interval": "10s"
     },
     "cache": {
       "enabled": true,

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -246,6 +246,9 @@ max_size = "512 MB"
 # Time to retain log files before deletion.
 retention = "7 days"
 
+# Interval for printing system information to the log.
+sysinfo_print_interval = "10s"
+
 # Cache configuration.
 [system.cache]
 # Enables or disables the system cache.

--- a/integration/tests/config_provider/mod.rs
+++ b/integration/tests/config_provider/mod.rs
@@ -36,7 +36,7 @@ async fn validate_server_config_json_from_repository() {
 #[tokio::test]
 async fn validate_custom_env_provider() {
     let expected_database_path = "awesome_database_path";
-    let expected_datagram_send_buffer_size = "1 KB";
+    let expected_datagram_send_buffer_size = "1.00 KB";
     let expected_quic_certificate_self_signed = false;
     let expected_http_enabled = false;
     let expected_tcp_enabled = "false";

--- a/integration/tests/streaming/consumer_group.rs
+++ b/integration/tests/streaming/consumer_group.rs
@@ -1,7 +1,10 @@
 use crate::streaming::common::test_setup::TestSetup;
 use iggy::identifier::Identifier;
 use server::streaming::topics::topic::Topic;
-use std::sync::{atomic::AtomicU64, Arc};
+use std::sync::{
+    atomic::{AtomicU32, AtomicU64},
+    Arc,
+};
 
 #[tokio::test]
 async fn should_persist_consumer_group_and_then_load_it_from_disk() {
@@ -74,6 +77,7 @@ async fn init_topic(setup: &TestSetup) -> Topic {
     let stream_id = 1;
     let size_of_parent_stream = Arc::new(AtomicU64::new(0));
     let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
+    let segments_count_of_parent_stream = Arc::new(AtomicU32::new(0));
 
     setup.create_topics_directory(stream_id).await;
     let name = "test";
@@ -86,6 +90,7 @@ async fn init_topic(setup: &TestSetup) -> Topic {
         setup.storage.clone(),
         size_of_parent_stream,
         messages_count_of_parent_stream,
+        segments_count_of_parent_stream,
         None,
         None,
         1,

--- a/integration/tests/streaming/messages.rs
+++ b/integration/tests/streaming/messages.rs
@@ -7,7 +7,7 @@ use server::configs::system::{PartitionConfig, SystemConfig};
 use server::streaming::partitions::partition::Partition;
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 
 #[tokio::test]
@@ -37,6 +37,7 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU32::new(0)),
     );
 
     let mut messages = Vec::with_capacity(messages_count as usize);
@@ -100,6 +101,7 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU32::new(0)),
     );
     loaded_partition.load().await.unwrap();
     let loaded_messages = loaded_partition

--- a/integration/tests/streaming/partition.rs
+++ b/integration/tests/streaming/partition.rs
@@ -2,7 +2,7 @@ use crate::streaming::common::test_setup::TestSetup;
 use crate::streaming::create_messages;
 use server::streaming::partitions::partition::Partition;
 use server::streaming::segments::segment::{INDEX_EXTENSION, LOG_EXTENSION, TIME_INDEX_EXTENSION};
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 use tokio::fs;
 
@@ -27,6 +27,7 @@ async fn should_persist_partition_with_segment() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
 
         partition.persist().await.unwrap();
@@ -56,6 +57,7 @@ async fn should_load_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;
@@ -72,6 +74,7 @@ async fn should_load_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         loaded_partition.load().await.unwrap();
 
@@ -120,6 +123,7 @@ async fn should_delete_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;
@@ -151,6 +155,7 @@ async fn should_purge_existing_partition_on_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         );
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.path, with_segment).await;

--- a/integration/tests/streaming/topic.rs
+++ b/integration/tests/streaming/topic.rs
@@ -1,4 +1,4 @@
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 
 use crate::streaming::common::test_setup::TestSetup;
@@ -27,6 +27,7 @@ async fn should_persist_topics_with_partitions_directories_and_info_file() {
             setup.storage.clone(),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
             None,
             None,
             1,
@@ -62,6 +63,7 @@ async fn should_load_existing_topic_from_disk() {
             setup.storage.clone(),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
             None,
             None,
             1,
@@ -78,6 +80,9 @@ async fn should_load_existing_topic_from_disk() {
         let mut loaded_topic = Topic::empty(
             stream_id,
             topic_id,
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
             setup.config.clone(),
             setup.storage.clone(),
         );
@@ -109,6 +114,7 @@ async fn should_delete_existing_topic_from_disk() {
             setup.storage.clone(),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
             None,
             None,
             1,
@@ -146,6 +152,7 @@ async fn should_purge_existing_topic_on_disk() {
             setup.storage.clone(),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
             None,
             None,
             1,

--- a/integration/tests/streaming/topic_messages.rs
+++ b/integration/tests/streaming/topic_messages.rs
@@ -12,7 +12,7 @@ use server::streaming::topics::topic::Topic;
 use server::streaming::utils::hash;
 use std::collections::HashMap;
 use std::str::{from_utf8, FromStr};
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 
 #[tokio::test]
@@ -208,6 +208,7 @@ async fn init_topic(setup: &TestSetup, partitions_count: u32) -> Topic {
         setup.storage.clone(),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU32::new(0)),
         None,
         None,
         1,

--- a/sdk/src/binary/mapper.rs
+++ b/sdk/src/binary/mapper.rs
@@ -29,22 +29,23 @@ const EMPTY_CONSUMER_GROUPS: Vec<ConsumerGroup> = vec![];
 pub fn map_stats(payload: Bytes) -> Result<Stats, IggyError> {
     let process_id = u32::from_le_bytes(payload[..4].try_into()?);
     let cpu_usage = f32::from_le_bytes(payload[4..8].try_into()?);
-    let memory_usage = u64::from_le_bytes(payload[8..16].try_into()?).into();
-    let total_memory = u64::from_le_bytes(payload[16..24].try_into()?).into();
-    let available_memory = u64::from_le_bytes(payload[24..32].try_into()?).into();
-    let run_time = u64::from_le_bytes(payload[32..40].try_into()?);
-    let start_time = u64::from_le_bytes(payload[40..48].try_into()?);
-    let read_bytes = u64::from_le_bytes(payload[48..56].try_into()?).into();
-    let written_bytes = u64::from_le_bytes(payload[56..64].try_into()?).into();
-    let total_size_bytes = u64::from_le_bytes(payload[64..72].try_into()?).into();
-    let streams_count = u32::from_le_bytes(payload[72..76].try_into()?);
-    let topics_count = u32::from_le_bytes(payload[76..80].try_into()?);
-    let partitions_count = u32::from_le_bytes(payload[80..84].try_into()?);
-    let segments_count = u32::from_le_bytes(payload[84..88].try_into()?);
-    let messages_count = u64::from_le_bytes(payload[88..96].try_into()?);
-    let clients_count = u32::from_le_bytes(payload[96..100].try_into()?);
-    let consumer_groups_count = u32::from_le_bytes(payload[100..104].try_into()?);
-    let mut current_position = 104;
+    let total_cpu_usage = f32::from_le_bytes(payload[8..12].try_into()?);
+    let memory_usage = u64::from_le_bytes(payload[12..20].try_into()?).into();
+    let total_memory = u64::from_le_bytes(payload[20..28].try_into()?).into();
+    let available_memory = u64::from_le_bytes(payload[28..36].try_into()?).into();
+    let run_time = u64::from_le_bytes(payload[36..44].try_into()?).into();
+    let start_time = u64::from_le_bytes(payload[44..52].try_into()?).into();
+    let read_bytes = u64::from_le_bytes(payload[52..60].try_into()?).into();
+    let written_bytes = u64::from_le_bytes(payload[60..68].try_into()?).into();
+    let messages_size_bytes = u64::from_le_bytes(payload[68..76].try_into()?).into();
+    let streams_count = u32::from_le_bytes(payload[76..80].try_into()?);
+    let topics_count = u32::from_le_bytes(payload[80..84].try_into()?);
+    let partitions_count = u32::from_le_bytes(payload[84..88].try_into()?);
+    let segments_count = u32::from_le_bytes(payload[88..92].try_into()?);
+    let messages_count = u64::from_le_bytes(payload[92..100].try_into()?);
+    let clients_count = u32::from_le_bytes(payload[100..104].try_into()?);
+    let consumer_groups_count = u32::from_le_bytes(payload[104..108].try_into()?);
+    let mut current_position = 108;
     let hostname_length =
         u32::from_le_bytes(payload[current_position..current_position + 4].try_into()?) as usize;
     let hostname =
@@ -71,6 +72,7 @@ pub fn map_stats(payload: Bytes) -> Result<Stats, IggyError> {
     Ok(Stats {
         process_id,
         cpu_usage,
+        total_cpu_usage,
         memory_usage,
         total_memory,
         available_memory,
@@ -78,7 +80,7 @@ pub fn map_stats(payload: Bytes) -> Result<Stats, IggyError> {
         start_time,
         read_bytes,
         written_bytes,
-        messages_size_bytes: total_size_bytes,
+        messages_size_bytes,
         streams_count,
         topics_count,
         partitions_count,
@@ -331,7 +333,7 @@ pub fn map_stream(payload: Bytes) -> Result<StreamDetails, IggyError> {
 
 fn map_to_stream(payload: Bytes, position: usize) -> Result<(Stream, usize), IggyError> {
     let id = u32::from_le_bytes(payload[position..position + 4].try_into()?);
-    let created_at = u64::from_le_bytes(payload[position + 4..position + 12].try_into()?);
+    let created_at = u64::from_le_bytes(payload[position + 4..position + 12].try_into()?).into();
     let topics_count = u32::from_le_bytes(payload[position + 12..position + 16].try_into()?);
     let size_bytes = u64::from_le_bytes(payload[position + 16..position + 24].try_into()?).into();
     let messages_count = u64::from_le_bytes(payload[position + 24..position + 32].try_into()?);

--- a/sdk/src/cli/message/poll_messages.rs
+++ b/sdk/src/cli/message/poll_messages.rs
@@ -94,7 +94,7 @@ impl CliCommand for PollMessagesCmd {
         messages.messages.iter().for_each(|message| {
             table.add_row(vec![
                 format!("{}", message.offset),
-                IggyTimestamp::from(message.timestamp).to_local("%Y-%m-%d %H:%M:%S%.6f"),
+                IggyTimestamp::from(message.timestamp).to_local_string("%Y-%m-%d %H:%M:%S%.6f"),
                 format!("{}", message.id),
                 format!("{}", message.payload.len()),
                 String::from_utf8_lossy(&message.payload).to_string(),

--- a/sdk/src/cli/personal_access_tokens/get_personal_access_tokens.rs
+++ b/sdk/src/cli/personal_access_tokens/get_personal_access_tokens.rs
@@ -52,7 +52,9 @@ impl CliCommand for GetPersonalAccessTokensCmd {
                     table.add_row(vec![
                         format!("{}", token.name.clone()),
                         match token.expiry {
-                            Some(value) => IggyTimestamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            Some(value) => {
+                                IggyTimestamp::from(value).to_local_string("%Y-%m-%d %H:%M:%S")
+                            }
                             None => String::from("unlimited"),
                         },
                     ]);
@@ -66,7 +68,7 @@ impl CliCommand for GetPersonalAccessTokensCmd {
                         "{}|{}",
                         token.name,
                         match token.expiry {
-                            Some(value) => IggyTimestamp::from(value).to_local("%Y-%m-%d %H:%M:%S"),
+                            Some(value) => IggyTimestamp::from(value).to_local_string("%Y-%m-%d %H:%M:%S"),
                             None => String::from("unlimited"),
                         },
                     );

--- a/sdk/src/cli/streams/get_stream.rs
+++ b/sdk/src/cli/streams/get_stream.rs
@@ -2,7 +2,6 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::identifier::Identifier;
 use crate::streams::get_stream::GetStream;
-use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -38,12 +37,7 @@ impl CliCommand for GetStreamCmd {
 
         table.set_header(vec!["Property", "Value"]);
         table.add_row(vec!["Stream ID", format!("{}", stream.id).as_str()]);
-        table.add_row(vec![
-            "Created",
-            IggyTimestamp::from(stream.created_at)
-                .to_string("%Y-%m-%d %H:%M:%S")
-                .as_str(),
-        ]);
+        table.add_row(vec!["Created", format!("{}", stream.created_at).as_str()]);
         table.add_row(vec!["Stream name", stream.name.as_str()]);
         table.add_row(vec![
             "Stream size",

--- a/sdk/src/cli/streams/get_streams.rs
+++ b/sdk/src/cli/streams/get_streams.rs
@@ -1,7 +1,6 @@
 use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::client::Client;
 use crate::streams::get_streams::GetStreams;
-use crate::utils::timestamp::IggyTimestamp;
 use anyhow::Context;
 use async_trait::async_trait;
 use comfy_table::Table;
@@ -67,7 +66,7 @@ impl CliCommand for GetStreamsCmd {
                 streams.iter().for_each(|stream| {
                     table.add_row(vec![
                         format!("{}", stream.id),
-                        IggyTimestamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        format!("{}", stream.created_at),
                         stream.name.clone(),
                         format!("{}", stream.size_bytes),
                         format!("{}", stream.messages_count),
@@ -82,7 +81,7 @@ impl CliCommand for GetStreamsCmd {
                     event!(target: PRINT_TARGET, Level::INFO,
                         "{}|{}|{}|{}|{}|{}",
                         stream.id,
-                        IggyTimestamp::from(stream.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        stream.created_at,
                         stream.name,
                         stream.size_bytes,
                         stream.messages_count,

--- a/sdk/src/cli/system/stats.rs
+++ b/sdk/src/cli/system/stats.rs
@@ -3,10 +3,8 @@ use crate::client::Client;
 use crate::system::get_stats::GetStats;
 use anyhow::Context;
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
 use comfy_table::Table;
-use humantime::format_duration;
-use std::time::{Duration, SystemTime};
+use std::time::SystemTime;
 use tracing::{event, Level};
 
 pub struct GetStatsCmd {
@@ -51,6 +49,10 @@ impl CliCommand for GetStatsCmd {
             format!("{:.4} %", stats.cpu_usage).as_str(),
         ]);
         table.add_row(vec![
+            "Total CPU Usage",
+            format!("{:.4} %", stats.total_cpu_usage).as_str(),
+        ]);
+        table.add_row(vec![
             "Iggy Server Memory Usage",
             stats.memory_usage.as_bytes_u64().to_string().as_str(),
         ]);
@@ -63,18 +65,15 @@ impl CliCommand for GetStatsCmd {
             "Available Memory (RAM)",
             stats.available_memory.as_bytes_u64().to_string().as_str(),
         ]);
-
         table.add_row(vec![
             "Iggy Server Run Time",
-            format!("{}", format_duration(Duration::from_secs(stats.run_time))).as_str(),
+            stats.run_time.as_secs().to_string().as_str(),
         ]);
 
-        let start_time = SystemTime::UNIX_EPOCH + Duration::from_secs(stats.start_time);
-        let date_time_utc: DateTime<Utc> = start_time.into();
-
+        let start_time_utc = stats.start_time + SystemTime::UNIX_EPOCH;
         table.add_row(vec![
             "Start Time (UTC)",
-            format!("{}", date_time_utc.format("%Y-%m-%d %H:%M:%S")).as_str(),
+            start_time_utc.to_string().as_str(),
         ]);
 
         table.add_row(vec![
@@ -93,7 +92,6 @@ impl CliCommand for GetStatsCmd {
                 .to_string()
                 .as_str(),
         ]);
-
         table.add_row(vec![
             "Streams Count",
             format!("{}", stats.streams_count).as_str(),

--- a/sdk/src/cli/topics/get_topic.rs
+++ b/sdk/src/cli/topics/get_topic.rs
@@ -47,7 +47,7 @@ impl CliCommand for GetTopicCmd {
         table.add_row(vec![
             "Created",
             IggyTimestamp::from(topic.created_at)
-                .to_string("%Y-%m-%d %H:%M:%S")
+                .to_utc_string("%Y-%m-%d %H:%M:%S")
                 .as_str(),
         ]);
         table.add_row(vec!["Topic name", topic.name.as_str()]);

--- a/sdk/src/cli/topics/get_topics.rs
+++ b/sdk/src/cli/topics/get_topics.rs
@@ -74,7 +74,7 @@ impl CliCommand for GetTopicsCmd {
                 topics.iter().for_each(|topic| {
                     table.add_row(vec![
                         format!("{}", topic.id),
-                        IggyTimestamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(topic.created_at).to_utc_string("%Y-%m-%d %H:%M:%S"),
                         topic.name.clone(),
                         format!("{}", topic.size),
                         match topic.max_topic_size {
@@ -97,7 +97,7 @@ impl CliCommand for GetTopicsCmd {
                     event!(target: PRINT_TARGET, Level::INFO,
                         "{}|{}|{}|{}|{}|{}|{}|{}",
                         topic.id,
-                        IggyTimestamp::from(topic.created_at).to_string("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(topic.created_at).to_utc_string("%Y-%m-%d %H:%M:%S"),
                         topic.name,
                         topic.size,
                         match topic.max_topic_size {

--- a/sdk/src/cli/users/get_user.rs
+++ b/sdk/src/cli/users/get_user.rs
@@ -149,7 +149,7 @@ impl CliCommand for GetUserCmd {
         table.add_row(vec![
             "Created",
             IggyTimestamp::from(user.created_at)
-                .to_local("%Y-%m-%d %H:%M:%S")
+                .to_local_string("%Y-%m-%d %H:%M:%S")
                 .as_str(),
         ]);
         table.add_row(vec!["Status", format!("{}", user.status).as_str()]);

--- a/sdk/src/cli/users/get_users.rs
+++ b/sdk/src/cli/users/get_users.rs
@@ -65,7 +65,7 @@ impl CliCommand for GetUsersCmd {
                 users.iter().for_each(|user| {
                     table.add_row(vec![
                         format!("{}", user.id),
-                        IggyTimestamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(user.created_at).to_local_string("%Y-%m-%d %H:%M:%S"),
                         user.status.clone().to_string(),
                         user.username.clone(),
                     ]);
@@ -78,7 +78,7 @@ impl CliCommand for GetUsersCmd {
                     event!(target: PRINT_TARGET, Level::INFO,
                         "{}|{}|{}|{}",
                         user.id,
-                        IggyTimestamp::from(user.created_at).to_local("%Y-%m-%d %H:%M:%S"),
+                        IggyTimestamp::from(user.created_at).to_local_string("%Y-%m-%d %H:%M:%S"),
                         user.status.clone().to_string(),
                         user.username.clone(),
                     );

--- a/sdk/src/models/stats.rs
+++ b/sdk/src/models/stats.rs
@@ -1,4 +1,4 @@
-use crate::utils::byte_size::IggyByteSize;
+use crate::utils::{byte_size::IggyByteSize, duration::IggyDuration, timestamp::IggyTimestamp};
 use serde::{Deserialize, Serialize};
 
 /// `Stats` represents the statistics and details of the server and running process.
@@ -8,6 +8,8 @@ pub struct Stats {
     pub process_id: u32,
     /// The CPU usage of the process.
     pub cpu_usage: f32,
+    /// the total CPU usage of the system.
+    pub total_cpu_usage: f32,
     /// The memory usage of the process.
     pub memory_usage: IggyByteSize,
     /// The total memory of the system.
@@ -15,9 +17,9 @@ pub struct Stats {
     /// The available memory of the system.
     pub available_memory: IggyByteSize,
     /// The run time of the process.
-    pub run_time: u64,
+    pub run_time: IggyDuration,
     /// The start time of the process.
-    pub start_time: u64,
+    pub start_time: IggyTimestamp,
     /// The total number of bytes read.
     pub read_bytes: IggyByteSize,
     /// The total number of bytes written.
@@ -46,4 +48,33 @@ pub struct Stats {
     pub os_version: String,
     /// The version of the kernel.
     pub kernel_version: String,
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self {
+            process_id: 0,
+            cpu_usage: 0.0,
+            total_cpu_usage: 0.0,
+            memory_usage: 0.into(),
+            total_memory: 0.into(),
+            available_memory: 0.into(),
+            run_time: 0.into(),
+            start_time: 0.into(),
+            read_bytes: 0.into(),
+            written_bytes: 0.into(),
+            messages_size_bytes: 0.into(),
+            streams_count: 0,
+            topics_count: 0,
+            partitions_count: 0,
+            segments_count: 0,
+            messages_count: 0,
+            clients_count: 0,
+            consumer_groups_count: 0,
+            hostname: "unknown_hostname".to_string(),
+            os_name: "unknown_os_name".to_string(),
+            os_version: "unknown_os_version".to_string(),
+            kernel_version: "unknown_kernel_version".to_string(),
+        }
+    }
 }

--- a/sdk/src/models/stream.rs
+++ b/sdk/src/models/stream.rs
@@ -1,5 +1,5 @@
-use crate::models::topic::Topic;
 use crate::utils::byte_size::IggyByteSize;
+use crate::{models::topic::Topic, utils::timestamp::IggyTimestamp};
 use serde::{Deserialize, Serialize};
 
 /// `Stream` represents the highest level of logical separation of data.
@@ -15,7 +15,7 @@ pub struct Stream {
     /// The unique identifier (numeric) of the stream.
     pub id: u32,
     /// The timestamp when the stream was created.
-    pub created_at: u64,
+    pub created_at: IggyTimestamp,
     /// The unique name of the stream.
     pub name: String,
     /// The total size of the stream in bytes.
@@ -40,7 +40,7 @@ pub struct StreamDetails {
     /// The unique identifier (numeric) of the stream.
     pub id: u32,
     /// The timestamp when the stream was created.
-    pub created_at: u64,
+    pub created_at: IggyTimestamp,
     /// The unique name of the stream.
     pub name: String,
     /// The total size of the stream in bytes.

--- a/sdk/src/utils/duration.rs
+++ b/sdk/src/utils/duration.rs
@@ -58,6 +58,41 @@ impl FromStr for IggyDuration {
     }
 }
 
+impl From<Option<u64>> for IggyDuration {
+    fn from(byte_size: Option<u64>) -> Self {
+        match byte_size {
+            Some(value) => IggyDuration {
+                duration: Duration::from_secs(value),
+            },
+            None => IggyDuration {
+                duration: Duration::new(0, 0),
+            },
+        }
+    }
+}
+
+impl From<u64> for IggyDuration {
+    fn from(value: u64) -> Self {
+        IggyDuration {
+            duration: Duration::from_secs(value),
+        }
+    }
+}
+
+impl From<IggyDuration> for u64 {
+    fn from(iggy_duration: IggyDuration) -> u64 {
+        iggy_duration.duration.as_secs()
+    }
+}
+
+impl Default for IggyDuration {
+    fn default() -> Self {
+        IggyDuration {
+            duration: Duration::new(0, 0),
+        }
+    }
+}
+
 impl Display for IggyDuration {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_human_time_string())

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -18,11 +18,12 @@ pub fn map_stats(stats: &Stats) -> Bytes {
     let mut bytes = BytesMut::with_capacity(104);
     bytes.put_u32_le(stats.process_id);
     bytes.put_f32_le(stats.cpu_usage);
+    bytes.put_f32_le(stats.total_cpu_usage);
     bytes.put_u64_le(stats.memory_usage.as_bytes_u64());
     bytes.put_u64_le(stats.total_memory.as_bytes_u64());
     bytes.put_u64_le(stats.available_memory.as_bytes_u64());
-    bytes.put_u64_le(stats.run_time);
-    bytes.put_u64_le(stats.start_time);
+    bytes.put_u64_le(stats.run_time.into());
+    bytes.put_u64_le(stats.start_time.into());
     bytes.put_u64_le(stats.read_bytes.as_bytes_u64());
     bytes.put_u64_le(stats.written_bytes.as_bytes_u64());
     bytes.put_u64_le(stats.messages_size_bytes.as_bytes_u64());
@@ -197,7 +198,7 @@ pub async fn map_consumer_groups(consumer_groups: &[&RwLock<ConsumerGroup>]) -> 
 
 async fn extend_stream(stream: &Stream, bytes: &mut BytesMut) {
     bytes.put_u32_le(stream.stream_id);
-    bytes.put_u64_le(stream.created_at);
+    bytes.put_u64_le(stream.created_at.into());
     bytes.put_u32_le(stream.get_topics().len() as u32);
     bytes.put_u64_le(stream.get_size().as_bytes_u64());
     bytes.put_u64_le(stream.get_messages_count());

--- a/server/src/channels/commands/clean_messages.rs
+++ b/server/src/channels/commands/clean_messages.rs
@@ -127,10 +127,6 @@ async fn delete_expired_segments(
         .get_expired_segments_start_offsets_per_partition(now)
         .await;
     if expired_segments.is_empty() {
-        info!(
-            "No expired segments found for stream ID: {}, topic ID: {}",
-            topic.stream_id, topic.topic_id
-        );
         return Ok(None);
     }
 

--- a/server/src/channels/commands/mod.rs
+++ b/server/src/channels/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod clean_messages;
 pub mod clean_personal_access_tokens;
+pub mod print_sysinfo;
 pub mod save_messages;

--- a/server/src/channels/commands/print_sysinfo.rs
+++ b/server/src/channels/commands/print_sysinfo.rs
@@ -1,0 +1,105 @@
+use crate::{
+    channels::server_command::ServerCommand, configs::server::ServerConfig,
+    streaming::systems::system::SharedSystem,
+};
+use async_trait::async_trait;
+use flume::{Receiver, Sender};
+use iggy::utils::duration::IggyDuration;
+use tokio::time::{self};
+use tracing::{error, info, warn};
+
+#[derive(Debug, Default, Clone)]
+pub struct SysInfoPrintCommand;
+
+pub struct SysInfoPrinter {
+    interval: IggyDuration,
+    sender: Sender<SysInfoPrintCommand>,
+}
+
+pub struct SysInfoPrintExecutor;
+
+impl SysInfoPrinter {
+    pub fn new(interval: IggyDuration, sender: Sender<SysInfoPrintCommand>) -> Self {
+        Self { interval, sender }
+    }
+
+    pub fn start(&self) {
+        let interval = self.interval;
+        let sender = self.sender.clone();
+        if interval.is_zero() {
+            info!("SysInfoPrinter is disabled.");
+            return;
+        }
+
+        info!(
+            "SysInfoPrinter is enabled, system information will be printed every {:?} seconds.",
+            interval.as_secs()
+        );
+
+        tokio::spawn(async move {
+            let mut interval_timer = time::interval(interval.get_duration());
+            loop {
+                interval_timer.tick().await;
+                let command = SysInfoPrintCommand {};
+                sender.send(command).unwrap_or_else(|e| {
+                    error!("Failed to send SysInfoPrintCommand. Error: {e}");
+                });
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl ServerCommand<SysInfoPrintCommand> for SysInfoPrintExecutor {
+    async fn execute(&mut self, system: &SharedSystem, _command: SysInfoPrintCommand) {
+        let stats = match system.read().get_stats_bypass_auth().await {
+            Ok(stats) => stats,
+            Err(e) => {
+                error!("Failed to get system information. Error: {e}");
+                return;
+            }
+        };
+
+        let free_memory_percent = (stats.available_memory.as_bytes_u64() as f64
+            / stats.total_memory.as_bytes_u64() as f64)
+            * 100f64;
+
+        info!("CPU: {:.2}% / {:.2}% (IggyUsage/Total), Mem: {:.2}% / {} / {} / {} (Free/IggyUsage/TotalUsed/Total), Clients: {}, Messages processed: {}, Read: {}, Written: {}, Run Time: {} s",
+              stats.cpu_usage,
+              stats.total_cpu_usage,
+              free_memory_percent,
+              stats.memory_usage,
+              stats.total_memory - stats.available_memory,
+              stats.total_memory,
+              stats.clients_count,
+              stats.messages_count,
+              stats.read_bytes,
+              stats.written_bytes,
+              stats.run_time);
+    }
+
+    fn start_command_sender(
+        &mut self,
+        _system: SharedSystem,
+        config: &ServerConfig,
+        sender: Sender<SysInfoPrintCommand>,
+    ) {
+        let printer = SysInfoPrinter::new(config.system.logging.sysinfo_print_interval, sender);
+        printer.start();
+    }
+
+    fn start_command_consumer(
+        mut self,
+        system: SharedSystem,
+        _config: &ServerConfig,
+        receiver: Receiver<SysInfoPrintCommand>,
+    ) {
+        tokio::spawn(async move {
+            let system = system.clone();
+            while let Ok(command) = receiver.recv_async().await {
+                self.execute(&system, command).await;
+            }
+            warn!("Sysinfo printer stopped receiving commands.");
+        });
+    }
+}

--- a/server/src/configs/defaults.rs
+++ b/server/src/configs/defaults.rs
@@ -186,6 +186,7 @@ impl Default for LoggingConfig {
             level: "info".to_string(),
             max_size: "200 MB".parse().unwrap(),
             retention: "7 days".parse().unwrap(),
+            sysinfo_print_interval: "10s".parse().unwrap(),
         }
     }
 }

--- a/server/src/configs/system.rs
+++ b/server/src/configs/system.rs
@@ -48,6 +48,8 @@ pub struct LoggingConfig {
     pub max_size: IggyByteSize,
     #[serde_as(as = "DisplayFromStr")]
     pub retention: IggyDuration,
+    #[serde_as(as = "DisplayFromStr")]
+    pub sysinfo_print_interval: IggyDuration,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/server/src/http/jwt/cleaner.rs
+++ b/server/src/http/jwt/cleaner.rs
@@ -2,30 +2,27 @@ use crate::http::shared::AppState;
 use iggy::utils::timestamp::IggyTimestamp;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{error, trace};
 
 pub fn start_expired_tokens_cleaner(app_state: Arc<AppState>) {
     tokio::spawn(async move {
         let mut interval_timer = tokio::time::interval(Duration::from_secs(300));
         loop {
             interval_timer.tick().await;
-            info!("Deleting expired tokens...");
+            trace!("Deleting expired tokens...");
             let now = IggyTimestamp::now().to_secs();
             app_state
                 .jwt_manager
                 .delete_expired_revoked_tokens(now)
                 .await
                 .unwrap_or_else(|err| {
-                    error!(
-                        "Failed to delete expired revoked access tokens. Error: {}",
-                        err
-                    );
+                    error!("Failed to delete expired revoked access tokens. Error: {err}",);
                 });
             app_state
                 .jwt_manager
                 .delete_expired_refresh_tokens(now)
                 .await
-                .unwrap_or_else(|err| {
+                .unwrap_or_else(|err: iggy::error::IggyError| {
                     error!("Failed to delete expired refresh tokens. Error: {}", err);
                 });
         }

--- a/server/src/http/jwt/storage.rs
+++ b/server/src/http/jwt/storage.rs
@@ -80,7 +80,9 @@ impl TokenStorage {
             .collect();
 
         let refresh_tokens = refresh_tokens?;
-        info!("Loaded {} refresh tokens", refresh_tokens.len());
+        if !refresh_tokens.is_empty() {
+            info!("Loaded {} refresh tokens", refresh_tokens.len());
+        }
         Ok(refresh_tokens)
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,6 +4,7 @@ use figlet_rs::FIGfont;
 use server::args::Args;
 use server::channels::commands::clean_messages::CleanMessagesExecutor;
 use server::channels::commands::clean_personal_access_tokens::CleanPersonalAccessTokensExecutor;
+use server::channels::commands::print_sysinfo::SysInfoPrintExecutor;
 use server::channels::commands::save_messages::SaveMessagesExecutor;
 use server::channels::handler::ServerCommandHandler;
 use server::configs::config_provider;
@@ -47,7 +48,8 @@ async fn main() -> Result<(), ServerError> {
     let _command_handler = ServerCommandHandler::new(system.clone(), &config)
         .install_handler(SaveMessagesExecutor)
         .install_handler(CleanMessagesExecutor)
-        .install_handler(CleanPersonalAccessTokensExecutor);
+        .install_handler(CleanPersonalAccessTokensExecutor)
+        .install_handler(SysInfoPrintExecutor);
 
     #[cfg(unix)]
     let (mut ctrl_c, mut sigterm) = {

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -392,7 +392,7 @@ impl Partition {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU32, AtomicU64};
 
     use super::*;
     use crate::configs::system::{MessageDeduplicationConfig, SystemConfig};
@@ -453,6 +453,7 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU32::new(0)),
         )
     }
 }

--- a/server/src/streaming/segments/messages.rs
+++ b/server/src/streaming/segments/messages.rs
@@ -274,20 +274,22 @@ impl Segment {
         Ok(())
     }
 
-    pub async fn persist_messages(&mut self) -> Result<(), IggyError> {
+    pub async fn persist_messages(&mut self) -> Result<usize, IggyError> {
         let storage = self.storage.segment.clone();
         if self.unsaved_messages.is_none() {
-            return Ok(());
+            return Ok(0);
         }
 
         let unsaved_messages = self.unsaved_messages.as_ref().unwrap();
         if unsaved_messages.is_empty() {
-            return Ok(());
+            return Ok(0);
         }
+
+        let unsaved_messages_number: usize = unsaved_messages.len();
 
         trace!(
             "Saving {} messages on disk in segment with start offset: {} for partition with ID: {}...",
-            unsaved_messages.len(),
+            unsaved_messages_number,
             self.start_offset,
             self.partition_id
         );
@@ -301,7 +303,7 @@ impl Segment {
 
         trace!(
             "Saved {} messages on disk in segment with start offset: {} for partition with ID: {}, total bytes written: {}.",
-            unsaved_messages.len(),
+            unsaved_messages_number,
             self.start_offset,
             self.partition_id,
             saved_bytes
@@ -315,6 +317,6 @@ impl Segment {
             self.unsaved_messages.as_mut().unwrap().clear();
         }
 
-        Ok(())
+        Ok(unsaved_messages_number)
     }
 }

--- a/server/src/streaming/streams/persistence.rs
+++ b/server/src/streaming/streams/persistence.rs
@@ -19,12 +19,13 @@ impl Stream {
         self.storage.stream.delete(self).await
     }
 
-    pub async fn persist_messages(&self) -> Result<(), IggyError> {
+    pub async fn persist_messages(&self) -> Result<usize, IggyError> {
+        let mut saved_messages_number = 0;
         for topic in self.get_topics() {
-            topic.persist_messages().await?;
+            saved_messages_number += topic.persist_messages().await?;
         }
 
-        Ok(())
+        Ok(saved_messages_number)
     }
 
     pub async fn purge(&self) -> Result<(), IggyError> {

--- a/server/src/streaming/streams/segments.rs
+++ b/server/src/streaming/streams/segments.rs
@@ -1,12 +1,8 @@
 use crate::streaming::streams::stream::Stream;
+use std::sync::atomic::Ordering;
 
 impl Stream {
-    pub async fn get_segments_count(&self) -> u32 {
-        let mut segments_count = 0;
-        for topic in self.topics.values() {
-            segments_count += topic.get_segments_count().await;
-        }
-
-        segments_count
+    pub fn get_segments_count(&self) -> u32 {
+        self.segments_count.load(Ordering::SeqCst)
     }
 }

--- a/server/src/streaming/streams/storage.rs
+++ b/server/src/streaming/streams/storage.rs
@@ -5,9 +5,11 @@ use anyhow::Context;
 use async_trait::async_trait;
 use futures::future::join_all;
 use iggy::error::IggyError;
+use iggy::utils::timestamp::IggyTimestamp;
 use serde::{Deserialize, Serialize};
 use sled::Db;
 use std::path::Path;
+use std::sync::atomic::{AtomicU32, AtomicU64};
 use std::sync::Arc;
 use tokio::fs;
 use tokio::fs::create_dir;
@@ -33,7 +35,7 @@ impl StreamStorage for FileStreamStorage {}
 #[derive(Debug, Serialize, Deserialize)]
 struct StreamData {
     name: String,
-    created_at: u64,
+    created_at: IggyTimestamp,
 }
 
 #[async_trait]
@@ -96,6 +98,9 @@ impl Storage<Stream> for FileStreamStorage {
             let topic = Topic::empty(
                 stream.stream_id,
                 topic_id,
+                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU32::new(0)),
                 stream.config.clone(),
                 stream.storage.clone(),
             );

--- a/server/src/streaming/streams/stream.rs
+++ b/server/src/streaming/streams/stream.rs
@@ -13,10 +13,11 @@ pub struct Stream {
     pub name: String,
     pub path: String,
     pub topics_path: String,
-    pub created_at: u64,
+    pub created_at: IggyTimestamp,
     pub current_topic_id: AtomicU32,
     pub size_bytes: Arc<AtomicU64>,
     pub messages_count: Arc<AtomicU64>,
+    pub segments_count: Arc<AtomicU32>,
     pub(crate) topics: HashMap<u32, Topic>,
     pub(crate) topics_ids: HashMap<String, u32>,
     pub(crate) config: Arc<SystemConfig>,
@@ -46,10 +47,11 @@ impl Stream {
             current_topic_id: AtomicU32::new(1),
             size_bytes: Arc::new(AtomicU64::new(0)),
             messages_count: Arc::new(AtomicU64::new(0)),
+            segments_count: Arc::new(AtomicU32::new(0)),
             topics: HashMap::new(),
             topics_ids: HashMap::new(),
             storage,
-            created_at: IggyTimestamp::now().to_micros(),
+            created_at: IggyTimestamp::now(),
         }
     }
 

--- a/server/src/streaming/streams/topics.rs
+++ b/server/src/streaming/streams/topics.rs
@@ -58,6 +58,7 @@ impl Stream {
             self.storage.clone(),
             self.size_bytes.clone(),
             self.messages_count.clone(),
+            self.segments_count.clone(),
             message_expiry,
             max_topic_size,
             replication_factor,

--- a/server/src/streaming/systems/stats.rs
+++ b/server/src/streaming/systems/stats.rs
@@ -3,96 +3,92 @@ use crate::streaming::systems::system::System;
 use iggy::error::IggyError;
 use iggy::locking::IggySharedMutFn;
 use iggy::models::stats::Stats;
+use std::sync::OnceLock;
+use sysinfo::{Pid, System as SysinfoSystem};
+use tokio::sync::Mutex;
 
-const PROCESS_NAME: &str = "iggy-server";
+fn sysinfo() -> &'static Mutex<SysinfoSystem> {
+    static SYSINFO: OnceLock<Mutex<SysinfoSystem>> = OnceLock::new();
+    SYSINFO.get_or_init(|| {
+        let mut sys = SysinfoSystem::new_all();
+        sys.refresh_all();
+        Mutex::new(sys)
+    })
+}
 
 impl System {
     pub async fn get_stats(&self, session: &Session) -> Result<Stats, IggyError> {
         self.ensure_authenticated(session)?;
         self.permissioner.get_stats(session.get_user_id())?;
-        let mut sys = sysinfo::System::new_all();
-        sys.refresh_all();
+        self.get_stats_bypass_auth().await
+    }
+
+    pub async fn get_stats_bypass_auth(&self) -> Result<Stats, IggyError> {
+        let mut sys = sysinfo().lock().await;
+        let process_id = std::process::id();
+        sys.refresh_cpu();
+        sys.refresh_memory();
+        sys.refresh_process(Pid::from_u32(process_id));
+
+        let total_cpu_usage = sys.global_cpu_info().cpu_usage();
+        let total_memory = sys.total_memory().into();
+        let available_memory = sys.available_memory().into();
+        let clients_count = self.client_manager.read().await.get_clients().len() as u32;
+        let hostname = sysinfo::System::host_name().unwrap_or("unknown_hostname".to_string());
+        let os_name = sysinfo::System::name().unwrap_or("unknown_os_name".to_string());
+        let os_version =
+            sysinfo::System::long_os_version().unwrap_or("unknown_os_version".to_string());
+        let kernel_version =
+            sysinfo::System::kernel_version().unwrap_or("unknown_kernel_version".to_string());
 
         let mut stats = Stats {
-            process_id: 0,
-            cpu_usage: 0.0,
-            memory_usage: 0.into(),
-            total_memory: 0.into(),
-            available_memory: 0.into(),
-            run_time: 0,
-            start_time: 0,
-            streams_count: self.streams.len() as u32,
-            topics_count: self
-                .streams
-                .values()
-                .map(|s| s.topics.len() as u32)
-                .sum::<u32>(),
-            partitions_count: self
-                .streams
-                .values()
-                .map(|s| {
-                    s.topics
-                        .values()
-                        .map(|t| t.partitions.len() as u32)
-                        .sum::<u32>()
-                })
-                .sum::<u32>(),
-            segments_count: 0,
-            messages_count: 0,
-            clients_count: self.client_manager.read().await.get_clients().len() as u32,
-            consumer_groups_count: self
-                .streams
-                .values()
-                .map(|s| {
-                    s.topics
-                        .values()
-                        .map(|t| t.consumer_groups.len() as u32)
-                        .sum::<u32>()
-                })
-                .sum::<u32>(),
-            read_bytes: 0.into(),
-            written_bytes: 0.into(),
-            messages_size_bytes: 0.into(),
-            hostname: sysinfo::System::host_name().unwrap_or("unknown_hostname".to_string()),
-            os_name: sysinfo::System::name().unwrap_or("unknown_os_name".to_string()),
-            os_version: sysinfo::System::long_os_version()
-                .unwrap_or("unknown_os_version".to_string()),
-            kernel_version: sysinfo::System::kernel_version()
-                .unwrap_or("unknown_kernel_version".to_string()),
+            process_id,
+            total_cpu_usage,
+            total_memory,
+            available_memory,
+            clients_count,
+            hostname,
+            os_name,
+            os_version,
+            kernel_version,
+            ..Default::default()
         };
 
-        for (pid, process) in sys.processes() {
-            if process.name() != PROCESS_NAME {
-                continue;
-            }
-
-            stats.process_id = pid.as_u32();
+        if let Some(process) = sys
+            .processes()
+            .values()
+            .find(|p| p.pid() == Pid::from_u32(process_id))
+        {
+            stats.process_id = process.pid().as_u32();
             stats.cpu_usage = process.cpu_usage();
             stats.memory_usage = process.memory().into();
-            stats.total_memory = sys.total_memory().into();
-            stats.available_memory = sys.available_memory().into();
-            stats.run_time = process.run_time();
-            stats.start_time = process.start_time();
+            stats.run_time = process.run_time().into();
+            stats.start_time = process.start_time().into();
+
             let disk_usage = process.disk_usage();
             stats.read_bytes = disk_usage.total_read_bytes.into();
             stats.written_bytes = disk_usage.total_written_bytes.into();
-            break;
         }
 
-        let mut messages_size_bytes = 0u64;
+        drop(sys);
+
         for stream in self.streams.values() {
-            for topic in stream.topics.values() {
-                for partition in topic.partitions.values() {
-                    let partition = partition.read().await;
-                    stats.messages_count += partition.get_messages_count();
-                    stats.segments_count += partition.segments.len() as u32;
-                    for segment in &partition.segments {
-                        messages_size_bytes += segment.size_bytes as u64;
-                    }
-                }
-            }
+            stats.messages_count += stream.get_messages_count();
+            stats.segments_count += stream.get_segments_count();
+            stats.messages_size_bytes += stream.get_size();
+            stats.streams_count += 1;
+            stats.topics_count += stream.topics.len() as u32;
+            stats.partitions_count += stream
+                .topics
+                .values()
+                .map(|t| t.partitions.len() as u32)
+                .sum::<u32>();
+            stats.consumer_groups_count += stream
+                .topics
+                .values()
+                .map(|t| t.consumer_groups.len() as u32)
+                .sum::<u32>();
         }
-        stats.messages_size_bytes = messages_size_bytes.into();
 
         Ok(stats)
     }

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -63,8 +63,7 @@ impl System {
             self.metrics.increment_topics(stream.get_topics_count());
             self.metrics
                 .increment_partitions(stream.get_partitions_count());
-            self.metrics
-                .increment_segments(stream.get_segments_count().await);
+            self.metrics.increment_segments(stream.get_segments_count());
             self.metrics.increment_messages(stream.get_messages_count());
 
             self.streams_ids
@@ -261,8 +260,7 @@ impl System {
         self.metrics
             .decrement_partitions(stream.get_partitions_count());
         self.metrics.decrement_messages(stream.get_messages_count());
-        self.metrics
-            .decrement_segments(stream.get_segments_count().await);
+        self.metrics.decrement_segments(stream.get_segments_count());
 
         self.streams.remove(&stream_id);
         self.streams_ids.remove(&stream_name);

--- a/server/src/streaming/systems/system.rs
+++ b/server/src/streaming/systems/system.rs
@@ -164,13 +164,14 @@ impl System {
         Ok(())
     }
 
-    pub async fn persist_messages(&self) -> Result<(), IggyError> {
+    pub async fn persist_messages(&self) -> Result<usize, IggyError> {
         trace!("Saving buffered messages on disk...");
+        let mut saved_messages_number = 0;
         for stream in self.streams.values() {
-            stream.persist_messages().await?;
+            saved_messages_number += stream.persist_messages().await?;
         }
 
-        Ok(())
+        Ok(saved_messages_number)
     }
 
     pub fn ensure_authenticated(&self, session: &Session) -> Result<(), IggyError> {

--- a/server/src/streaming/topics/consumer_groups.rs
+++ b/server/src/streaming/topics/consumer_groups.rs
@@ -161,7 +161,7 @@ mod tests {
     use super::*;
     use crate::configs::system::SystemConfig;
     use crate::streaming::storage::tests::get_test_system_storage;
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU32, AtomicU64};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -309,6 +309,7 @@ mod tests {
         let config = Arc::new(SystemConfig::default());
         let size_of_parent_stream = Arc::new(AtomicU64::new(0));
         let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
+        let segments_count_of_parent_stream = Arc::new(AtomicU32::new(0));
 
         Topic::create(
             stream_id,
@@ -319,6 +320,7 @@ mod tests {
             storage,
             size_of_parent_stream,
             messages_count_of_parent_stream,
+            segments_count_of_parent_stream,
             None,
             None,
             1,

--- a/server/src/streaming/topics/messages.rs
+++ b/server/src/streaming/topics/messages.rs
@@ -258,7 +258,7 @@ mod tests {
     use crate::streaming::storage::tests::get_test_system_storage;
     use bytes::Bytes;
     use iggy::models::messages::MessageState;
-    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::{AtomicU32, AtomicU64};
     use std::sync::Arc;
 
     #[tokio::test]
@@ -380,6 +380,7 @@ mod tests {
         let config = Arc::new(SystemConfig::default());
         let size_of_parent_stream = Arc::new(AtomicU64::new(0));
         let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
+        let segments_count_of_parent_stream = Arc::new(AtomicU32::new(0));
 
         Topic::create(
             stream_id,
@@ -390,6 +391,7 @@ mod tests {
             storage,
             size_of_parent_stream,
             messages_count_of_parent_stream,
+            segments_count_of_parent_stream,
             None,
             None,
             1,

--- a/server/src/streaming/topics/partitions.rs
+++ b/server/src/streaming/topics/partitions.rs
@@ -39,6 +39,7 @@ impl Topic {
                 self.messages_count.clone(),
                 self.size_of_parent_stream.clone(),
                 self.size_bytes.clone(),
+                self.segments_count_of_parent_stream.clone(),
             );
             self.partitions
                 .insert(partition_id, IggySharedMut::new(partition));

--- a/server/src/streaming/topics/persistence.rs
+++ b/server/src/streaming/topics/persistence.rs
@@ -40,15 +40,16 @@ impl Topic {
         self.storage.topic.delete(self).await
     }
 
-    pub async fn persist_messages(&self) -> Result<(), IggyError> {
+    pub async fn persist_messages(&self) -> Result<usize, IggyError> {
+        let mut saved_messages_number = 0;
         for partition in self.get_partitions() {
             let mut partition = partition.write().await;
             for segment in partition.get_segments_mut() {
-                segment.persist_messages().await?;
+                saved_messages_number += segment.persist_messages().await?;
             }
         }
 
-        Ok(())
+        Ok(saved_messages_number)
     }
 
     pub async fn purge(&self) -> Result<(), IggyError> {

--- a/server/src/streaming/topics/storage.rs
+++ b/server/src/streaming/topics/storage.rs
@@ -224,6 +224,7 @@ impl Storage<Topic> for FileTopicStorage {
                 topic.messages_count.clone(),
                 topic.size_of_parent_stream.clone(),
                 topic.size_bytes.clone(),
+                topic.segments_count_of_parent_stream.clone(),
             );
             unloaded_partitions.push(partition);
         }

--- a/server/src/streaming/topics/topic.rs
+++ b/server/src/streaming/topics/topic.rs
@@ -23,6 +23,7 @@ pub struct Topic {
     pub(crate) size_of_parent_stream: Arc<AtomicU64>,
     pub(crate) messages_count_of_parent_stream: Arc<AtomicU64>,
     pub(crate) messages_count: Arc<AtomicU64>,
+    pub(crate) segments_count_of_parent_stream: Arc<AtomicU32>,
     pub(crate) config: Arc<SystemConfig>,
     pub(crate) partitions: HashMap<u32, IggySharedMut<Partition>>,
     pub(crate) storage: Arc<SystemStorage>,
@@ -39,6 +40,9 @@ impl Topic {
     pub fn empty(
         stream_id: u32,
         topic_id: u32,
+        size_of_parent_stream: Arc<AtomicU64>,
+        messages_count_of_parent_stream: Arc<AtomicU64>,
+        segments_count_of_parent_stream: Arc<AtomicU32>,
         config: Arc<SystemConfig>,
         storage: Arc<SystemStorage>,
     ) -> Topic {
@@ -49,8 +53,9 @@ impl Topic {
             0,
             config,
             storage,
-            Arc::new(AtomicU64::new(0)),
-            Arc::new(AtomicU64::new(0)),
+            size_of_parent_stream,
+            messages_count_of_parent_stream,
+            segments_count_of_parent_stream,
             None,
             None,
             1,
@@ -68,6 +73,7 @@ impl Topic {
         storage: Arc<SystemStorage>,
         size_of_parent_stream: Arc<AtomicU64>,
         messages_count_of_parent_stream: Arc<AtomicU64>,
+        segments_count_of_parent_stream: Arc<AtomicU32>,
         message_expiry: Option<u32>,
         max_topic_size: Option<IggyByteSize>,
         replication_factor: u8,
@@ -86,6 +92,7 @@ impl Topic {
             size_of_parent_stream,
             messages_count_of_parent_stream,
             messages_count: Arc::new(AtomicU64::new(0)),
+            segments_count_of_parent_stream,
             consumer_groups: HashMap::new(),
             consumer_groups_ids: HashMap::new(),
             current_partition_id: AtomicU32::new(1),
@@ -168,6 +175,7 @@ mod tests {
         let path = config.get_topic_path(stream_id, topic_id);
         let size_of_parent_stream = Arc::new(AtomicU64::new(0));
         let messages_count_of_parent_stream = Arc::new(AtomicU64::new(0));
+        let segments_count_of_parent_stream = Arc::new(AtomicU32::new(0));
 
         let topic = Topic::create(
             stream_id,
@@ -178,6 +186,7 @@ mod tests {
             storage,
             messages_count_of_parent_stream,
             size_of_parent_stream,
+            segments_count_of_parent_stream,
             Some(message_expiry),
             Some(max_topic_size),
             replication_factor,


### PR DESCRIPTION
- Implement sysinfo_print_interval for periodic logging
- Add subtraction operation for IggyByteSize struct
- Remove redundant log for no expired segments in clean_messages
- Introduce print_sysinfo command module for system info output
- Adjust byte size formatting to two decimal places
- Modify save_messages to log only when messages are saved
- Set default sysinfo_print_interval in configs/defaults.rs
- Streamline token cleaner logs to use trace level
- Log refresh token loading only when tokens are present
- Update main.rs to include SysInfoPrintExecutor
- Return number of messages saved in persist_messages
- Add get_sysinfo method for system stats retrieval
- Ensure message save count is accumulated across streams
- Include saved message count in topic persistence logic

Closes #174.
