### PR TITLE
Enable unused dependencies check using cargo machete

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -52,14 +52,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --doc
 
-  #  unused_dependencies:
-  #    name: Unused dependencies
-  #    runs-on: ubuntu-latest
-  #    steps:
-  #      - uses: actions/checkout@v4
-  #      - uses: dtolnay/rust-toolchain@nightly
-  #      - uses: taiki-e/install-action@cargo-udeps
-  #      - run: cargo +nightly udeps --all-targets --all-features
+  unused_dependencies:
+    name: Unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bnjbvr/cargo-machete@main
 
   check-commit-message:
     name: Validate commit messages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,7 +612,6 @@ name = "bench"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "bytes",
  "clap",
  "colored",
  "derive_more",
@@ -622,10 +621,7 @@ dependencies = [
  "iggy",
  "integration",
  "nonzero_lit",
- "quinn",
- "rustls",
  "serde",
- "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -972,7 +968,6 @@ name = "cli"
 version = "0.20.1"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "clap_complete",
  "figlet-rs",
@@ -2086,7 +2081,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -2147,7 +2141,6 @@ version = "0.0.1"
 dependencies = [
  "assert_cmd",
  "async-trait",
- "byte-unit",
  "bytes",
  "derive_more",
  "futures",
@@ -2162,8 +2155,6 @@ dependencies = [
  "sled",
  "tempfile",
  "tokio",
- "toml",
- "tracing",
  "tracing-subscriber",
  "uuid",
  "xxhash-rust",
@@ -2635,9 +2626,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
@@ -3844,7 +3835,6 @@ dependencies = [
 name = "server"
 version = "0.2.22"
 dependencies = [
- "aes-gcm",
  "anyhow",
  "async-stream",
  "async-trait",
@@ -3853,9 +3843,7 @@ dependencies = [
  "axum-server",
  "bcrypt",
  "blake3",
- "byte-unit",
  "bytes",
- "chrono",
  "clap",
  "console-subscriber",
  "dashmap",
@@ -3886,10 +3874,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "toml",
- "tower",
  "tower-http",
- "tower-layer",
- "tower-service",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -4489,11 +4474,9 @@ name = "tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes",
  "clap",
  "iggy",
  "rand",
- "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ codegen-units = 1
 resolver = "2"
 members = ["bench", "cli", "examples", "integration", "sdk", "server", "tools"]
 exclude = ["tpc"]
+
+[workspace.metadata.cargo-machete]
+ignored = ["openssl"]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1.80"
-bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive"] }
 colored = "2.0.4"
 derive_more = "0.99.17"
@@ -15,10 +14,7 @@ human_format = "1.1.0"
 iggy = { path = "../sdk" }
 integration = { path = "../integration" }
 nonzero_lit = "0.1.2"
-quinn = { version = "0.10.2" }
-rustls = { version = "0.21.11" }
 serde = { version = "1.0.202", features = ["derive"] }
-thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["full"] }
 toml = "0.8.13"
 tracing = { version = "0.1.37" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -8,7 +8,6 @@ homepage = "https://iggy.rs"
 
 [dependencies]
 anyhow = "1.0.83"
-async-trait = "0.1.80"
 clap = { version = "4.5.4", features = ["derive"] }
 clap_complete = "4.5.2"
 figlet-rs = "0.1.5"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -43,7 +43,6 @@ iggy = { path = "../sdk" }
 rand = "0.8.5"
 serde = { version = "1.0.202", features = ["derive", "rc"] }
 serde_json = "1.0.117"
-thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16" }

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -6,10 +6,6 @@ edition = "2021"
 [dependencies]
 assert_cmd = "2.0.14"
 async-trait = "0.1.80"
-byte-unit = { version = "5.1.4", default-features = false, features = [
-    "serde",
-    "byte",
-] }
 bytes = "1.6.0"
 derive_more = "0.99.17"
 futures = "0.3.30"
@@ -24,8 +20,6 @@ server = { path = "../server" }
 sled = "0.34.7"
 tempfile = "3.10.1"
 tokio = { version = "1.37.0", features = ["full"] }
-toml = "0.8.13"
-tracing = "0.1"
 tracing-subscriber = "0.3.18"
 uuid = { version = "1.8.0", features = ["v4", "fast-rng", "zerocopy"] }
 xxhash-rust = { version = "0.8.10", features = ["xxh32"] }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -10,7 +10,6 @@ jemalloc = ["dep:tikv-jemallocator"]
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dependencies]
-aes-gcm = "0.10.3"
 anyhow = "1.0.83"
 async-stream = "0.3.5"
 async-trait = "0.1.80"
@@ -19,12 +18,7 @@ axum = "0.7.5"
 axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 bcrypt = "0.15.1"
 blake3 = "1.5.1"
-byte-unit = { version = "5.1.4", default-features = false, features = [
-    "serde",
-    "byte",
-] }
 bytes = "1.6.0"
-chrono = "0.4.38"
 clap = { version = "4.5.4", features = ["derive"] }
 console-subscriber = { version = "0.2.0", optional = true }
 dashmap = "5.5.3"
@@ -54,14 +48,11 @@ thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["full"] }
 tokio-native-tls = "0.3.1"
 toml = "0.8.13"
-tower = { version = "0.4.13" }
 tower-http = { version = "0.5.2", features = [
     "add-extension",
     "cors",
     "trace",
 ] }
-tower-layer = "0.3.2"
-tower-service = "0.3.2"
 tracing = { version = "0.1.40" }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,11 +9,9 @@ path = "src/data-seeder/main.rs"
 
 [dependencies]
 anyhow = "1.0.83"
-bytes = "1.6.0"
 clap = { version = "4.5.4", features = ["derive"] }
 iggy = { path = "../sdk" }
 rand = "0.8.5"
-thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["full"] }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16" }

--- a/tpc/Cargo.toml
+++ b/tpc/Cargo.toml
@@ -4,22 +4,9 @@ version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-anyhow = "1.0.78"
-async-trait = "0.1.76"
-bytes = "1.4.0"
-chrono = "0.4.30"
-clap = { version = "4.4.12", features = ["derive"] }
 figlet-rs = "0.1.5"
-figment = { version = "0.10.8", features = ["toml", "env"] }
-flume = "0.11.0"
-futures = "0.3.30"
-serde = { version = "1.0.193", features = ["derive", "rc"] }
-sled = "0.34.7"
-thiserror = "1.0.53"
-toml = "0.8.8"
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.18", features = ["fmt"] }
-tracing-appender = "0.2.3"
 monoio = { version = "0.2.1", features = ["signal"] }
 
 [[bin]]


### PR DESCRIPTION
Remove unused dependencies using machete from whole iggy workspace.
Add configuration for machete to workspace Cargo.toml in order to
keep openssl crate (due to failing musl builds when it is removed).
