### PR TITLE
Fix deadlock issue in CleanMessagesExecutor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.17"
+version = "0.2.18"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/channels/commands/clean_messages.rs
+++ b/server/src/channels/commands/clean_messages.rs
@@ -65,8 +65,8 @@ impl MessagesCleaner {
 impl ServerCommand<CleanMessagesCommand> for CleanMessagesExecutor {
     async fn execute(&mut self, system: &SharedSystem, _command: CleanMessagesCommand) {
         let now = IggyTimestamp::now().to_micros();
-        let system_read = system.read();
-        let streams = system_read.get_streams();
+        let system = system.write();
+        let streams = system.get_streams();
         for stream in streams {
             let topics = stream.get_topics();
             for topic in topics {
@@ -81,11 +81,9 @@ impl ServerCommand<CleanMessagesCommand> for CleanMessagesExecutor {
                     );
 
                     system
-                        .write()
                         .metrics
                         .decrement_segments(deleted_segments.segments_count);
                     system
-                        .write()
                         .metrics
                         .decrement_messages(deleted_segments.messages_count);
                 }


### PR DESCRIPTION
This commit resolves a deadlock by acquiring a write lock on the system
once instead of multiple times within the CleanMessagesExecutor. The
redundant system.write() calls have been removed, ensuring that the
metrics are updated without the need for additional locks.

This closes #897.
