### PR TITLE
Add message size validation scenario for TCP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/integration/tests/server/scenarios/message_size_scenario.rs
+++ b/integration/tests/server/scenarios/message_size_scenario.rs
@@ -1,0 +1,229 @@
+use bytes::Bytes;
+use iggy::client::{MessageClient, StreamClient, TopicClient};
+use iggy::clients::client::{IggyClient, IggyClientBackgroundConfig};
+use iggy::consumer::Consumer;
+use iggy::error::IggyError;
+use iggy::error::IggyError::InvalidResponse;
+use iggy::identifier::Identifier;
+use iggy::messages::poll_messages::{PollMessages, PollingStrategy};
+use iggy::messages::send_messages::{Message, Partitioning, SendMessages};
+use iggy::models::header::{HeaderKey, HeaderValue};
+use iggy::streams::create_stream::CreateStream;
+use iggy::streams::delete_stream::DeleteStream;
+use iggy::topics::create_topic::CreateTopic;
+use integration::test_server::{assert_clean_system, login_root, ClientFactory};
+use std::collections::HashMap;
+use std::str::FromStr;
+
+const STREAM_ID: u32 = 1;
+const TOPIC_ID: u32 = 1;
+const STREAM_NAME: &str = "test-stream";
+const TOPIC_NAME: &str = "test-topic";
+const PARTITIONS_COUNT: u32 = 3;
+const PARTITION_ID: u32 = 1;
+const MAX_HEADER_SIZE: usize = 255;
+
+enum MessageToSend {
+    NoMessage,
+    OfSize(usize),
+    OfSizeWithHeaders(usize, usize),
+}
+
+pub async fn run(client_factory: &dyn ClientFactory) {
+    let client = client_factory.create_client().await;
+    let client = IggyClient::create(
+        client,
+        IggyClientBackgroundConfig::default(),
+        None,
+        None,
+        None,
+    );
+
+    login_root(&client).await;
+    init_system(&client).await;
+
+    // 3. Send message and check the result
+    send_message_and_check_result(
+        &client,
+        MessageToSend::NoMessage,
+        Err(IggyError::InvalidMessagesCount),
+    )
+    .await;
+    send_message_and_check_result(&client, MessageToSend::OfSize(1), Ok(())).await;
+    send_message_and_check_result(&client, MessageToSend::OfSize(1_000_000), Ok(())).await;
+    send_message_and_check_result(&client, MessageToSend::OfSize(10_000_000), Ok(())).await;
+    send_message_and_check_result(
+        &client,
+        MessageToSend::OfSizeWithHeaders(1, 10_000_000),
+        Ok(()),
+    )
+    .await;
+    send_message_and_check_result(
+        &client,
+        MessageToSend::OfSizeWithHeaders(1_000, 10_000_000),
+        Ok(()),
+    )
+    .await;
+    send_message_and_check_result(
+        &client,
+        MessageToSend::OfSizeWithHeaders(100_000, 10_000_000),
+        Ok(()),
+    )
+    .await;
+    send_message_and_check_result(
+        &client,
+        MessageToSend::OfSizeWithHeaders(100_001, 10_000_000),
+        Err(InvalidResponse(
+            4017,
+            23,
+            "Too big headers payload".to_owned(),
+        )),
+    )
+    .await;
+    send_message_and_check_result(
+        &client,
+        MessageToSend::OfSizeWithHeaders(100_000, 10_000_001),
+        Err(InvalidResponse(
+            4022,
+            23,
+            "Too big message payload".to_owned(),
+        )),
+    )
+    .await;
+
+    assert_message_count(&client, 6).await;
+    cleanup_system(&client).await;
+    assert_clean_system(&client).await;
+}
+
+async fn assert_message_count(client: &IggyClient, expected_count: u32) {
+    // 4. Poll messages and validate the headers
+    let poll_messages = PollMessages {
+        consumer: Consumer::default(),
+        stream_id: Identifier::numeric(STREAM_ID).unwrap(),
+        topic_id: Identifier::numeric(TOPIC_ID).unwrap(),
+        partition_id: Some(PARTITION_ID),
+        strategy: PollingStrategy::offset(0),
+        count: expected_count * 2,
+        auto_commit: false,
+    };
+
+    let polled_messages = client.poll_messages(&poll_messages).await.unwrap();
+    assert_eq!(polled_messages.messages.len() as u32, expected_count);
+}
+
+async fn init_system(client: &IggyClient) {
+    // 1. Create the stream
+    let create_stream = CreateStream {
+        stream_id: Some(STREAM_ID),
+        name: STREAM_NAME.to_string(),
+    };
+    client.create_stream(&create_stream).await.unwrap();
+
+    // 2. Create the topic
+    let create_topic = CreateTopic {
+        stream_id: Identifier::numeric(STREAM_ID).unwrap(),
+        topic_id: Some(TOPIC_ID),
+        partitions_count: PARTITIONS_COUNT,
+        name: TOPIC_NAME.to_string(),
+        message_expiry: None,
+        max_topic_size: None,
+        replication_factor: 1,
+    };
+    client.create_topic(&create_topic).await.unwrap();
+}
+
+async fn cleanup_system(client: &IggyClient) {
+    let delete_stream = DeleteStream {
+        stream_id: Identifier::numeric(STREAM_ID).unwrap(),
+    };
+    client.delete_stream(&delete_stream).await.unwrap();
+}
+
+async fn send_message_and_check_result(
+    client: &IggyClient,
+    message_params: MessageToSend,
+    expected_result: Result<(), IggyError>,
+) {
+    let mut messages = Vec::new();
+
+    match message_params {
+        MessageToSend::NoMessage => {
+            println!("Sending message without messages inside");
+        }
+        MessageToSend::OfSize(size) => {
+            println!("Sending message with payload size = {size}");
+            messages.push(create_message(None, size));
+        }
+        MessageToSend::OfSizeWithHeaders(header_size, payload_size) => {
+            println!("Sending message with header size = {header_size} and payload size = {payload_size}");
+            messages.push(create_message(Some(header_size), payload_size));
+        }
+    };
+
+    let mut send_messages = SendMessages {
+        stream_id: Identifier::numeric(STREAM_ID).unwrap(),
+        topic_id: Identifier::numeric(TOPIC_ID).unwrap(),
+        partitioning: Partitioning::partition_id(PARTITION_ID),
+        messages,
+    };
+
+    let send_result = client.send_messages(&mut send_messages).await;
+    println!("Received = {send_result:?}, expected = {expected_result:?}");
+    match expected_result {
+        Ok(()) => assert!(send_result.is_ok()),
+        Err(error) => {
+            assert!(send_result.is_err());
+            let send_result = send_result.err().unwrap();
+            assert_eq!(error.as_code(), send_result.as_code());
+            assert_eq!(error.to_string(), send_result.to_string());
+        }
+    }
+}
+
+fn create_string_of_size(size: usize) -> String {
+    "x".repeat(size)
+}
+
+fn create_message_header_of_size(size: usize) -> HashMap<HeaderKey, HeaderValue> {
+    let mut headers = HashMap::new();
+    let mut header_id = 1;
+    let mut size = size;
+
+    while size > 0 {
+        let header_size = if size > MAX_HEADER_SIZE {
+            MAX_HEADER_SIZE
+        } else {
+            size
+        };
+        headers.insert(
+            HeaderKey::new(format!("header-{header_id}").as_str()).unwrap(),
+            HeaderValue::from_str(create_string_of_size(header_size).as_str()).unwrap(),
+        );
+        header_id += 1;
+        size -= header_size;
+    }
+
+    headers
+}
+
+fn create_message(header_size: Option<usize>, payload_size: usize) -> Message {
+    let headers = match header_size {
+        Some(header_size) => {
+            if header_size > 0 {
+                Some(create_message_header_of_size(header_size))
+            } else {
+                None
+            }
+        }
+        None => None,
+    };
+
+    let payload = create_string_of_size(payload_size);
+    Message {
+        id: 1u128,
+        length: payload.len() as u32,
+        payload: Bytes::from(payload),
+        headers,
+    }
+}

