### PR TITLE
Remove QEMU runner blocks for GitHub CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,6 @@ jobs:
             name: iggy-Linux-arm-musl.tar.gz
             docker_arch: linux/arm/v7
             cross: true
-            qemu_runner: "qemu-arm"
 
           - os_name: Linux-aarch64-musl
             os: ubuntu-latest
@@ -101,7 +100,6 @@ jobs:
             name: iggy-Linux-aarch64-musl.tar.gz
             docker_arch: linux/arm64/v8
             cross: true
-            qemu_runner: "qemu-aarch64"
 
         toolchain:
           - stable
@@ -114,10 +112,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
         with:
           key: "v2"
-
-      - name: Set environment variables
-        run: export QEMU_RUNNER=${{ matrix.platform.qemu_runner }}
-        if: ${{ matrix.platform.cross }}
 
       - name: Install musl-tools on Linux
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools

--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -41,7 +41,6 @@ jobs:
             docker_arch: linux/arm/v7
             profile: release
             cross: true
-            qemu_runner: "qemu-arm"
 
           - os_name: Linux-aarch64-musl
             os: ubuntu-latest
@@ -50,7 +49,6 @@ jobs:
             docker_arch: linux/arm64/v8
             profile: release
             cross: true
-            qemu_runner: "qemu-aarch64"
 
         toolchain:
           - stable
@@ -68,10 +66,6 @@ jobs:
         run: |
           git config --global user.email "jdoe@example.com"
           git config --global user.name "J. Doe"
-
-      - name: Set environment variables
-        run: export QEMU_RUNNER=${{ matrix.platform.qemu_runner }}
-        if: ${{ matrix.platform.cross }}
 
       - name: Install musl-tools, gnome-keyring and keyutils on Linux
         run: |

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,8 +1,2 @@
 [build.env]
 passthrough = ["IGGY_SYSTEM_PATH", "IGGY_CI_BUILD", "RUST_BACKTRACE=1"]
-
-[target.aarch64-unknown-linux-musl.env]
-passthrough = ["QEMU_RUNNER=qemu-aarch64"]
-
-[target.arm-unknown-linux-musleabi.env]
-passthrough = ["QEMU_RUNNER=qemu-arm"]

--- a/integration/src/test_server.rs
+++ b/integration/src/test_server.rs
@@ -161,17 +161,6 @@ impl TestServer {
         command.env(SYSTEM_PATH_ENV_VAR, files_path.clone());
         command.envs(self.envs.clone());
 
-        // When running action from github CI, binary needs to be started via QEMU.
-        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
-            let mut runner_command = Command::new(runner);
-            runner_command
-                .arg(command.get_program().to_str().unwrap())
-                .env(SYSTEM_PATH_ENV_VAR, files_path);
-
-            runner_command.envs(self.envs.clone());
-            command = runner_command;
-        };
-
         // By default, server all logs are redirected to files,
         // and dumped to stderr when test fails. With IGGY_TEST_VERBOSE=1
         // logs are dumped to stdout during test execution.

