### PR TITLE
Add network check and pause in post-release workflow

### DIFF
--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -34,6 +34,8 @@ jobs:
           while ! nc -z 127.0.0.1 8090; do
             sleep 1
           done
+          sleep 1
+          ss -tuln | grep :8090
 
       - name: Test Benchmark - Send
         timeout-minutes: 1


### PR DESCRIPTION
This commit introduces a network check to confirm that port 8090
is open before proceeding with the post-release actions.
Additionally, a one-second pause has been added to ensure that
any transient conditions have time to stabilize. This should
help in troubleshooting and ensuring that the iggy server is
ready for the subsequent test benchmark step.

This fixes #787, fixes #792, fixes #793, fixes #795, fixes #801,
fixes #802, fixes #804, fixes #810
