### PR TITLE
Fix `IggyTimestamp` serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2022,7 +2022,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.5"
+version = "0.2.6"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
- Refactor IggyTimestamp to manually implement Serialize and Deserialize
  because #696 broke backwards compatibility due to bug in which SystemTime was stored instead of epoch u64 micros
- Bump iggy version from 0.2.5 to 0.2.6
- Bump server version from 0.2.3 to 0.2.4