### PR TITLE
Add login-session feature to iggy CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,13 +107,22 @@ jobs:
         run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
         if: contains(matrix.platform.name, 'musl')
 
-      - name: Build release binary
+      - name: Build iggy-server release binary
         uses: houseabsolute/actions-rust-cross@v0
         with:
           command: "build"
           target: ${{ matrix.platform.target }}
           toolchain: ${{ matrix.toolchain }}
-          args: "--verbose --release"
+          args: "--verbose --release --bin iggy-server"
+        if: ${{ matrix.toolchain }} == 'stable'
+
+      - name: Build iggy-cli release binary
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: ${{ matrix.platform.target }}
+          toolchain: ${{ matrix.toolchain }}
+          args: "--verbose --release --no-default-features --bin iggy"
         if: ${{ matrix.toolchain }} == 'stable'
 
       - name: Prepare artifacts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,7 +2335,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.5.12"
+version = "0.5.13"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.14"
+version = "0.4.20"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cli"
-version = "0.5.12"
+version = "0.5.13"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -9,6 +9,10 @@ description = "Iggy is the persistent message streaming platform written in Rust
 license = "MIT"
 keywords = ["iggy", "cli", "messaging", "streaming"]
 
+[features]
+default = ["login-session"]
+login-session = ["dep:keyring"]
+
 [dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.86"
@@ -16,7 +20,7 @@ clap = { version = "4.5.4", features = ["derive"] }
 clap_complete = "4.5.16"
 figlet-rs = "0.1.5"
 iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.12" }
-keyring = { version = "3.2.0", features = ["sync-secret-service", "vendored"] }
+keyring = { version = "3.2.0", features = ["sync-secret-service", "vendored"], optional = true }
 passterm = "2.0.1"
 thiserror = "1.0.61"
 tokio = { version = "1.38.0", features = ["full"] }

--- a/cli/src/args/mod.rs
+++ b/cli/src/args/mod.rs
@@ -17,9 +17,12 @@ use crate::args::{
     partition::PartitionAction,
     personal_access_token::PersonalAccessTokenAction,
     stream::StreamAction,
-    system::{LoginArgs, PingArgs, StatsArgs},
+    system::{PingArgs, StatsArgs},
     topic::TopicAction,
 };
+
+#[cfg(feature = "login-session")]
+use crate::args::system::LoginArgs;
 
 use self::user::UserAction;
 
@@ -80,6 +83,7 @@ pub(crate) struct CliOptions {
     #[clap(short, long, group = "credentials")]
     pub(crate) token: Option<String>,
 
+    #[cfg(feature = "login-session")]
     /// Iggy server personal access token name
     ///
     /// When personal access token is created using command line tool and stored
@@ -154,6 +158,7 @@ pub(crate) enum Command {
     /// context operations
     #[command(subcommand, visible_alias = "ctx")]
     Context(ContextAction),
+    #[cfg(feature = "login-session")]
     /// login to Iggy server
     ///
     /// Command logs in to Iggy server using provided credentials and stores session token
@@ -161,6 +166,7 @@ pub(crate) enum Command {
     /// subsequent commands until logout command is executed.
     #[clap(verbatim_doc_comment, visible_alias = "li")]
     Login(LoginArgs),
+    #[cfg(feature = "login-session")]
     /// logout from Iggy server
     ///
     /// Command logs out from Iggy server and removes session token from platform-specific
@@ -218,6 +224,7 @@ impl IggyMergedConsoleArgs {
             username: args.cli.username.or(context.username),
             password: args.cli.password.or(context.password),
             token: args.cli.token.or(context.token),
+            #[cfg(feature = "login-session")]
             token_name: args.cli.token_name.or(context.token_name),
             generator: args.cli.generator,
         };

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub(crate) enum CmdToolError {
     MissingCredentials,
+    #[cfg(feature = "login-session")]
     MissingServerAddress,
 }
 
@@ -13,6 +14,7 @@ impl Display for CmdToolError {
             Self::MissingCredentials => {
                 write!(f, "Missing iggy server credentials")
             }
+            #[cfg(feature = "login-session")]
             Self::MissingServerAddress => {
                 write!(f, "Missing iggy server address")
             }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.14"
+version = "0.4.20"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Add login-session feature to default features for iggy CLI and disable
it for official docker release due to missing keyring storage inside
docker. Updating release workflow to build server and cli separately.
