### PR TITLE
implement fmt::Display for Partition

### DIFF
--- a/server/src/streaming/partitions/partition.rs
+++ b/server/src/streaming/partitions/partition.rs
@@ -9,6 +9,7 @@ use dashmap::DashMap;
 use iggy::consumer::ConsumerKind;
 use iggy::utils::duration::IggyDuration;
 use iggy::utils::timestamp::IggyTimestamp;
+use std::fmt;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -39,6 +40,16 @@ pub struct Partition {
     pub(crate) segments: Vec<Segment>,
     pub(crate) config: Arc<SystemConfig>,
     pub(crate) storage: Arc<SystemStorage>,
+}
+
+impl fmt::Display for Partition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ID: {}, ", self.partition_id)?;
+        write!(f, "segments count: {}, ", self.get_segments_count())?;
+        write!(f, "current offset: {}, ", self.current_offset)?;
+        write!(f, "size bytes: {}, ", self.get_size_bytes())?;
+        write!(f, "messages count: {}", self.get_messages_count())
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -211,6 +222,10 @@ mod tests {
             Arc::new(AtomicU32::new(0)),
         );
 
+        assert_eq!(
+            "ID: 3, segments count: 1, current offset: 0, size bytes: 0, messages count: 0",
+            format!("{}", partition)
+        );
         assert_eq!(partition.stream_id, stream_id);
         assert_eq!(partition.topic_id, topic_id);
         assert_eq!(partition.partition_id, partition_id);

--- a/server/src/streaming/segments/segment.rs
+++ b/server/src/streaming/segments/segment.rs
@@ -16,8 +16,8 @@ use crate::streaming::utils::file;
 use futures::{pin_mut, TryStreamExt};
 use iggy::error::IggyError;
 use iggy::utils::timestamp::IggyTimestamp;
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::{fmt, sync::atomic::AtomicU64};
 use tokio::io::AsyncWriteExt;
 use tracing::{info, trace};
 
@@ -53,6 +53,14 @@ pub struct Segment {
     pub(crate) unsaved_indexes: Vec<u8>,
     pub(crate) unsaved_timestamps: Vec<u8>,
     pub(crate) storage: Arc<SystemStorage>,
+}
+
+impl fmt::Display for Segment {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "stream ID: {}, ", self.stream_id)?;
+        write!(f, "topic ID: {}, ", self.topic_id)?;
+        write!(f, "partition ID: {}", self.partition_id)
+    }
 }
 
 impl Segment {
@@ -265,6 +273,10 @@ mod tests {
             messages_count_of_parent_partition,
         );
 
+        assert_eq!(
+            "stream ID: 1, topic ID: 2, partition ID: 3",
+            format!("{}", segment)
+        );
         assert_eq!(segment.stream_id, stream_id);
         assert_eq!(segment.topic_id, topic_id);
         assert_eq!(segment.partition_id, partition_id);

--- a/server/src/streaming/streams/stream.rs
+++ b/server/src/streaming/streams/stream.rs
@@ -4,6 +4,7 @@ use crate::streaming::topics::topic::Topic;
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::timestamp::IggyTimestamp;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -22,6 +23,15 @@ pub struct Stream {
     pub(crate) topics_ids: HashMap<String, u32>,
     pub(crate) config: Arc<SystemConfig>,
     pub(crate) storage: Arc<SystemStorage>,
+}
+
+impl fmt::Display for Stream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ID: {}, ", self.stream_id)?;
+        write!(f, "name: {}, ", self.name)?;
+        write!(f, "size bytes: {:?}, ", self.size_bytes)?;
+        write!(f, "messages count: {:?}", self.messages_count)
+    }
 }
 
 impl Stream {
@@ -81,5 +91,6 @@ mod tests {
         assert_eq!(stream.path, path);
         assert_eq!(stream.topics_path, topics_path);
         assert!(stream.topics.is_empty());
+        assert_eq!("ID: 1, name: test, size bytes: 0, messages count: 0", format!("{}", stream));
     }
 }


### PR DESCRIPTION
Implement the Display functionality for `Partition` (similar to [topic.rs](https://github.com/iggy-rs/iggy/blob/master/server/src/streaming/topics/topic.rs#L146-L161) )

PR raised as an initial response to: https://github.com/iggy-rs/iggy/issues/481

Please let me know if you are happy with these changes.  If so, I can also implement `Segment` and `Stream`!