### PR TITLE
Improve CLI login session handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -215,8 +215,8 @@ impl IggyCmdTest {
         test_case.verify_command(assert);
     }
 
-    pub(crate) fn get_sever_ip_address(&self) -> Option<String> {
-        self.server.get_server_ip_addr()
+    pub(crate) fn get_tcp_server_address(&self) -> Option<String> {
+        self.server.get_raw_tcp_addr()
     }
 }
 

--- a/integration/tests/cli/system/test_cli_session_scenario.rs
+++ b/integration/tests/cli/system/test_cli_session_scenario.rs
@@ -10,7 +10,7 @@ pub async fn should_be_successful() {
     let mut iggy_cmd_test = IggyCmdTest::default();
 
     iggy_cmd_test.setup().await;
-    let server_address = iggy_cmd_test.get_sever_ip_address();
+    let server_address = iggy_cmd_test.get_tcp_server_address();
     assert!(server_address.is_some());
     let server_address = server_address.unwrap();
 
@@ -72,7 +72,7 @@ pub async fn should_be_successful() {
     iggy_cmd_test
         .execute_test(TestMeCmd::new(
             Protocol::Tcp,
-            Scenario::FailureDueToSessionTimeout,
+            Scenario::FailureDueToSessionTimeout(server_address),
         ))
         .await;
 }

--- a/integration/tests/cli/system/test_me_command.rs
+++ b/integration/tests/cli/system/test_me_command.rs
@@ -20,7 +20,7 @@ pub(super) enum Scenario {
     SuccessWithCredentials,
     SuccessWithoutCredentials,
     FailureWithoutCredentials,
-    FailureDueToSessionTimeout,
+    FailureDueToSessionTimeout(String),
 }
 
 impl Protocol {
@@ -63,7 +63,7 @@ impl IggyCmdTestCase for TestMeCmd {
         match &self.scenario {
             Scenario::SuccessWithCredentials => command.with_env_credentials(),
             Scenario::FailureWithoutCredentials => command.disable_backtrace(),
-            Scenario::FailureDueToSessionTimeout => command.disable_backtrace(),
+            Scenario::FailureDueToSessionTimeout(_) => command.disable_backtrace(),
             _ => command,
         }
     }
@@ -81,8 +81,8 @@ impl IggyCmdTestCase for TestMeCmd {
                     .failure()
                     .stderr(diff("Error: CommandError(Iggy command line tool error\n\nCaused by:\n    Missing iggy server credentials)\n"));
             }
-            Scenario::FailureDueToSessionTimeout => {
-                command_state.failure().stderr(diff("Error: CommandError(Login session expired for Iggy server: 127.0.0.1, please login again or use other authentication method)\n"));
+            Scenario::FailureDueToSessionTimeout(server_address) => {
+                command_state.failure().stderr(diff(format!("Error: CommandError(Login session expired for Iggy server: {server_address}, please login again or use other authentication method)\n")));
             }
         }
     }

--- a/sdk/src/args.rs
+++ b/sdk/src/args.rs
@@ -280,18 +280,14 @@ const TCP_TRANSPORT: &str = "tcp";
 impl Args {
     pub fn get_server_address(&self) -> Option<String> {
         match self.transport.as_str() {
-            QUIC_TRANSPORT => Some(self.quic_server_address.split(':').next().unwrap().into()),
+            QUIC_TRANSPORT => Some(self.quic_server_address.replace("localhost", "127.0.0.1")),
             HTTP_TRANSPORT => Some(
                 self.http_api_url
                     .clone()
                     .replace("http://", "")
-                    .replace("localhost", "127.0.0.1")
-                    .split(':')
-                    .next()
-                    .unwrap()
-                    .into(),
+                    .replace("localhost", "127.0.0.1"),
             ),
-            TCP_TRANSPORT => Some(self.tcp_server_address.split(':').next().unwrap().into()),
+            TCP_TRANSPORT => Some(self.tcp_server_address.replace("localhost", "127.0.0.1")),
             _ => None,
         }
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Use server address with port for CLI session key in keyring and add
localhost replacing localhost with 127.0.0.1 for all protocols. Adapt
intergration tests for this change and bump CLI crate version.
