### PR TITLE
Add support for message headers to send and poll commands

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -233,6 +233,7 @@ fn get_command(
                 send_args.partition_id,
                 send_args.message_key.clone(),
                 send_args.messages.clone(),
+                send_args.headers.clone(),
             )),
             MessageAction::Poll(poll_args) => Box::new(PollMessagesCmd::new(
                 poll_args.stream_id.clone(),
@@ -245,6 +246,7 @@ fn get_command(
                 poll_args.last,
                 poll_args.next,
                 poll_args.consumer.clone(),
+                poll_args.show_headers,
             )),
         },
         Command::ConsumerOffset(command) => match command {

--- a/integration/tests/cli/message/test_message_poll_command.rs
+++ b/integration/tests/cli/message/test_message_poll_command.rs
@@ -4,12 +4,15 @@ use crate::cli::common::{
 };
 use assert_cmd::assert::Assert;
 use async_trait::async_trait;
+use bytes::Bytes;
 use iggy::messages::poll_messages::{PollingKind, PollingStrategy};
 use iggy::messages::send_messages::{Message, Partitioning};
+use iggy::models::header::{HeaderKey, HeaderValue};
 use iggy::next_client::ClientNext;
 use iggy::utils::expiry::IggyExpiry;
 use predicates::str::{contains, starts_with};
 use serial_test::parallel;
+use std::collections::HashMap;
 use std::str::FromStr;
 
 struct TestMessagePollCmd {
@@ -24,6 +27,8 @@ struct TestMessagePollCmd {
     strategy: PollingStrategy,
     using_stream_id: TestStreamId,
     using_topic_id: TestTopicId,
+    show_headers: bool,
+    headers: (HeaderKey, HeaderValue),
 }
 
 impl TestMessagePollCmd {
@@ -40,6 +45,8 @@ impl TestMessagePollCmd {
         strategy: PollingStrategy,
         using_stream_id: TestStreamId,
         using_topic_id: TestTopicId,
+        show_headers: bool,
+        headers: (HeaderKey, HeaderValue),
     ) -> Self {
         assert!(partition_id <= partitions_count);
         assert!(partition_id > 0);
@@ -56,6 +63,8 @@ impl TestMessagePollCmd {
             strategy,
             using_stream_id,
             using_topic_id,
+            show_headers,
+            headers,
         }
     }
 
@@ -74,6 +83,10 @@ impl TestMessagePollCmd {
             "--message-count".into(),
             format!("{}", self.message_count),
         ]);
+
+        if self.show_headers {
+            command.extend(vec!["--show-headers".into()]);
+        }
 
         command.extend(match self.using_stream_id {
             TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
@@ -116,7 +129,10 @@ impl IggyCmdTestCase for TestMessagePollCmd {
         let mut messages = self
             .messages
             .iter()
-            .filter_map(|s| Message::from_str(s).ok())
+            .map(|s| {
+                let payload = Bytes::from(s.as_bytes().to_vec());
+                Message::new(None, payload, Some(HashMap::from([self.headers.clone()])))
+            })
             .collect::<Vec<_>>();
 
         let send_status = client
@@ -152,7 +168,15 @@ impl IggyCmdTestCase for TestMessagePollCmd {
         let message = format!("Executing poll messages from topic ID: {} and stream with ID: {}\nPolled messages from topic with ID: {} and stream with ID: {} (from partition with ID: {})\nPolled {} messages",
             topic_id, stream_id, topic_id, stream_id, self.partition_id, self.message_count);
 
-        let status = command_state.success().stdout(starts_with(message));
+        let mut status = command_state.success().stdout(starts_with(message));
+
+        if self.show_headers {
+            status = status
+                .stdout(contains(format!("Header: {}", self.headers.0)))
+                .stdout(contains(self.headers.1.kind.to_string()))
+                .stdout(contains(self.headers.1.value_only_to_string()).count(self.message_count))
+        }
+
         // Check if messages are printed based on the strategy
         match self.strategy.kind {
             PollingKind::Offset => {
@@ -219,13 +243,19 @@ pub async fn should_be_successful() {
         "accusantium doloremque laudantium, totam rem aperiam, eaque ipsa".into(),
     ];
 
-    let test_parameters: Vec<(u32, usize, PollingStrategy, TestStreamId, TestTopicId)> = vec![
+    let test_headers = (
+        HeaderKey::from_str("key1").unwrap(),
+        HeaderValue::from_str("value1").unwrap(),
+    );
+
+    let test_parameters: Vec<(u32, usize, PollingStrategy, TestStreamId, TestTopicId, bool)> = vec![
         (
             1,
             1,
             PollingStrategy::offset(0),
             TestStreamId::Numeric,
             TestTopicId::Numeric,
+            true,
         ),
         (
             2,
@@ -233,6 +263,7 @@ pub async fn should_be_successful() {
             PollingStrategy::offset(0),
             TestStreamId::Numeric,
             TestTopicId::Named,
+            true,
         ),
         (
             3,
@@ -240,6 +271,7 @@ pub async fn should_be_successful() {
             PollingStrategy::offset(3),
             TestStreamId::Named,
             TestTopicId::Numeric,
+            true,
         ),
         (
             4,
@@ -247,6 +279,7 @@ pub async fn should_be_successful() {
             PollingStrategy::first(),
             TestStreamId::Named,
             TestTopicId::Named,
+            true,
         ),
         (
             1,
@@ -254,6 +287,7 @@ pub async fn should_be_successful() {
             PollingStrategy::last(),
             TestStreamId::Numeric,
             TestTopicId::Numeric,
+            true,
         ),
         (
             2,
@@ -261,11 +295,13 @@ pub async fn should_be_successful() {
             PollingStrategy::next(),
             TestStreamId::Numeric,
             TestTopicId::Named,
+            false,
         ),
     ];
 
     iggy_cmd_test.setup().await;
-    for (partition_id, message_count, strategy, using_stream_id, using_topic_id) in test_parameters
+    for (partition_id, message_count, strategy, using_stream_id, using_topic_id, show_headers) in
+        test_parameters
     {
         iggy_cmd_test
             .execute_test(TestMessagePollCmd::new(
@@ -280,6 +316,8 @@ pub async fn should_be_successful() {
                 strategy,
                 using_stream_id,
                 using_topic_id,
+                show_headers,
+                test_headers.clone(),
             ))
             .await;
     }
@@ -357,6 +395,12 @@ Options:
 {CLAP_INDENT}
           [default: 1]
 
+  -s, --show-headers
+          Include the message headers in the output
+{CLAP_INDENT}
+          Flag indicates whether to include headers in the output
+          after polling the messages.
+
   -h, --help
           Print help (see a summary with '-h')
 "#,
@@ -391,6 +435,7 @@ Options:
   -l, --last                           Polling strategy - start polling from the last message in the partition
   -n, --next                           Polling strategy - start polling from the next message
   -c, --consumer <CONSUMER>            Regular consumer which will poll messages [default: 1]
+  -s, --show-headers                   Include the message headers in the output
   -h, --help                           Print help (see more with '--help')
 "#,
             ),

--- a/integration/tests/cli/message/test_message_send_command.rs
+++ b/integration/tests/cli/message/test_message_send_command.rs
@@ -6,10 +6,12 @@ use assert_cmd::assert::Assert;
 use async_trait::async_trait;
 use iggy::consumer::Consumer;
 use iggy::messages::poll_messages::PollingStrategy;
+use iggy::models::header::{HeaderKey, HeaderValue};
 use iggy::next_client::ClientNext;
 use iggy::utils::expiry::IggyExpiry;
 use predicates::str::diff;
 use serial_test::parallel;
+use std::collections::HashMap;
 use std::str::from_utf8;
 use xxhash_rust::xxh32::xxh32;
 
@@ -47,6 +49,7 @@ struct TestMessageSendCmd {
     using_stream_id: TestStreamId,
     using_topic_id: TestTopicId,
     partitioning: PartitionSelection,
+    header: Option<HashMap<HeaderKey, HeaderValue>>,
 }
 
 impl TestMessageSendCmd {
@@ -62,6 +65,7 @@ impl TestMessageSendCmd {
         using_stream_id: TestStreamId,
         using_topic_id: TestTopicId,
         partitioning: PartitionSelection,
+        header: Option<HashMap<HeaderKey, HeaderValue>>,
     ) -> Self {
         Self {
             stream_id,
@@ -74,6 +78,7 @@ impl TestMessageSendCmd {
             using_stream_id,
             using_topic_id,
             partitioning,
+            header,
         }
     }
 
@@ -90,8 +95,21 @@ impl TestMessageSendCmd {
             TestTopicId::Named => self.topic_name.clone(),
         });
 
+        if let Some(header) = &self.header {
+            command.push("--headers".to_string());
+            command.push(
+                header
+                    .iter()
+                    .map(|(k, v)| format!("{k}:{}:{}", v.kind, v.value_only_to_string()))
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+
         match &self.message_input {
-            ProvideMessages::AsArgs => command.extend(self.messages.clone()),
+            ProvideMessages::AsArgs => {
+                command.extend(self.messages.clone());
+            }
             ProvideMessages::ViaStdin => {}
         }
 
@@ -209,6 +227,13 @@ impl IggyCmdTestCase for TestMessageSendCmd {
             self.messages
         );
 
+        if let Some(expected_header) = &self.header {
+            polled_messages.messages.iter().for_each(|m| {
+                assert!(m.headers.is_some());
+                assert_eq!(expected_header, m.headers.as_ref().unwrap());
+            })
+        };
+
         let topic = client
             .delete_topic(
                 &self.stream_id.try_into().unwrap(),
@@ -322,6 +347,16 @@ pub async fn should_be_successful() {
                 using_stream_id,
                 using_topic_id,
                 using_partitioning,
+                Some(HashMap::from([
+                    (
+                        HeaderKey::new("key1").unwrap(),
+                        HeaderValue::from_kind_str_and_value_str("string", "value1").unwrap(),
+                    ),
+                    (
+                        HeaderKey::new("key2").unwrap(),
+                        HeaderValue::from_kind_str_and_value_str("int32", "42").unwrap(),
+                    ),
+                ])),
             ))
             .await;
     }
@@ -378,6 +413,13 @@ Options:
 {CLAP_INDENT}
           Value of the key will be used by the server to calculate the partition ID
 
+  -H, --headers <HEADERS>
+          Comma separated list of key:kind:value, sent as header with the message
+{CLAP_INDENT}
+          Headers are comma seperated key-value pairs that can be sent with the message.
+          Kind can be one of the following: raw, string, bool, int8, int16, int32, int64,
+          int128, uint8, uint16, uint32, uint64, uint128, float32, float64
+
   -h, --help
           Print help (see a summary with '-h')
 "#,
@@ -407,6 +449,7 @@ Arguments:
 Options:
   -p, --partition-id <PARTITION_ID>  ID of the partition to which the message will be sent
   -m, --message-key <MESSAGE_KEY>    Messages key which will be used to partition the messages
+  -H, --headers <HEADERS>            Comma separated list of key:kind:value, sent as header with the message
   -h, --help                         Print help (see more with '--help')
 "#,
             ),

--- a/sdk/src/cli/message/poll_messages.rs
+++ b/sdk/src/cli/message/poll_messages.rs
@@ -2,16 +2,20 @@ use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::consumer::Consumer;
 use crate::identifier::Identifier;
 use crate::messages::poll_messages::{PollMessages, PollingStrategy};
+use crate::models::header::{HeaderKey, HeaderKind};
+use crate::models::messages::PolledMessages;
 use crate::next_client::ClientNext;
 use crate::utils::{byte_size::IggyByteSize, duration::IggyDuration, timestamp::IggyTimestamp};
 use anyhow::Context;
 use async_trait::async_trait;
-use comfy_table::Table;
+use comfy_table::{Cell, CellAlignment, Row, Table};
+use std::collections::HashSet;
 use std::mem::size_of_val;
 use tracing::{event, Level};
 
 pub struct PollMessagesCmd {
     poll_messages: PollMessages,
+    show_headers: bool,
 }
 
 impl PollMessagesCmd {
@@ -27,6 +31,7 @@ impl PollMessagesCmd {
         last: bool,
         next: bool,
         consumer: Identifier,
+        show_headers: bool,
     ) -> Self {
         let strategy = match (offset, first, last, next) {
             (Some(offset), false, false, false) => PollingStrategy::offset(offset),
@@ -45,7 +50,84 @@ impl PollMessagesCmd {
                 count: message_count,
                 auto_commit,
             },
+            show_headers,
         }
+    }
+
+    fn create_message_header_keys(
+        &self,
+        polled_messages: &PolledMessages,
+    ) -> HashSet<(HeaderKey, HeaderKind)> {
+        if !self.show_headers {
+            return HashSet::new();
+        }
+        polled_messages
+            .messages
+            .iter()
+            .flat_map(|m| match m.headers.as_ref() {
+                Some(h) => h
+                    .iter()
+                    .map(|(k, v)| (k.clone(), v.kind))
+                    .collect::<Vec<_>>(),
+                None => vec![],
+            })
+            .collect::<HashSet<_>>()
+    }
+
+    fn create_table_header(header_key_set: &HashSet<(HeaderKey, HeaderKind)>) -> Row {
+        let mut table_header = vec![
+            Cell::new("Offset"),
+            Cell::new("Timestamp"),
+            Cell::new("ID"),
+            Cell::new("Length"),
+            Cell::new("Payload"),
+        ];
+        let message_headers = header_key_set
+            .iter()
+            .map(|(key, kind)| {
+                Cell::new(format!("Header: {}\n{}", key.as_str(), kind))
+                    .set_alignment(CellAlignment::Center)
+            })
+            .collect::<Vec<_>>();
+        table_header.extend(message_headers);
+        Row::from(table_header)
+    }
+
+    fn create_table_content(
+        polled_messages: &PolledMessages,
+        message_header_keys: &HashSet<(HeaderKey, HeaderKind)>,
+    ) -> Vec<Row> {
+        polled_messages
+            .messages
+            .iter()
+            .map(|message| {
+                let mut row = vec![
+                    format!("{}", message.offset),
+                    IggyTimestamp::from(message.timestamp).to_local_string("%Y-%m-%d %H:%M:%S%.6f"),
+                    format!("{}", message.id),
+                    format!("{}", message.payload.len()),
+                    String::from_utf8_lossy(&message.payload).to_string(),
+                ];
+
+                let values = message_header_keys
+                    .iter()
+                    .map(|(key, kind)| {
+                        message
+                            .headers
+                            .as_ref()
+                            .map(|h| {
+                                h.get(key)
+                                    .filter(|v| v.kind == *kind)
+                                    .map(|v| v.value_only_to_string())
+                                    .unwrap_or_default()
+                            })
+                            .unwrap_or_default()
+                    })
+                    .collect::<Vec<_>>();
+                row.extend(values);
+                Row::from(row)
+            })
+            .collect::<_>()
     }
 }
 
@@ -96,18 +178,13 @@ impl CliCommand for PollMessagesCmd {
 
         event!(target: PRINT_TARGET, Level::INFO, "Polled {} messages of total size {polled_size}, it took {}", messages.messages.len(), elapsed.as_human_time_string());
 
-        let mut table = Table::new();
-        table.set_header(vec!["Offset", "Timestamp", "ID", "Length", "Payload"]);
+        let message_header_keys = self.create_message_header_keys(&messages);
 
-        messages.messages.iter().for_each(|message| {
-            table.add_row(vec![
-                format!("{}", message.offset),
-                IggyTimestamp::from(message.timestamp).to_local_string("%Y-%m-%d %H:%M:%S%.6f"),
-                format!("{}", message.id),
-                format!("{}", message.payload.len()),
-                String::from_utf8_lossy(&message.payload).to_string(),
-            ]);
-        });
+        let mut table = Table::new();
+        let table_header = Self::create_table_header(&message_header_keys);
+        let table_content = Self::create_table_content(&messages, &message_header_keys);
+        table.set_header(table_header);
+        table.add_rows(table_content);
 
         event!(target: PRINT_TARGET, Level::INFO, "{table}");
 

--- a/sdk/src/cli/message/send_messages.rs
+++ b/sdk/src/cli/message/send_messages.rs
@@ -1,11 +1,12 @@
 use crate::cli_command::{CliCommand, PRINT_TARGET};
 use crate::identifier::Identifier;
 use crate::messages::send_messages::{Message, Partitioning};
+use crate::models::header::{HeaderKey, HeaderValue};
 use crate::next_client::ClientNext;
 use anyhow::Context;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::io::{self, Read};
-use std::vec::Vec;
 use tracing::{event, Level};
 
 pub struct SendMessagesCmd {
@@ -13,6 +14,7 @@ pub struct SendMessagesCmd {
     topic_id: Identifier,
     partitioning: Partitioning,
     messages: Option<Vec<String>>,
+    headers: Vec<(HeaderKey, HeaderValue)>,
 }
 
 impl SendMessagesCmd {
@@ -22,6 +24,7 @@ impl SendMessagesCmd {
         partition_id: Option<u32>,
         message_key: Option<String>,
         messages: Option<Vec<String>>,
+        headers: Vec<(HeaderKey, HeaderValue)>,
     ) -> Self {
         let partitioning = match (partition_id, message_key) {
             (Some(_), Some(_)) => unreachable!(),
@@ -40,6 +43,7 @@ impl SendMessagesCmd {
             topic_id,
             partitioning,
             messages,
+            headers,
         }
     }
 
@@ -49,6 +53,13 @@ impl SendMessagesCmd {
         io::stdin().read_to_string(&mut buffer)?;
 
         Ok(buffer)
+    }
+
+    fn get_headers(&self) -> Option<HashMap<HeaderKey, HeaderValue>> {
+        match self.headers.len() {
+            0 => None,
+            _ => Some(self.headers.iter().cloned().collect()),
+        }
     }
 }
 
@@ -65,14 +76,14 @@ impl CliCommand for SendMessagesCmd {
         let mut messages = match &self.messages {
             Some(messages) => messages
                 .iter()
-                .map(|s| Message::new(None, s.clone().into(), None))
+                .map(|s| Message::new(None, s.clone().into(), self.get_headers()))
                 .collect::<Vec<_>>(),
             None => {
                 let input = self.read_message_from_stdin()?;
 
                 input
                     .lines()
-                    .map(|m| Message::new(None, String::from(m).into(), None))
+                    .map(|m| Message::new(None, String::from(m).into(), self.get_headers()))
                     .collect()
             }
         };

--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -112,6 +112,12 @@ pub enum IggyError {
     CannotParseByteUnit(#[from] byte_unit::ParseError) = 205,
     #[error("Connection closed")]
     ConnectionClosed = 206,
+    #[error("Cannot parse float")]
+    CannotParseFloat(#[from] std::num::ParseFloatError) = 207,
+    #[error("Cannot parse bool")]
+    CannotParseBool(#[from] std::str::ParseBoolError) = 208,
+    #[error("Cannot parse header kind from {0}")]
+    CannotParseHeaderKind(String) = 209,
     #[error("HTTP response error, status: {0}, body: {1}")]
     HttpResponseError(u16, String) = 300,
     #[error("Request middleware error")]


### PR DESCRIPTION
This refers to #646

## Features

- You can set headers in message send command with a comma separated list and the format key:kind:value
- Sends messages with the provided header
- Option to display the headers with the poll command

## Review

If you want to have already a look on it. Please. I'm not happy with the `value_only_to_string` function in the HeaderValue impl. I tried a struct for `value` and implement `Display` for it. But obviously we don't have the `HeaderKind` then. And `Display` for `HeaderKind` is already implemented in a different way.
