### PR TITLE
Set merge-multiple for github release artifact download workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,9 +242,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+        uses: actions/download-artifact@v4
         with:
           path: all_artifacts
+          merge-multiple: true
 
       - name: Zip artifacts for each platform
         run: |


### PR DESCRIPTION
Use actions/download-artifact@v4 workflow version and set merge-multiple
flat to true.
