### PR TITLE
Remove Linux-arm build, update cargo-machete, add test_daily workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,16 +81,6 @@ jobs:
             docker_arch: linux/amd64
             cross: false
 
-          - os_name: Linux-arm
-            os: ubuntu-latest
-            target: arm-unknown-linux-musleabi
-            bin:
-              - iggy-server
-              - iggy
-            name: iggy-Linux-arm-musl.tar.gz
-            docker_arch: linux/arm/v7
-            cross: true
-
           - os_name: Linux-aarch64-musl
             os: ubuntu-latest
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bnjbvr/cargo-machete@main
+      - uses: bnjbvr/cargo-machete@v0.6.2
 
   check-commit-message:
     name: Validate commit messages

--- a/.github/workflows/test_daily.yml
+++ b/.github/workflows/test_daily.yml
@@ -1,8 +1,8 @@
-name: test_nightly
+name: test_daily
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 23 * * *'  # At 11:00 PM UTC, which is 10:00 PM CET
+    - cron: '0 8 * * *'  # At 8:00 AM UTC, which is 9:00 AM CET
 
 env:
   CRATE_NAME: iggy
@@ -46,8 +46,7 @@ jobs:
             cross: true
 
         toolchain:
-          - nightly
-          - beta
+          - stable
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Removed Linux-arm build from release and nightly workflows. Updated
cargo-machete to v0.6 in sanity workflow. Added new test_daily
workflow for daily tests at 8:00 AM UTC. Adjusted nightly test
schedule to run it at night at 11:00 PM UTC.
