### PR TITLE
Fix post_release flow

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   post_release:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'}}
     steps:
       - uses: actions/checkout@v4
 
@@ -24,28 +24,43 @@ jobs:
       - uses: addnab/docker-run-action@v3
         name: Spin up Docker Container
         with:
-          image: iggyrs/iggy
-          options: -d -p 8090:8090 --name iggy_container
+          image: iggyrs/iggy:latest
+          options: -d -p 8090:8090
+          run: /iggy/iggy-server
+
+      - name: Wait till iggy-server has bound to TCP 8090 port
+        timeout-minutes: 1
+        run: |
+          while ! nc -z 127.0.0.1 8090; do
+            sleep 1
+          done
 
       - name: Test Benchmark - Send
         timeout-minutes: 1
         run: |
-          ./target/debug/iggy-bench send --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
+          ./target/debug/iggy-bench --skip-server-start --warmup-time 0s send --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
 
       - name: Test Benchmark - Poll
         timeout-minutes: 1
         run: |
-          ./target/debug/iggy-bench poll --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
+          ./target/debug/iggy-bench --skip-server-start --warmup-time 0s poll --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
 
       - name: Test Benchmark - Send and Poll
         timeout-minutes: 1
         run: |
-          ./target/debug/iggy-bench send-and-poll --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
+          ./target/debug/iggy-bench --skip-server-start --warmup-time 0s send-and-poll --message-batches 100 --messages-per-batch 100 tcp --server-address 127.0.0.1:8090
 
-      - name: Test CLI - topic creation
+      - name: Check if number of messages is correct
         timeout-minutes: 1
         run: |
-          IGGY_USERNAME=iggy IGGY_PASSWORD=iggy ./target/debug/iggy stream create test-stream
+          STATS=$(./target/debug/iggy -u iggy -p iggy stats)
+          echo "$STATS"
+          MESSAGE_COUNT=$(echo "$STATS" | grep -oP 'Message Count\s+\|\s+\K\d+')
+          readonly EXPECTED_MESSAGE_COUNT=200000
+          if [ "$MESSAGE_COUNT" -ne "$EXPECTED_MESSAGE_COUNT" ]; then
+            echo "Expected message count to be $EXPECTED_MESSAGE_COUNT, but got $MESSAGE_COUNT"
+            exit 1
+          fi
 
       - name: Clean up
         run: docker rm -f iggy_container

--- a/bench/src/args/common.rs
+++ b/bench/src/args/common.rs
@@ -32,8 +32,12 @@ pub struct IggyBenchArgs {
     pub verbose: bool,
 
     /// Warmup time
-    #[arg(long, short = 'w', default_value_t = IggyDuration::from(1))]
+    #[arg(long, short = 'w', default_value_t = IggyDuration::from(DEFAULT_WARMUP_TIME_SECONDS))]
     pub warmup_time: IggyDuration,
+
+    /// Skip server start
+    #[arg(long, short = 'k', default_value_t = DEFAULT_SKIP_SERVER_START)]
+    pub skip_server_start: bool,
 }
 
 fn validate_server_executable_path(v: &str) -> Result<String, String> {

--- a/bench/src/args/defaults.rs
+++ b/bench/src/args/defaults.rs
@@ -27,3 +27,6 @@ pub const DEFAULT_NUMBER_OF_PRODUCERS: NonZeroU32 = u32!(10);
 pub const DEFAULT_PERFORM_CLEANUP: bool = false;
 pub const DEFAULT_SERVER_SYSTEM_PATH: &str = "local_data";
 pub const DEFAULT_SERVER_STDOUT_VISIBILITY: bool = false;
+
+pub const DEFAULT_WARMUP_TIME_SECONDS: u64 = 1;
+pub const DEFAULT_SKIP_SERVER_START: bool = false;

--- a/bench/src/server_starter.rs
+++ b/bench/src/server_starter.rs
@@ -19,6 +19,11 @@ struct ConfigAddress {
 }
 
 pub async fn start_server_if_needed(args: &mut IggyBenchArgs) -> Option<TestServer> {
+    if args.skip_server_start {
+        info!("Skipping iggy-server start");
+        return None;
+    }
+
     let default_config: ServerConfig =
         toml::from_str(include_str!("../../configs/server.toml")).unwrap();
     let (should_start, mut envs) = match &args.transport() {


### PR DESCRIPTION
Ensure iggy-server is ready by waiting for TCP port 8090 to bind before
benchmarks. Update Docker image to use the latest tag. Introduce a
check for the correct message count after benchmarks. Refactor
benchmark arguments to include defaults for warmup time and server
start skipping. Adjust server starter logic to respect the new
skip server start option.