--- a/integration/tests/server/scenarios/mod.rs
+++ b/integration/tests/server/scenarios/mod.rs
@@ -2,6 +2,7 @@ pub mod consumer_group_join_scenario;
 pub mod consumer_group_with_multiple_clients_polling_messages_scenario;
 pub mod consumer_group_with_single_client_polling_messages_scenario;
 pub mod create_message_payload;
+pub mod message_size_scenario;
 pub mod next;
 pub mod stream_size_validation_scenario;
 pub mod system_scenario;

--- a/integration/tests/server/tcp_server.rs
+++ b/integration/tests/server/tcp_server.rs
@@ -1,7 +1,7 @@
 use crate::server::scenarios::{
     consumer_group_join_scenario, consumer_group_with_multiple_clients_polling_messages_scenario,
-    consumer_group_with_single_client_polling_messages_scenario, create_message_payload, next,
-    stream_size_validation_scenario, system_scenario, user_scenario,
+    consumer_group_with_single_client_polling_messages_scenario, create_message_payload,
+    message_size_scenario, next, stream_size_validation_scenario, system_scenario, user_scenario,
 };
 use integration::{tcp_client::TcpClientFactory, test_server::TestServer};
 use serial_test::parallel;
@@ -145,4 +145,14 @@ async fn stream_size_validation_scenario_next_should_be_valid() {
     let server_addr = test_server.get_raw_tcp_addr().unwrap();
     let client_factory = TcpClientFactory { server_addr };
     next::stream_size_validation_scenario::run(&client_factory).await;
+}
+
+#[tokio::test]
+#[parallel]
+async fn message_size_scenario_should_be_valid() {
+    let mut test_server = TestServer::default();
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+    let client_factory = TcpClientFactory { server_addr };
+    message_size_scenario::run(&client_factory).await;
 }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.14"