--- a/integration/tests/bench/mod.rs
+++ b/integration/tests/bench/mod.rs
@@ -17,13 +17,6 @@ const BENCH_FILES_PREFIX: &str = "bench_";
 fn run_bench_and_wait_for_finish(server_addr: &str, transport: Transport) {
     let mut command = Command::cargo_bin("iggy-bench").unwrap();
 
-    // When running action from github CI, binary needs to be started via QEMU.
-    if let Ok(runner) = std::env::var("QEMU_RUNNER") {
-        let mut runner_command = Command::new(runner);
-        runner_command.arg(command.get_program().to_str().unwrap());
-        command = runner_command;
-    };
-
     let mut stderr_file_path = None;
     let mut stdout_file_path = None;
 

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -144,15 +144,6 @@ impl IggyCmdTest {
         // Set server address for the command - it's randomized for each test
         command.args(test_case.protocol(&self.server));
 
-        // When running action from github CI, binary needs to be started via QEMU.
-        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
-            let mut runner_command = Command::new(runner);
-            runner_command.envs(command_args.get_env());
-            runner_command.arg(command.get_program().to_str().unwrap());
-            runner_command.args(test_case.protocol(&self.server));
-            command = runner_command;
-        };
-
         // Print used environment variables and command with all arguments.
         // By default, it will not be visible but once test is executed with
         // --nocapture flag, it will be visible.
@@ -210,14 +201,6 @@ impl IggyCmdTest {
         let command_args = test_case.get_command();
         // Set environment variables for the command
         command.envs(command_args.get_env());
-
-        // When running action from github CI, binary needs to be started via QEMU.
-        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
-            let mut runner_command = Command::new(runner);
-            runner_command.arg(command.get_program().to_str().unwrap());
-            runner_command.envs(command_args.get_env());
-            command = runner_command;
-        };
 
         // Print used environment variables and command with all arguments.
         // By default, it will not be visible but once test is executed with

--- a/integration/tests/examples/mod.rs
+++ b/integration/tests/examples/mod.rs
@@ -3,7 +3,6 @@ mod test_getting_started;
 mod test_message_envelope;
 mod test_message_headers;
 
-use assert_cmd::cargo::CommandCargoExt;
 use assert_cmd::Command;
 use iggy::client::Client;
 use iggy::client::StreamClient;
@@ -22,7 +21,6 @@ use iggy::users::defaults::*;
 use iggy::users::login_user::LoginUser;
 use integration::test_server::{IpAddrKind, TestServer};
 use regex::Regex;
-use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -165,30 +163,20 @@ impl<'a> IggyExampleTest<'a> {
 
 impl<'a> IggyExampleTest<'a> {
     async fn spawn_executables(&mut self, tcp_server_address: Vec<String>) -> (String, String) {
-        let producer_binary = StdCommand::cargo_bin(format!("examples/{}-producer", self.module))
+        let mut producer_cmd = Command::cargo_bin(format!("examples/{}-producer", self.module))
             .unwrap_or_else(|_| panic!("Failed to find {}-producer", self.module));
-        let consumer_binary = StdCommand::cargo_bin(format!("examples/{}-consumer", self.module))
+        let mut consumer_cmd = Command::cargo_bin(format!("examples/{}-consumer", self.module))
             .unwrap_or_else(|_| panic!("Failed to find {}-consumer", self.module));
-
-        let mut producer_cmd = Command::new(producer_binary.get_program().to_str().unwrap());
-        let mut consumer_cmd = Command::new(consumer_binary.get_program().to_str().unwrap());
-
-        if let Ok(runner) = std::env::var("QEMU_RUNNER") {
-            let mut producer_runner_command = Command::new(runner.clone());
-            let mut consumer_runner_command = Command::new(runner);
-            producer_runner_command.arg(producer_binary.get_program().to_str().unwrap());
-            consumer_runner_command.arg(consumer_binary.get_program().to_str().unwrap());
-            producer_cmd = producer_runner_command;
-            consumer_cmd = consumer_runner_command
-        };
 
         let mut args: Vec<String> = tcp_server_address.clone();
         args.push("--message-batches-limit".into());
         args.push("1".into());
-        let args_clone = args.clone();
+
+        producer_cmd.args(args.clone());
+        consumer_cmd.args(args);
+
         let producer_handle = tokio::spawn(async move {
             let producer_assert = producer_cmd
-                .args(args_clone.clone())
                 .timeout(Duration::from_secs(10))
                 .assert()
                 .success();
@@ -197,10 +185,8 @@ impl<'a> IggyExampleTest<'a> {
                 .as_ref()
                 .to_string()
         });
-        let args_clone = args.clone();
         let consumer_handle = tokio::spawn(async move {
             let consumer_assert = consumer_cmd
-                .args(args_clone)
                 .timeout(Duration::from_secs(10))
                 .assert()
                 .success();


### PR DESCRIPTION
This commit removes the conditional QEMU runner blocks that were previously required to start binaries via QEMU when running actions from GitHub CI for ARM architectures. The removal affects several integration test files where the QEMU runner logic is no longer necessary since new version of assert_cmd crate directly support correct commands execution under cross tool.

This fix #705 #709 #713 #716 #718 #720 #722
