### PR TITLE
Improve connection handling and closure in TCP server

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -110,6 +110,8 @@ pub enum IggyError {
     CannotParseSlice(#[from] std::array::TryFromSliceError) = 204,
     #[error("Cannot parse byte unit")]
     CannotParseByteUnit(#[from] byte_unit::ParseError) = 205,
+    #[error("Connection closed")]
+    ConnectionClosed = 206,
     #[error("HTTP response error, status: {0}, body: {1}")]
     HttpResponseError(u16, String) = 300,
     #[error("Request middleware error")]


### PR DESCRIPTION
This commit introduces improved error handling for the case when a TCP
connection is closed by the client. The SDK now includes a specific
error for this scenario, and the server's connection handler has been
updated to return an error when the connection is closed, rather than
continuing to attempt to read from the stream. Additionally, the error
handling logic distinguishes between a closed connection and other SDK
errors, logging a debug message for the former and an error for the
latter. The read function in the sender module has also been modified
to return a ConnectionClosed error when an EOF is encountered.
