### PR TITLE
Prepare existing Client and IggyClient for the future migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.2.20"
+version = "0.2.30"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.2.20"
+version = "0.2.30"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/client.rs
+++ b/sdk/src/client.rs
@@ -57,6 +57,10 @@ use std::fmt::Debug;
 /// The client is the main interface to the Iggy server.
 /// It consists of multiple modules, each of which is responsible for a specific set of commands.
 /// Except the ping, login and get me commands, all the other commands require authentication.
+///
+/// **This trait will become obsolete starting from version 0.3.0 - instead, use the `ClientNext`.**
+///
+/// **In the future release, starting from version 0.4.0, `ClientNext` will be renamed to `Client` and will remain the only available client trait to use.**
 #[async_trait]
 pub trait Client:
     SystemClient

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -79,7 +79,12 @@ use tracing::{error, info, warn};
 pub use crate::clients::builder::IggyClientBuilder;
 
 /// The main client struct which implements all the `Client` traits and wraps the underlying low-level client for the specific transport.
-/// It also provides additional functionality (outside of the shared trait) like sending messages in background, partitioning, client-side encryption or message handling via channels.
+///
+/// It also provides additional functionality (outside the shared trait) like sending messages in background, partitioning, client-side encryption or message handling via channels.
+///
+/// **This client will become obsolete starting from version 0.3.0 - instead, use the `IggyClientNext`.**
+///
+/// **In the future release, starting from version 0.4.0, `IggyClientNext` will be renamed to `IggyClient` and will remain the only available client to use.**
 #[derive(Debug)]
 pub struct IggyClient {
     client: IggySharedMut<Box<dyn Client>>,

--- a/sdk/src/clients/next_client.rs
+++ b/sdk/src/clients/next_client.rs
@@ -52,7 +52,13 @@ pub const DEFAULT_SEND_MESSAGES_INTERVAL_MS: u64 = 100;
 pub const DEFAULT_POLL_MESSAGES_INTERVAL_MS: u64 = 100;
 
 /// The next version of main client struct which implements all the `ClientNext` traits and wraps the underlying low-level client for the specific transport.
+///
 /// It also provides additional functionality (outside the shared trait) like sending messages in background, partitioning, client-side encryption or message handling via channels.
+///
+///
+/// **This client will become the default client starting from version 0.3.0, instead of the currently existing `IggyClient`.**
+///
+/// **In the future release, starting from version 0.4.0, `IggyClientNext` will be renamed to `IggyClient` and will remain the only available client to use.**
 #[derive(Debug)]
 pub struct IggyClientNext {
     client: IggySharedMut<Box<dyn ClientNext>>,

--- a/sdk/src/next_client.rs
+++ b/sdk/src/next_client.rs
@@ -25,6 +25,10 @@ use std::fmt::Debug;
 /// The next version of the client which is the main interface to the Iggy server.
 /// It consists of multiple modules, each of which is responsible for a specific set of commands.
 /// Except the ping, login and get me, all the other methods require authentication.
+///
+/// **This trait will become the default one starting from version 0.3.0, instead of the currently existing `Client` trait.**
+///
+/// **In the future release, starting from version 0.4.0, `ClientNext` will be renamed to `Client` and will remain the only available client trait to use.**
 #[async_trait]
 pub trait ClientNext:
     SystemClientNext


### PR DESCRIPTION
Instead of the existing `Client` and `IggyClient` the `ClientNext` and `IggyClientNext` components should be used.