### PR TITLE
Refactor login and me command tests for various scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "cli"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/integration/tests/cli/common/command.rs
+++ b/integration/tests/cli/common/command.rs
@@ -75,4 +75,8 @@ impl IggyCmdCommand {
     pub(crate) fn get_env(&self) -> HashMap<String, String> {
         self.env.clone()
     }
+
+    pub(crate) fn disable_backtrace(self) -> Self {
+        self.env("RUST_BACKTRACE", "0")
+    }
 }

--- a/integration/tests/cli/system/test_cli_session_scenario.rs
+++ b/integration/tests/cli/system/test_cli_session_scenario.rs
@@ -1,7 +1,7 @@
 use crate::cli::common::IggyCmdTest;
-use crate::cli::system::test_login_cmd::TestLoginCmd;
+use crate::cli::system::test_login_cmd::{TestLoginCmd, TestLoginCmdType};
 use crate::cli::system::test_logout_cmd::TestLogoutCmd;
-use crate::cli::system::test_me_command::TestMeCmd;
+use crate::cli::system::test_me_command::{Protocol, Scenario, TestMeCmd};
 use serial_test::serial;
 
 #[tokio::test]
@@ -14,11 +14,65 @@ pub async fn should_be_successful() {
     assert!(server_address.is_some());
     let server_address = server_address.unwrap();
 
+    // Login with admin credentials (username and password)
     iggy_cmd_test
-        .execute_test(TestLoginCmd::new(server_address.clone()))
+        .execute_test(TestLoginCmd::new(
+            server_address.clone(),
+            TestLoginCmdType::Success,
+        ))
         .await;
-    iggy_cmd_test.execute_test(TestMeCmd::default()).await;
+    // Check if session works using "me" command (which requires authentication)
+    // Command shall be executed without credentials and should be successful
     iggy_cmd_test
-        .execute_test(TestLogoutCmd::new(server_address))
+        .execute_test(TestMeCmd::new(
+            Protocol::Tcp,
+            Scenario::SuccessWithoutCredentials,
+        ))
+        .await;
+    // Login again with admin credentials (username and password)
+    // Command should inform about already open session
+    iggy_cmd_test
+        .execute_test(TestLoginCmd::new(
+            server_address.clone(),
+            TestLoginCmdType::AlreadyLoggedIn,
+        ))
+        .await;
+    // Logout from the server
+    iggy_cmd_test
+        .execute_test(TestLogoutCmd::new(server_address.clone()))
+        .await;
+    // Login with admin credentials (username and password)
+    // In prepare_server_state create PAT with session name, keyring shall be empty
+    // Command should inform about already open session (and store PAT in keyring)
+    iggy_cmd_test
+        .execute_test(TestLoginCmd::new(
+            server_address.clone(),
+            TestLoginCmdType::AlreadyLoggedInWithToken,
+        ))
+        .await;
+    // Logout from the server
+    iggy_cmd_test
+        .execute_test(TestLogoutCmd::new(server_address.clone()))
+        .await;
+    // Login with admin credentials (username and password) and timeout
+    // Minimum timeout for session is 1 second (due to PAT timeout in SDK)
+    let login_session_timeout = 1;
+    iggy_cmd_test
+        .execute_test(TestLoginCmd::new(
+            server_address.clone(),
+            TestLoginCmdType::SuccessWithTimeout(login_session_timeout),
+        ))
+        .await;
+    // sleep for given seconds (min 1 second)
+    tokio::time::sleep(tokio::time::Duration::from_secs(login_session_timeout)).await;
+    // Check if session expired using "me" command (which requires authentication,
+    // not provided in this case).
+    // Command shall be executed without credentials and should fail with proper
+    // error message.
+    iggy_cmd_test
+        .execute_test(TestMeCmd::new(
+            Protocol::Tcp,
+            Scenario::FailureDueToSessionTimeout,
+        ))
         .await;
 }

--- a/integration/tests/cli/system/test_login_cmd.rs
+++ b/integration/tests/cli/system/test_login_cmd.rs
@@ -3,18 +3,30 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::cli::system::session::ServerSession;
 use iggy::client::Client;
-use iggy::personal_access_tokens::delete_personal_access_token::DeletePersonalAccessToken;
+use iggy::personal_access_tokens::create_personal_access_token::CreatePersonalAccessToken;
 use iggy::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
 use predicates::str::diff;
 
 #[derive(Debug)]
