### PR TITLE
Add Docker support for keyring in cross-compilation tests

### DIFF
--- a/.github/workflows/test_nightly.yml
+++ b/.github/workflows/test_nightly.yml
@@ -10,6 +10,9 @@ env:
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
   IGGY_CI_BUILD: true
+  # Option needed for starting docker under cross to be able to lock memory
+  # in order to be able to use keyring inside Docker container
+  CROSS_CONTAINER_OPTS: "--cap-add ipc_lock"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,7 +20,7 @@ concurrency:
 
 jobs:
   build_and_test:
-    name: 'build and test ${{ matrix.platform.profile }} ${{ matrix.platform.os_name }}'
+    name: 'build and test ${{ matrix.toolchain }} ${{ matrix.platform.os_name }}'
     runs-on: ${{ matrix.platform.os }}
     timeout-minutes: 120
     strategy:
@@ -73,6 +76,12 @@ jobs:
           rm -f $HOME/.local/share/keyrings/*
           echo -n "test" | gnome-keyring-daemon --unlock
         if: contains(matrix.platform.name, 'musl')
+
+      - name: Prepare Cross.toml
+        run: |
+          scripts/prepare-cross-toml.sh
+          cat Cross.toml
+        if: ${{ matrix.platform.cross }}
 
       - name: Build binary
         uses: houseabsolute/actions-rust-cross@v0

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ local_data*
 bench_*
 /sdk/errors_table/
 /rust-clippy-results.sarif
+/Cross.toml

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,0 @@
-[build.env]
-passthrough = ["IGGY_SYSTEM_PATH", "IGGY_CI_BUILD", "RUST_BACKTRACE=1"]

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,0 +1,25 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+ARG USER
+ARG CROSS_CONTAINER_UID
+ARG CROSS_CONTAINER_GID
+
+USER root
+RUN apt-get update \
+    && apt-get install gnome-keyring \
+    --yes --no-install-recommends \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Copy the entrypoint script into the container
+COPY scripts/cross-docker-entrypoint.sh /usr/local/bin/
+
+# Make the entrypoint script executable
+RUN chmod +x /usr/local/bin/cross-docker-entrypoint.sh
+
+# Add user with specified UID and GID
+RUN groupadd -g $CROSS_CONTAINER_GID $USER
+RUN useradd -r -u $CROSS_CONTAINER_UID -g $CROSS_CONTAINER_GID -m $USER
+
+# Set the entry point
+ENTRYPOINT ["/usr/local/bin/cross-docker-entrypoint.sh"]

--- a/integration/tests/cli/personal_access_token/mod.rs
+++ b/integration/tests/cli/personal_access_token/mod.rs
@@ -2,6 +2,6 @@ mod test_pat_create_command;
 mod test_pat_delete_command;
 mod test_pat_help_command;
 mod test_pat_list_command;
-// Disable tests due to missing keyring on arm and aarch64 until #294 is implemented
-#[cfg(not(any(target_arch = "aarch64", target_arch = "arm")))]
+// Disable tests due to missing keyring on macOS until #794 is implemented
+#[cfg(not(target_os = "macos"))]
 mod test_pat_login_options;

--- a/integration/tests/cli/system/mod.rs
+++ b/integration/tests/cli/system/mod.rs
@@ -1,4 +1,5 @@
-#[cfg(not(any(target_arch = "aarch64", target_arch = "arm")))]
+// Disable tests due to missing keyring on macOS until #794 is implemented
+#[cfg(not(target_os = "macos"))]
 mod test_cli_session_scenario;
 mod test_login_cmd;
 mod test_login_command;

--- a/scripts/cross-docker-entrypoint.sh
+++ b/scripts/cross-docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Script designed for iggy internal tests for non-native / non-x86_64
+# architectures inside Docker container (using cross tool).
+
+set -euo pipefail
+
+echo "Got following docker command \"$*\""
+
+# If this is cargo build command do execute it
+if [[ $* == *"cargo test"* ]]; then
+    # Strip prefix (sh -c) as it is not evaluated properly under
+    # dbus / gnome-keyring session.
+    command="$*"
+    command=${command#sh -c }
+
+    # Unlock keyring and run command
+    dbus-run-session -- sh -c "echo \"iggy\" | gnome-keyring-daemon --unlock && eval \"${command}\""
+else
+    # Otherwise (non cargo test scenario) just execute what has been requested
+    exec "$@"
+fi

--- a/scripts/prepare-cross-toml.sh
+++ b/scripts/prepare-cross-toml.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script is used to generate Cross.toml file for user which executes
+# this script. This is needed since Cross.toml build.dockerfile.build-args
+# section requires statically defined Docker build arguments and parameters
+# like current UID or GID must be entered (cannot be generated or fetched
+# during cross execution time).
+
+readonly CROSS_TOML_FILE="Cross.toml"
+USER_UID=$(id -u)
+readonly USER_UID
+USER_GID=$(id -g)
+readonly USER_GID
+USER_NAME=$(id -un)
+readonly USER_NAME
+
+echo "Preparing ${CROSS_TOML_FILE} file for user ${USER_NAME} with UID ${USER_UID} and GID ${USER_GID}."
+
+cat << EOF > "${CROSS_TOML_FILE}"
+[build.env]
+passthrough = ["IGGY_SYSTEM_PATH", "IGGY_CI_BUILD", "RUST_BACKTRACE=1"]
+
+[build.dockerfile]
+file = "Dockerfile.cross"
+build-args = { USER = "${USER_NAME}", CROSS_CONTAINER_UID = "${USER_UID}", CROSS_CONTAINER_GID = "${USER_GID}" }
+
+EOF


### PR DESCRIPTION
This commit introduces several changes to improve the cross-compilation
testing environment by adding Docker support for keyring functionality.
Add CROSS_CONTAINER_OPTS to GitHub workflows to enable IPC lock
capabilities, allowing keyring usage within Docker containers.
Create a new Dockerfile.cross to set up a Docker image with gnome-keyring
installed and configured a user with the appropriate UID and GID. Add
a new entrypoint script cross-docker-entrypoint.sh for the Docker
container to handle keyring unlocking and execution of the test commands.
Generate a Cross.toml configuration file using prepare-cross-toml.sh
script to pass the current user's UID and GID to the Docker build context.
Adjusted integration tests to reflect the new keyring support in Docker
for ARM and AArch64 architectures.

Updated the job name in the CI workflow to use matrix.toolchain instead of
matrix.platform.profile.

This fixes #294
