### PR TITLE
Fix issue with wrong root credentials handling in CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,7 +1073,7 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2262,7 +2262,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -318,7 +318,10 @@ async fn main() -> Result<(), IggyCmdError> {
             Aes256GcmEncryptor::from_base64_key(&iggy_args.encryption_key).unwrap(),
         )),
     };
-    let client_provider_config = Arc::new(ClientProviderConfig::from_args(iggy_args.clone())?);
+    let client_provider_config = Arc::new(ClientProviderConfig::from_args_set_autologin(
+        iggy_args.clone(),
+        false,
+    )?);
 
     let client =
         client_provider::get_raw_client(client_provider_config, command.connection_required())

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.3"
+version = "0.6.4"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/client_provider.rs
+++ b/sdk/src/client_provider.rs
@@ -48,6 +48,15 @@ impl Default for ClientProviderConfig {
 impl ClientProviderConfig {
     /// Create a new `ClientProviderConfig` from the provided `Args`.
     pub fn from_args(args: crate::args::Args) -> Result<Self, ClientError> {
+        Self::from_args_set_autologin(args, true)
+    }
+
+    /// Create a new `ClientProviderConfig` from the provided `Args` with possibility to enable or disable
+    /// auto login option for TCP or QUIC protocols.
+    pub fn from_args_set_autologin(
+        args: crate::args::Args,
+        auto_login: bool,
+    ) -> Result<Self, ClientError> {
         let transport = args.transport;
         let mut config = Self {
             transport,
@@ -70,10 +79,14 @@ impl ClientProviderConfig {
                         )
                         .unwrap(),
                     },
-                    auto_login: AutoLogin::Enabled(Credentials::UsernamePassword(
-                        args.username,
-                        args.password,
-                    )),
+                    auto_login: if auto_login {
+                        AutoLogin::Enabled(Credentials::UsernamePassword(
+                            args.username,
+                            args.password,
+                        ))
+                    } else {
+                        AutoLogin::Disabled
+                    },
                     response_buffer_size: args.quic_response_buffer_size,
                     max_concurrent_bidi_streams: args.quic_max_concurrent_bidi_streams,
                     datagram_send_buffer_size: args.quic_datagram_send_buffer_size,
@@ -105,10 +118,14 @@ impl ClientProviderConfig {
                         )
                         .unwrap(),
                     },
-                    auto_login: AutoLogin::Enabled(Credentials::UsernamePassword(
-                        args.username,
-                        args.password,
-                    )),
+                    auto_login: if auto_login {
+                        AutoLogin::Enabled(Credentials::UsernamePassword(
+                            args.username,
+                            args.password,
+                        ))
+                    } else {
+                        AutoLogin::Disabled
+                    },
                 }));
             }
             _ => return Err(ClientError::InvalidTransport(config.transport.clone())),

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Add new method for creating ClientProviderConfig with possibility
to enable or disable AutoLogin option while creating from Args.
Disabling AutoLogin for CLI.