+version = "0.2.15"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -651,7 +651,7 @@ impl MessageClient for IggyClient {
 
     async fn send_messages(&self, command: &mut SendMessages) -> Result<(), IggyError> {
         if command.messages.is_empty() {
-            return Ok(());
+            return Err(IggyError::InvalidMessagesCount);
         }
 
         if let Some(partitioner) = &self.partitioner {

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -284,6 +284,8 @@ pub enum IggyError {
     InvalidMessageChecksum(u32, u32, u64) = 4027,
     #[error("Invalid key value length")]
     InvalidKeyValueLength = 4028,
+    #[error("Command length error: {0}")]
+    CommandLengthError(String) = 4029,
     #[error("Invalid offset: {0}")]
     InvalidOffset(u64) = 4100,
     #[error("Failed to read consumers offsets for partition with ID: {0}")]

--- a/server/src/tcp/connection_handler.rs
+++ b/server/src/tcp/connection_handler.rs
@@ -7,6 +7,7 @@ use crate::streaming::systems::system::SharedSystem;
 use bytes::{BufMut, BytesMut};
 use iggy::bytes_serializable::BytesSerializable;
 use iggy::command::Command;
+use iggy::error::IggyError;
 use std::io::ErrorKind;
 use std::net::SocketAddr;
 use tracing::{debug, error, info};
@@ -23,11 +24,19 @@ pub(crate) async fn handle_connection(
     let session = Session::from_client_id(client_id, address);
     let mut initial_buffer = [0u8; INITIAL_BYTES_LENGTH];
     loop {
-        let read_length = sender.read(&mut initial_buffer).await?;
+        let read_length = match sender.read(&mut initial_buffer).await {
+            Ok(read_length) => read_length,
+            Err(error) => {
+                sender.send_error_response(error).await?;
+                continue;
+            }
+        };
+
         if read_length != INITIAL_BYTES_LENGTH {
-            return Err(ServerError::CommandLengthError(format!(
+            sender.send_error_response(IggyError::CommandLengthError(format!(
                 "Unable to read the TCP request length, expected: {INITIAL_BYTES_LENGTH} bytes, received: {read_length} bytes."
-            )));
+            ))).await?;
+            continue;
         }
 
         let length = u32::from_le_bytes(initial_buffer);
@@ -35,7 +44,13 @@ pub(crate) async fn handle_connection(
         let mut command_buffer = BytesMut::with_capacity(length as usize);
         command_buffer.put_bytes(0, length as usize);
         sender.read(&mut command_buffer).await?;
-        let command = Command::from_bytes(command_buffer.freeze())?;
+        let command = match Command::from_bytes(command_buffer.freeze()) {
+            Ok(command) => command,
+            Err(error) => {
+                sender.send_error_response(error).await?;
+                continue;
+            }
+        };
         debug!("Received a TCP command: {command}, payload size: {length}");
         command::handle(&command, sender, &session, system.clone()).await?;
         debug!("Sent a TCP response.");
@@ -61,7 +76,9 @@ pub(crate) fn handle_error(error: ServerError) {
                 error!("Connection has failed: {error}");
             }
         },
-        ServerError::SdkError(_) => {}
+        ServerError::SdkError(sdk_error) => {
+            error!("Failure in internal SDK call: {sdk_error}");
+        }
         _ => {
             error!("Connection has failed: {error}");
         }


### PR DESCRIPTION
This commit introduces a new test scenario for TCP server to validate
existing message size constraints (for payload and headers).

Updating implementation of IggyClient in the SDK to return an error
when attempting to send an empty message array. Handling of command
length errors in the TCP connection handler to provide more
informative error messages and continue processing subsequent
commands instead of closing connection (which ends on client side
with cryptic eof message).

This is pre-work for #21
