### PR TITLE
Update path for iggy cli in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ There's an ongoing effort to build the administrative web UI for the server, whi
 
 You can find the `Dockerfile` and `docker-compose` in the root of the repository. To build and start the server, run: `docker compose up`.
 
-Additionally, you can run the `CLI` which is available in the running container, by executing: `docker exec -it iggy-server /iggy/iggy`.
+Additionally, you can run the `CLI` which is available in the running container, by executing: `docker exec -it iggy-server /iggy`.
 
 Keep in mind that running the container on the OS other than Linux, where the Docker is running in the VM, might result in the significant performance degradation.
 


### PR DESCRIPTION
Updated path for `iggy cli` in `README.md` for local development environment.

While using previously mentioned path for cli `iggy/iggy`:
`% docker exec -it iggy-server /iggy/iggy ping`

`OCI runtime exec failed: exec failed: unable to start container process: exec: "/iggy/iggy": stat /iggy/iggy: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type`

After using the updated path `/iggy`:
`% docker exec -it iggy-server /iggy ping`
    
```
Executing ping command
Ping sequence id: 1 time: 0.26 ms

Ping statistics for 1 ping commands
min/avg/max/mdev = 0.262/0.262/0.262/0.000 ms
```