+pub enum TestLoginCmdType {
+    Success,
+    SuccessWithTimeout(u64),
+    AlreadyLoggedIn,
+    AlreadyLoggedInWithToken,
+}
+
+#[derive(Debug)]
 pub(super) struct TestLoginCmd {
     server_address: String,
+    login_type: TestLoginCmdType,
 }
 
 impl TestLoginCmd {
-    pub(super) fn new(server_address: String) -> Self {
-        Self { server_address }
+    pub(super) fn new(server_address: String, login_type: TestLoginCmdType) -> Self {
+        Self {
+            server_address,
+            login_type,
+        }
     }
 }
 
@@ -22,24 +34,67 @@ impl TestLoginCmd {
 impl IggyCmdTestCase for TestLoginCmd {
     async fn prepare_server_state(&mut self, client: &dyn Client) {
         let login_session = ServerSession::new(self.server_address.clone());
-        assert!(!login_session.is_active());
+        match self.login_type {
+            TestLoginCmdType::Success | TestLoginCmdType::SuccessWithTimeout(_) => {
+                assert!(!login_session.is_active());
 
-        let pats = client
-            .get_personal_access_tokens(&GetPersonalAccessTokens {})
-            .await
-            .unwrap();
-        assert_eq!(pats.len(), 0);
+                let pats = client
+                    .get_personal_access_tokens(&GetPersonalAccessTokens {})
+                    .await
+                    .unwrap();
+                assert_eq!(pats.len(), 0);
+            }
+            TestLoginCmdType::AlreadyLoggedIn => {
+                assert!(login_session.is_active());
+
+                let pats = client
+                    .get_personal_access_tokens(&GetPersonalAccessTokens {})
+                    .await
+                    .unwrap();
+                assert_eq!(pats.len(), 1);
+            }
+            TestLoginCmdType::AlreadyLoggedInWithToken => {
+                // Local keyring must be empty
+                assert!(!login_session.is_active());
+
+                let pat = client
+                    .create_personal_access_token(&CreatePersonalAccessToken {
+                        name: login_session.get_token_name(),
+                        expiry: None,
+                    })
+                    .await;
+                assert!(pat.is_ok());
+            }
+        }
     }
 
     fn get_command(&self) -> IggyCmdCommand {
-        IggyCmdCommand::new().with_env_credentials().arg("login")
+        let command = IggyCmdCommand::new().with_cli_credentials().arg("login");
+
+        if let TestLoginCmdType::SuccessWithTimeout(timeout) = self.login_type {
+            command.arg(format!("{timeout}s"))
+        } else {
+            command
+        }
     }
 
     fn verify_command(&self, command_state: Assert) {
-        command_state.success().stdout(diff(format!(
-            "Executing login command\nSuccessfully logged into Iggy server {}\n",
-            self.server_address
-        )));
+        match self.login_type {
+            TestLoginCmdType::Success
+            | TestLoginCmdType::AlreadyLoggedInWithToken
+            | TestLoginCmdType::SuccessWithTimeout(_) => {
+                command_state.success().stdout(diff(format!(
+                    "Executing login command\nSuccessfully logged into Iggy server {}\n",
+                    self.server_address
+                )));
+            }
+            TestLoginCmdType::AlreadyLoggedIn => {
+                command_state.success().stdout(diff(format!(
+                    "Executing login command\nAlready logged into Iggy server {}\n",
+                    self.server_address
+                )));
+            }
+        }
     }
 
     async fn verify_server_state(&self, client: &dyn Client) {
@@ -52,15 +107,5 @@ impl IggyCmdTestCase for TestLoginCmd {
             .unwrap();
         assert_eq!(pats.len(), 1);
         assert_eq!(pats[0].name, login_session.get_token_name());
-
-        let cleanup_session = login_session.delete();
-        assert!(cleanup_session.is_ok());
-
-        let token_cleanup = client
-            .delete_personal_access_token(&DeletePersonalAccessToken {
-                name: login_session.get_token_name(),
-            })
-            .await;
-        assert!(token_cleanup.is_ok());
     }
 }

--- a/integration/tests/cli/system/test_logout_cmd.rs
+++ b/integration/tests/cli/system/test_logout_cmd.rs
@@ -3,7 +3,6 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::cli::system::session::ServerSession;
 use iggy::client::Client;
-use iggy::personal_access_tokens::create_personal_access_token::CreatePersonalAccessToken;
 use iggy::personal_access_tokens::get_personal_access_tokens::GetPersonalAccessTokens;
 use predicates::str::diff;
 
@@ -20,20 +19,8 @@ impl TestLogoutCmd {
 
 #[async_trait]
 impl IggyCmdTestCase for TestLogoutCmd {
-    async fn prepare_server_state(&mut self, client: &dyn Client) {
+    async fn prepare_server_state(&mut self, _client: &dyn Client) {
         let login_session = ServerSession::new(self.server_address.clone());
-        assert!(!login_session.is_active());
-
-        let token = client
-            .create_personal_access_token(&CreatePersonalAccessToken {
-                name: login_session.get_token_name(),
-                expiry: None,
-            })
-            .await;
-        assert!(token.is_ok());
-
-        let token = token.unwrap();
-        login_session.store(&token.token).unwrap();
         assert!(login_session.is_active());
     }
 


### PR DESCRIPTION
This commit overhauls the integration tests for the CLI's login and me
commands to handle multiple scenarios, including successful logins,
logins with timeouts, and session expiration. The TestLoginCmd now
supports different types of login attempts, such as logging in with an
already active session or with a token already present. The TestMeCmd
has been extended to test the behavior of the me command under various
conditions, like without credentials or after a session timeout. The
login command in the SDK has been updated to delete and recreate the
login session if the local keyring is empty but a token exists on the
server, ensuring that the token on the server and the local keyring are
in sync.Disable Rust backtrace for selected iggy cli command calls
during tests.