### PR TITLE
Add message flush command to CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,7 +2205,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -2254,7 +2254,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.5.14"
+version = "0.6.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cli"
-version = "0.5.14"
+version = "0.6.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -20,7 +20,7 @@ anyhow = "1.0.86"
 clap = { version = "4.5.4", features = ["derive"] }
 clap_complete = "4.5.24"
 figlet-rs = "0.1.5"
-iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.12" }
+iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.15" }
 keyring = { version = "3.2.0", features = ["sync-secret-service", "vendored"], optional = true }
 passterm = "2.0.1"
 thiserror = "1.0.61"

--- a/cli/src/args/message.rs
+++ b/cli/src/args/message.rs
@@ -31,6 +31,23 @@ pub(crate) enum MessageAction {
     ///  iggy message poll --offset 0 stream topic 1
     #[clap(verbatim_doc_comment, visible_alias = "p")]
     Poll(PollMessagesArgs),
+    /// Flush messages from given topic ID and given stream ID
+    ///
+    /// Command is used to force a flush of unsaved_buffer to disk
+    /// for specific stream, topic and partition. If fsync is enabled
+    /// then the data is flushed to disk and fsynced, otherwise the
+    /// data is only flushed to disk.
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    /// Topic ID can be specified as a topic name or ID
+    ///
+    /// Examples:
+    ///  iggy message flush 1 2 1
+    ///  iggy message flush stream 2 1
+    ///  iggy message flush 1 topic 1
+    ///  iggy message flush stream topic 1
+    #[clap(verbatim_doc_comment, visible_alias = "f")]
+    Flush(FlushMessagesArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -150,6 +167,30 @@ pub(crate) struct PollMessagesArgs {
     #[clap(verbatim_doc_comment)]
     #[clap(short, long, default_value_t = false)]
     pub(crate) show_headers: bool,
+}
+
+#[derive(Debug, Clone, Args)]
+pub(crate) struct FlushMessagesArgs {
+    /// ID of the stream for which messages will be flushed
+    ///
+    /// Stream ID can be specified as a stream name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) stream_id: Identifier,
+    /// ID of the topic for which messages will be flushed
+    ///
+    /// Topic ID can be specified as a topic name or ID
+    #[arg(value_parser = clap::value_parser!(Identifier))]
+    pub(crate) topic_id: Identifier,
+    /// Partition ID for which messages will be flushed
+    #[arg(value_parser = clap::value_parser!(u32).range(1..))]
+    pub(crate) partition_id: u32,
+    /// fsync flushed data to disk
+    ///
+    /// If option is enabled then the data is flushed to disk and fsynced,
+    /// otherwise the data is only flushed to disk. Default is false.
+    #[clap(verbatim_doc_comment)]
+    #[clap(short, long, default_value_t = false)]
+    pub(crate) fsync: bool,
 }
 
 #[cfg(test)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -32,7 +32,10 @@ use iggy::cli::{
         get_consumer_offset::GetConsumerOffsetCmd, set_consumer_offset::SetConsumerOffsetCmd,
     },
     context::get_contexts::GetContextsCmd,
-    message::{poll_messages::PollMessagesCmd, send_messages::SendMessagesCmd},
+    message::{
+        flush_messages::FlushMessagesCmd, poll_messages::PollMessagesCmd,
+        send_messages::SendMessagesCmd,
+    },
     partitions::{create_partitions::CreatePartitionsCmd, delete_partitions::DeletePartitionsCmd},
     personal_access_tokens::{
         create_personal_access_token::CreatePersonalAccessTokenCmd,
@@ -255,6 +258,12 @@ fn get_command(
                 poll_args.next,
                 poll_args.consumer.clone(),
                 poll_args.show_headers,
+            )),
+            MessageAction::Flush(flush_args) => Box::new(FlushMessagesCmd::new(
+                flush_args.stream_id.clone(),
+                flush_args.topic_id.clone(),
+                flush_args.partition_id,
+                flush_args.fsync,
             )),
         },
         Command::ConsumerOffset(command) => match command {

--- a/integration/tests/cli/message/mod.rs
+++ b/integration/tests/cli/message/mod.rs
@@ -1,3 +1,4 @@
+mod test_message_flush_command;
 mod test_message_help_command;
 mod test_message_poll_command;
 mod test_message_send_command;

--- a/integration/tests/cli/message/test_message_flush_command.rs
+++ b/integration/tests/cli/message/test_message_flush_command.rs
@@ -1,0 +1,266 @@
+use crate::cli::common::{
+    IggyCmdCommand, IggyCmdTest, IggyCmdTestCase, TestHelpCmd, TestStreamId, TestTopicId,
+    CLAP_INDENT, USAGE_PREFIX,
+};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::utils::expiry::IggyExpiry;
+use iggy::utils::topic_size::MaxTopicSize;
+use predicates::str::diff;
+use serial_test::parallel;
+use std::str::FromStr;
+
+struct TestMessageFetchCmd {
+    stream_id: u32,
+    stream_name: String,
+    topic_id: u32,
+    topic_name: String,
+    partitions_count: u32,
+    using_stream_id: TestStreamId,
+    using_topic_id: TestTopicId,
+    partition_id: u32,
+    fsync: bool,
+}
+
+impl TestMessageFetchCmd {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        stream_id: u32,
+        stream_name: &str,
+        topic_id: u32,
+        topic_name: &str,
+        partitions_count: u32,
+        using_stream_id: TestStreamId,
+        using_topic_id: TestTopicId,
+        partition_id: u32,
+        fsync: bool,
+    ) -> Self {
+        Self {
+            stream_id,
+            stream_name: stream_name.to_string(),
+            topic_id,
+            topic_name: topic_name.to_string(),
+            partitions_count,
+            using_stream_id,
+            using_topic_id,
+            partition_id,
+            fsync,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = Vec::new();
+
+        command.extend(match self.using_stream_id {
+            TestStreamId::Numeric => vec![format!("{}", self.stream_id)],
+            TestStreamId::Named => vec![self.stream_name.clone()],
+        });
+
+        command.push(match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        });
+
+        command.push(format!("{}", self.partition_id));
+
+        if self.fsync {
+            command.push("--fsync".to_string());
+        }
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestMessageFetchCmd {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client.create_stream(&self.stream_name, None).await;
+        assert!(stream.is_ok());
+
+        let stream_id = Identifier::from_str(&self.stream_name);
+        assert!(stream_id.is_ok());
+        let stream_id = stream_id.unwrap();
+
+        let topic = client
+            .create_topic(
+                &stream_id,
+                &self.topic_name,
+                self.partitions_count,
+                Default::default(),
+                None,
+                None,
+                IggyExpiry::NeverExpire,
+                MaxTopicSize::ServerDefault,
+            )
+            .await;
+        assert!(topic.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("message")
+            .arg("flush")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let stream_id = match self.using_stream_id {
+            TestStreamId::Numeric => format!("{}", self.stream_id),
+            TestStreamId::Named => self.stream_name.clone(),
+        };
+
+        let topic_id = match self.using_topic_id {
+            TestTopicId::Numeric => format!("{}", self.topic_id),
+            TestTopicId::Named => self.topic_name.clone(),
+        };
+
+        let identification_part = format!(
+            "from topic with ID: {topic_id} and stream with ID: {stream_id} (partition with ID: {}) {}",
+            self.partition_id,
+            if self.fsync {
+                "with fsync"
+            } else {
+                "without fsync"
+            }
+        );
+
+        let message = format!("Executing flush messages {identification_part}\nFlushed messages {identification_part}\n");
+
+        command_state.success().stdout(diff(message));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let topic_id = Identifier::from_str(&self.topic_name);
+        assert!(topic_id.is_ok());
+        let topic_id = topic_id.unwrap();
+        let stream_id = Identifier::from_str(&self.stream_name);
+        assert!(stream_id.is_ok());
+        let stream_id = stream_id.unwrap();
+
+        let topic = client.delete_topic(&stream_id, &topic_id).await;
+        assert!(topic.is_ok());
+
+        let stream = client.delete_stream(&stream_id).await;
+        assert!(stream.is_ok());
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_parameters: Vec<(TestStreamId, TestTopicId, bool)> = vec![
+        (TestStreamId::Numeric, TestTopicId::Numeric, false),
+        (TestStreamId::Numeric, TestTopicId::Named, false),
+        (TestStreamId::Named, TestTopicId::Numeric, false),
+        (TestStreamId::Named, TestTopicId::Named, false),
+        (TestStreamId::Numeric, TestTopicId::Numeric, true),
+        (TestStreamId::Numeric, TestTopicId::Named, true),
+        (TestStreamId::Named, TestTopicId::Numeric, true),
+        (TestStreamId::Named, TestTopicId::Named, true),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (using_stream_id, using_topic_id, fsync) in test_parameters {
+        iggy_cmd_test
+            .execute_test(TestMessageFetchCmd::new(
+                1,
+                "stream",
+                1,
+                "topic",
+                1,
+                using_stream_id,
+                using_topic_id,
+                1,
+                fsync,
+            ))
+            .await;
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::help_message();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["message", "flush", "--help"],
+            format!(
+                r#"Flush messages from given topic ID and given stream ID
+
+Command is used to force a flush of unsaved_buffer to disk
+for specific stream, topic and partition. If fsync is enabled
+then the data is flushed to disk and fsynced, otherwise the
+data is only flushed to disk.
+
+Stream ID can be specified as a stream name or ID
+Topic ID can be specified as a topic name or ID
+
+Examples:
+ iggy message flush 1 2 1
+ iggy message flush stream 2 1
+ iggy message flush 1 topic 1
+ iggy message flush stream topic 1
+
+{USAGE_PREFIX} message flush [OPTIONS] <STREAM_ID> <TOPIC_ID> <PARTITION_ID>
+
+Arguments:
+  <STREAM_ID>
+          ID of the stream for which messages will be flushed
+{CLAP_INDENT}
+          Stream ID can be specified as a stream name or ID
+
+  <TOPIC_ID>
+          ID of the topic for which messages will be flushed
+{CLAP_INDENT}
+          Topic ID can be specified as a topic name or ID
+
+  <PARTITION_ID>
+          Partition ID for which messages will be flushed
+
+Options:
+  -f, --fsync
+          fsync flushed data to disk
+{CLAP_INDENT}
+          If option is enabled then the data is flushed to disk and fsynced,
+          otherwise the data is only flushed to disk. Default is false.
+
+  -h, --help
+          Print help (see a summary with '-h')
+"#,
+            ),
+        ))
+        .await;
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_short_help_match() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    iggy_cmd_test
+        .execute_test_for_help_command(TestHelpCmd::new(
+            vec!["message", "flush", "-h"],
+            format!(
+                r#"Flush messages from given topic ID and given stream ID
+
+{USAGE_PREFIX} message flush [OPTIONS] <STREAM_ID> <TOPIC_ID> <PARTITION_ID>
+
+Arguments:
+  <STREAM_ID>     ID of the stream for which messages will be flushed
+  <TOPIC_ID>      ID of the topic for which messages will be flushed
+  <PARTITION_ID>  Partition ID for which messages will be flushed
+
+Options:
+  -f, --fsync  fsync flushed data to disk
+  -h, --help   Print help (see more with '--help')
+"#,
+            ),
+        ))
+        .await;
+}

--- a/integration/tests/cli/message/test_message_help_command.rs
+++ b/integration/tests/cli/message/test_message_help_command.rs
@@ -15,9 +15,10 @@ pub async fn should_help_match() {
 {USAGE_PREFIX} message <COMMAND>
 
 Commands:
-  send  Send messages to given topic ID and given stream ID [aliases: s]
-  poll  Poll messages from given topic ID and given stream ID [aliases: p]
-  help  Print this message or the help of the given subcommand(s)
+  send   Send messages to given topic ID and given stream ID [aliases: s]
+  poll   Poll messages from given topic ID and given stream ID [aliases: p]
+  flush  Flush messages from given topic ID and given stream ID [aliases: f]
+  help   Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.14"
+version = "0.6.15"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"

--- a/sdk/src/cli/message/flush_messages.rs
+++ b/sdk/src/cli/message/flush_messages.rs
@@ -1,0 +1,73 @@
+use crate::cli_command::{CliCommand, PRINT_TARGET};
+use crate::client::Client;
+use crate::identifier::Identifier;
+use anyhow::{Context, Error};
+use async_trait::async_trait;
+use tracing::{event, Level};
+
+pub struct FlushMessagesCmd {
+    stream_id: Identifier,
+    topic_id: Identifier,
+    partition_id: u32,
+    fsync: bool,
+}
+
+impl FlushMessagesCmd {
+    pub fn new(
+        stream_id: Identifier,
+        topic_id: Identifier,
+        partition_id: u32,
+        fsync: bool,
+    ) -> Self {
+        Self {
+            stream_id,
+            topic_id,
+            partition_id,
+            fsync,
+        }
+    }
+}
+
+#[async_trait]
+impl CliCommand for FlushMessagesCmd {
+    fn explain(&self) -> String {
+        format!(
+            "flush messages from topic with ID: {} and stream with ID: {} (partition with ID: {}) {}",
+            self.topic_id,
+            self.stream_id,
+            self.partition_id,
+            if self.fsync {
+                "with fsync"
+            } else {
+                "without fsync"
+            },
+        )
+    }
+
+    async fn execute_cmd(&mut self, client: &dyn Client) -> anyhow::Result<(), Error> {
+        client
+            .flush_unsaved_buffer(
+                &self.stream_id,
+                &self.topic_id,
+                self.partition_id,
+                self.fsync,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "Problem flushing messages from topic with ID: {} and stream with ID: {} (partition with ID: {}) {}",
+                    self.topic_id, self.stream_id, self.partition_id, if self.fsync { "with fsync" } else { "without fsync" },
+                )
+            })?;
+
+        event!(target: PRINT_TARGET, Level::INFO,
+            "Flushed messages from topic with ID: {} and stream with ID: {} (partition with ID: {}) {}",
+            self.topic_id,
+            self.stream_id,
+            self.partition_id,
+            if self.fsync { "with fsync" } else { "without fsync" },
+        );
+
+        Ok(())
+    }
+}

--- a/sdk/src/cli/message/mod.rs
+++ b/sdk/src/cli/message/mod.rs
@@ -1,2 +1,3 @@
+pub mod flush_messages;
 pub mod poll_messages;
 pub mod send_messages;


### PR DESCRIPTION
Add new subcommand for flushing messages with optional fsync operation
for flushing of unsaved buffer to disk for specific stream, topic
and partition. Add integration tests for new command.
