### PR TITLE
Replace FlyCI runners with GitHub runners

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -116,7 +116,7 @@ jobs:
   build_and_test_macos:
     needs: sanity
     name: build and test macOS-aarch64
-    runs-on: flyci-macos-large-latest-m1
+    runs-on: macos-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR replaces the use of FlyCI macOS runners with GitHub ones since FlyCI macOS runners will be discontinued effective Sep 30, 2024. 

[Read more about the discontinuation of the FlyCI macOS runners](https://flyci.net/blog/flyci-discontinue-macos-runners?utm_source=site_link&utm_medium=github&utm_campaign=discontinue-runners).