### PR TITLE
Add warmup phase to benchmarks with configurable duration

### DIFF
--- a/bench/src/args/common.rs
+++ b/bench/src/args/common.rs
@@ -3,6 +3,7 @@ use super::props::{BenchmarkKindProps, BenchmarkTransportProps};
 use super::{defaults::*, transport::BenchmarkTransportCommand};
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
+use iggy::utils::duration::IggyDuration;
 use integration::test_server::Transport;
 use std::net::SocketAddr;
 use std::path::Path;
@@ -29,6 +30,10 @@ pub struct IggyBenchArgs {
     /// Server stdout visibility
     #[arg(long, short='v', default_value_t = DEFAULT_SERVER_STDOUT_VISIBILITY)]
     pub verbose: bool,
+
+    /// Warmup time
+    #[arg(long, short = 'w', default_value_t = IggyDuration::from(1))]
+    pub warmup_time: IggyDuration,
 }
 
 fn validate_server_executable_path(v: &str) -> Result<String, String> {
@@ -110,5 +115,9 @@ impl IggyBenchArgs {
         self.benchmark_kind
             .inner()
             .disable_parallel_consumer_streams()
+    }
+
+    pub fn warmup_time(&self) -> IggyDuration {
+        self.warmup_time
     }
 }

--- a/bench/src/benchmark_result.rs
+++ b/bench/src/benchmark_result.rs
@@ -56,7 +56,7 @@ impl BenchmarkResults {
         }
     }
 
-    fn calculate_statitics<F>(&self, mut predicate: F) -> BenchmarkStatistics
+    fn calculate_statistics<F>(&self, mut predicate: F) -> BenchmarkStatistics
     where
         F: FnMut(&&BenchmarkResult) -> bool,
     {
@@ -108,8 +108,8 @@ impl Display for BenchmarkResults {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Ok(test_type) = self.get_test_type() {
             if test_type == BenchmarkKind::SendAndPoll {
-                let producer_statics = self.calculate_statitics(|x| x.kind == BenchmarkKind::Send);
-                let consumer_statics = self.calculate_statitics(|x| x.kind == BenchmarkKind::Poll);
+                let producer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Send);
+                let consumer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Poll);
 
                 let producer_info = format!("Producer results: total throughput: {:.2} MB/s, {:.0} messages/s, average latency: {:.2} ms, average throughput: {:.2} MB/s, total duration: {:.2} s",
                 producer_statics.total_throughput, producer_statics.messages_per_second, producer_statics.average_latency, producer_statics.average_throughput, producer_statics.total_duration).green();
@@ -120,7 +120,7 @@ impl Display for BenchmarkResults {
             }
         }
 
-        let results = self.calculate_statitics(|x| {
+        let results = self.calculate_statistics(|x| {
             x.kind == BenchmarkKind::Send || x.kind == BenchmarkKind::Poll
         });
 

--- a/bench/src/benchmarks/poll_benchmark.rs
+++ b/bench/src/benchmarks/poll_benchmark.rs
@@ -43,6 +43,7 @@ impl Benchmarkable for PollMessagesBenchmark {
                 true => start_stream_id + client_id,
                 false => start_stream_id + 1,
             };
+            let warmup_time = args.warmup_time();
 
             let consumer = Consumer::new(
                 client_factory,
@@ -50,6 +51,7 @@ impl Benchmarkable for PollMessagesBenchmark {
                 stream_id,
                 messages_per_batch,
                 message_batches,
+                warmup_time,
             );
 
             let future = Box::pin(async move { consumer.run().await });

--- a/bench/src/benchmarks/send_and_poll_benchmark.rs
+++ b/bench/src/benchmarks/send_and_poll_benchmark.rs
@@ -61,6 +61,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
         let messages_per_batch = self.args.messages_per_batch();
         let message_batches = self.args.message_batches();
         let message_size = self.args.message_size();
+        let warmup_time = self.args.warmup_time();
         let mut futures: BenchmarkFutures =
             Ok(Vec::with_capacity((producers + consumers) as usize));
         for producer_id in 1..=producers {
@@ -76,6 +77,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 messages_per_batch,
                 message_batches,
                 message_size,
+                warmup_time,
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);
@@ -92,6 +94,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 stream_id,
                 messages_per_batch,
                 message_batches,
+                warmup_time,
             );
             let future = Box::pin(async move { consumer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/benchmarks/send_benchmark.rs
+++ b/bench/src/benchmarks/send_benchmark.rs
@@ -30,6 +30,7 @@ impl Benchmarkable for SendMessagesBenchmark {
         let messages_per_batch = self.args.messages_per_batch();
         let message_batches = self.args.message_batches();
         let message_size = self.args.message_size();
+        let warmup_time = self.args.warmup_time();
 
         let mut futures: BenchmarkFutures = Ok(Vec::with_capacity(clients_count as usize));
         for client_id in 1..=clients_count {
@@ -53,6 +54,7 @@ impl Benchmarkable for SendMessagesBenchmark {
                 messages_per_batch,
                 message_batches,
                 message_size,
+                warmup_time,
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -38,6 +38,7 @@ async fn main() -> Result<(), IggyError> {
         result = benchmark_future => {
             if let Err(e) = result {
                 error!("Benchmark failed with error: {:?}", e);
+                return Err(e);
             }
             info!("Finished the benchmarks");
         }

--- a/integration/tests/bench/mod.rs
+++ b/integration/tests/bench/mod.rs
@@ -29,6 +29,8 @@ fn run_bench_and_wait_for_finish(server_addr: &str, transport: Transport) {
 
     // 10 MB of data written to disk
     command.args([
+        "--warmup-time",
+        "0",
         "send-and-poll",
         "--messages-per-batch",
         "100",


### PR DESCRIPTION
This commit introduces a warmup time parameter to the benchmarking suite,
allowing for a configurable duration of warmup before measurements begin.
The warmup phase helps to stabilize the system, leading
to more consistent and accurate benchmark results. The `IggyDuration`
is utilized to manage the warmup duration, ensuring precise control over
the warmup period. Additionally, this update includes a fix for a typo in
the `calculate_statistics` method name.