### PR TITLE
Drop using artifacts upload and download for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,12 +131,6 @@ jobs:
           cp target/${{ matrix.platform.target }}/release/iggy-server release_artifacts/
           cp target/${{ matrix.platform.target }}/release/iggy release_artifacts/
 
-      - name: Upload release assets to GitHub Actions
-        uses: actions/upload-artifact@v4
-        with:
-          name: iggy-${{ matrix.platform.os_name }}
-          path: release_artifacts/
-
       - name: Print message
         run: echo "::notice ::Published ${{ needs.tag.outputs.server_version }} release artifacts on GitHub"
 
@@ -244,18 +238,62 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.tag.outputs.tag_created == 'true' }}
     needs:
-      - release_and_publish
       - tag
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Download all artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e
+      - name: Cache cargo & target directories
+        uses: Swatinem/rust-cache@v2
         with:
-          pattern: 'iggy-*'
-          path: all_artifacts
-          merge-multiple: true
+          key: "v2"
+
+      - name: Install musl-tools on Linux
+        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
+
+      - name: Build iggy-server release binary for Linux-x86_64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: x86_64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --bin iggy-server"
+
+      - name: Build iggy-cli release binary for Linux-x86_64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: x86_64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --no-default-features --bin iggy"
+
+      - name: Prepare Linux-x86_64 artifacts
+        run: |
+          mkdir -p all_artifacts/Linux-x86_64
+          cp target/x86_64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-x86_64/
+          cp target/x86_64-unknown-linux-musl/release/iggy all_artifacts/Linux-x86_64/
+
+      - name: Build iggy-server release binary for Linux-aarch64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: aarch64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --bin iggy-server"
+
+      - name: Build iggy-cli release binary for Linux-aarch64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: aarch64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --no-default-features --bin iggy"
+
+      - name: Prepare Linux-aarch64 artifacts
+        run: |
+          mkdir -p all_artifacts/Linux-aarch64
+          cp target/aarch64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-aarch64/
+          cp target/aarch64-unknown-linux-musl/release/iggy all_artifacts/Linux-aarch64/
 
       - name: Zip artifacts for each platform
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Move building x86_64 and aarch64 directly to create_github_release
step in order to fix GitHub release creation. Bump server version
to test new release flow.
