### PR TITLE
Change IggyTimestamp conversion to use microseconds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.4.2"
+version = "0.4.3"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/utils/timestamp.rs
+++ b/sdk/src/utils/timestamp.rs
@@ -57,7 +57,7 @@ impl From<u64> for IggyTimestamp {
 
 impl From<IggyTimestamp> for u64 {
     fn from(timestamp: IggyTimestamp) -> u64 {
-        timestamp.to_secs()
+        timestamp.to_micros()
     }
 }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.23"
+version = "0.2.24"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
This commit updates the conversion from IggyTimestamp to u64 to use
microseconds instead of seconds.
