### PR TITLE
Pin download-artifact action to specific version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,8 +242,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
         with:
+          pattern: 'iggy-*'
           path: all_artifacts
           merge-multiple: true
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Revert to use same version of download-artifact action for the release
to GitHub workflow (same as in docker release workflow). Add pattern
for downloaded artifacts (same set of parameters as in docker release
workflow).
