### PR TITLE
Refactor server configuration defaults to use static config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,6 +2950,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -3866,6 +3867,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sled",
+ "static-toml",
  "strip-ansi-escapes",
  "sysinfo",
  "thiserror",
@@ -4023,6 +4025,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "static-toml"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf47a76b3a01cafdeebf4feeb2691f28398a4ac028e6dd33fd61ed04306950c"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+ "toml",
 ]
 
 [[package]]

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -30,7 +30,7 @@ allowed_headers = ["content-type"]
 
 # Headers that browsers are allowed to access in CORS responses.
 # An empty array means no additional headers are exposed to browsers.
-exposed_headers = []
+exposed_headers = [""]
 
 # Determines if credentials like cookies or HTTP auth can be included in CORS requests.
 # `true` allows credentials to be included, useful for authenticated sessions.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -47,6 +47,7 @@ serde = { version = "1.0.197", features = ["derive", "rc"] }
 serde_json = "1.0.114"
 serde_with = { version = "3.7.0", features = ["base64", "macros"] }
 sled = "0.34.7"
+static-toml = "1.2.0"
 strip-ansi-escapes = "0.2.0"
 sysinfo = "0.30.7"
 thiserror = "1.0.58"

--- a/server/src/configs/http.rs
+++ b/server/src/configs/http.rs
@@ -15,7 +15,7 @@ pub struct HttpConfig {
     pub tls: HttpTlsConfig,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct HttpCorsConfig {
     pub enabled: bool,
     pub allowed_methods: Vec<String>,
@@ -47,7 +47,7 @@ pub struct HttpJwtConfig {
     pub use_base64_secret: bool,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct HttpMetricsConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -59,7 +59,7 @@ pub enum JwtSecret {
     Base64(String),
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct HttpTlsConfig {
     pub enabled: bool,
     pub cert_file: String,

--- a/server/src/configs/system.rs
+++ b/server/src/configs/system.rs
@@ -78,7 +78,7 @@ pub struct RetentionPolicyConfig {
     pub max_topic_size: IggyByteSize,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct EncryptionConfig {
     pub enabled: bool,
     pub key: String,

--- a/server/src/configs/tcp.rs
+++ b/server/src/configs/tcp.rs
@@ -7,7 +7,7 @@ pub struct TcpConfig {
     pub tls: TcpTlsConfig,
 }
 
-#[derive(Debug, Deserialize, Serialize, Default, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct TcpTlsConfig {
     pub enabled: bool,
     pub certificate: String,

--- a/server/src/http/http_server.rs
+++ b/server/src/http/http_server.rs
@@ -133,18 +133,21 @@ fn configure_cors(config: HttpCorsConfig) -> CorsLayer {
     let allowed_headers = config
         .allowed_headers
         .iter()
+        .filter(|s| !s.is_empty())
         .map(|s| s.parse().unwrap())
         .collect::<Vec<_>>();
 
     let exposed_headers = config
         .exposed_headers
         .iter()
+        .filter(|s| !s.is_empty())
         .map(|s| s.parse().unwrap())
         .collect::<Vec<_>>();
 
     let allowed_methods = config
         .allowed_methods
         .iter()
+        .filter(|s| !s.is_empty())
         .map(|s| match s.to_uppercase().as_str() {
             "GET" => Method::GET,
             "POST" => Method::POST,


### PR DESCRIPTION
This commit streamlines the server configuration by utilizing the static
SERVER_CONFIG for setting default values. It removes hardcoded strings and
replaces them with parsed values from the configuration file, ensuring
consistency and maintainability. The changes include updates to CORS headers,
QUIC, HTTP, and other server components, enhancing the configuration's
flexibility and readability.