### PR TITLE
Allow root user credentials configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/streaming/systems/streams.rs
+++ b/server/src/streaming/systems/streams.rs
@@ -297,6 +297,7 @@ mod tests {
     use crate::configs::system::SystemConfig;
     use crate::streaming::storage::tests::get_test_system_storage;
     use crate::streaming::users::user::User;
+    use iggy::users::defaults::{DEFAULT_ROOT_PASSWORD, DEFAULT_ROOT_USERNAME};
     use std::{
         net::{Ipv4Addr, SocketAddr},
         sync::Arc,
@@ -310,7 +311,7 @@ mod tests {
         let storage = get_test_system_storage();
         let mut system =
             System::create(config, storage, None, PersonalAccessTokenConfig::default());
-        let root = User::root();
+        let root = User::root(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD);
         let session = Session::new(
             1,
             root.id,

--- a/server/src/streaming/users/user.rs
+++ b/server/src/streaming/users/user.rs
@@ -53,11 +53,11 @@ impl User {
         }
     }
 
-    pub fn root() -> Self {
+    pub fn root(username: &str, password: &str) -> Self {
         Self::new(
             DEFAULT_ROOT_USER_ID,
-            DEFAULT_ROOT_USERNAME,
-            DEFAULT_ROOT_PASSWORD,
+            username,
+            password,
             UserStatus::Active,
             Some(Permissions::root()),
         )
@@ -78,7 +78,7 @@ mod tests {
 
     #[test]
     fn given_root_user_data_and_credentials_should_be_valid() {
-        let user = User::root();
+        let user = User::root(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD);
         assert_eq!(user.id, DEFAULT_ROOT_USER_ID);
         assert_eq!(user.username, DEFAULT_ROOT_USERNAME);
         assert_ne!(user.password, DEFAULT_ROOT_PASSWORD);


### PR DESCRIPTION
From now on, you can provide the `IGGY_ROOT_USERNAME` and `IGGY_ROOT_PASSWORD` environment variables in order to create the root user using your own credentials, instead of the default ones.