### PR TITLE
Add option to message poll command to store message in file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.16"
+version = "0.6.17"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -2012,7 +2012,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cli"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -20,7 +20,7 @@ anyhow = "1.0.86"
 clap = { version = "4.5.17", features = ["derive"] }
 clap_complete = "4.5.25"
 figlet-rs = "0.1.5"
-iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.15" }
+iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.17" }
 keyring = { version = "3.2.0", features = ["sync-secret-service", "vendored"], optional = true }
 passterm = "2.0.1"
 thiserror = "1.0.61"

--- a/cli/src/args/message.rs
+++ b/cli/src/args/message.rs
@@ -1,3 +1,4 @@
+use clap::builder::NonEmptyStringValueParser;
 use clap::{ArgGroup, Args, Subcommand};
 use iggy::error::IggyError;
 use iggy::error::IggyError::InvalidFormat;
@@ -159,7 +160,6 @@ pub(crate) struct PollMessagesArgs {
     #[clap(verbatim_doc_comment)]
     #[clap(short, long, default_value_t = Identifier::default(), value_parser = clap::value_parser!(Identifier))]
     pub(crate) consumer: Identifier,
-
     /// Include the message headers in the output
     ///
     /// Flag indicates whether to include headers in the output
@@ -167,6 +167,17 @@ pub(crate) struct PollMessagesArgs {
     #[clap(verbatim_doc_comment)]
     #[clap(short, long, default_value_t = false)]
     pub(crate) show_headers: bool,
+    /// Store polled message into file in binary format
+    ///
+    /// Polled messages will be stored in the file in binary format.
+    /// File can be used to replay the messages later. If the file
+    /// already exists, the messages will be appended to the file.
+    /// If the file does not exist, it will be created.
+    /// If the file is not specified, the messages will be printed
+    /// to the standard output.
+    #[clap(verbatim_doc_comment)]
+    #[clap(long, value_parser = NonEmptyStringValueParser::new())]
+    pub(crate) output_file: Option<String>,
 }
 
 #[derive(Debug, Clone, Args)]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -258,6 +258,7 @@ fn get_command(
                 poll_args.next,
                 poll_args.consumer.clone(),
                 poll_args.show_headers,
+                poll_args.output_file.clone(),
             )),
             MessageAction::Flush(flush_args) => Box::new(FlushMessagesCmd::new(
                 flush_args.stream_id.clone(),

--- a/integration/tests/cli/message/mod.rs
+++ b/integration/tests/cli/message/mod.rs
@@ -1,4 +1,5 @@
 mod test_message_flush_command;
 mod test_message_help_command;
 mod test_message_poll_command;
+mod test_message_poll_to_file_command;
 mod test_message_send_command;

--- a/integration/tests/cli/message/test_message_poll_command.rs
+++ b/integration/tests/cli/message/test_message_poll_command.rs
@@ -166,8 +166,13 @@ impl IggyCmdTestCase for TestMessagePollCmd {
             TestTopicId::Named => self.topic_name.clone(),
         };
 
-        let message = format!("Executing poll messages from topic ID: {} and stream with ID: {}\nPolled messages from topic with ID: {} and stream with ID: {} (from partition with ID: {})\nPolled {} messages",
-            topic_id, stream_id, topic_id, stream_id, self.partition_id, self.message_count);
+        let polled_status = match self.message_count {
+            1 => "Polled 1 message".into(),
+            _ => format!("Polled {} messages", self.message_count),
+        };
+
+        let message = format!("Executing poll messages from topic ID: {} and stream with ID: {}\nPolled messages from topic with ID: {} and stream with ID: {} (from partition with ID: {})\n{polled_status}",
+            topic_id, stream_id, topic_id, stream_id, self.partition_id);
 
         let mut status = command_state.success().stdout(starts_with(message));
 
@@ -402,6 +407,16 @@ Options:
           Flag indicates whether to include headers in the output
           after polling the messages.
 
+      --output-file <OUTPUT_FILE>
+          Store polled message into file in binary format
+{CLAP_INDENT}
+          Polled messages will be stored in the file in binary format.
+          File can be used to replay the messages later. If the file
+          already exists, the messages will be appended to the file.
+          If the file does not exist, it will be created.
+          If the file is not specified, the messages will be printed
+          to the standard output.
+
   -h, --help
           Print help (see a summary with '-h')
 "#,
@@ -437,6 +452,7 @@ Options:
   -n, --next                           Polling strategy - start polling from the next message
   -c, --consumer <CONSUMER>            Regular consumer which will poll messages [default: 1]
   -s, --show-headers                   Include the message headers in the output
+      --output-file <OUTPUT_FILE>      Store polled message into file in binary format
   -h, --help                           Print help (see more with '--help')
 "#,
             ),

--- a/integration/tests/cli/message/test_message_poll_to_file_command.rs
+++ b/integration/tests/cli/message/test_message_poll_to_file_command.rs
@@ -1,0 +1,248 @@
+use crate::cli::common::{IggyCmdCommand, IggyCmdTest, IggyCmdTestCase};
+use assert_cmd::assert::Assert;
+use async_trait::async_trait;
+use bytes::Bytes;
+use iggy::client::Client;
+use iggy::identifier::Identifier;
+use iggy::messages::poll_messages::{PollingKind, PollingStrategy};
+use iggy::messages::send_messages::{Message, Partitioning};
+use iggy::models::header::{HeaderKey, HeaderValue};
+use iggy::utils::expiry::IggyExpiry;
+use iggy::utils::topic_size::MaxTopicSize;
+use predicates::str::{contains, is_match, starts_with};
+use serial_test::parallel;
+use std::collections::HashMap;
+use std::path::Path;
+use std::str::FromStr;
+
+pub(super) struct TestMessagePollToFileCmd<'a> {
+    stream_name: String,
+    topic_name: String,
+    messages: Vec<&'a str>,
+    message_count: usize,
+    strategy: PollingStrategy,
+    headers: HashMap<HeaderKey, HeaderValue>,
+    output_file: String,
+    cleanup: bool,
+}
+
+impl<'a> TestMessagePollToFileCmd<'a> {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        stream_name: &str,
+        topic_name: &str,
+        messages: &[&'a str],
+        message_count: usize,
+        strategy: PollingStrategy,
+        headers: HashMap<HeaderKey, HeaderValue>,
+        output_file: &str,
+        cleanup: bool,
+    ) -> Self {
+        assert!(message_count <= messages.len());
+        Self {
+            stream_name: stream_name.into(),
+            topic_name: topic_name.into(),
+            messages: messages.to_owned(),
+            message_count,
+            strategy,
+            headers,
+            output_file: output_file.into(),
+            cleanup,
+        }
+    }
+
+    fn to_args(&self) -> Vec<String> {
+        let mut command = match self.strategy.kind {
+            PollingKind::Offset => vec!["--offset".into(), format!("{}", self.strategy.value)],
+            PollingKind::Timestamp => {
+                todo!("Timestamp based message polling is not supported yet")
+            }
+            PollingKind::First => vec!["--first".into()],
+            PollingKind::Next => vec!["--next".into()],
+            PollingKind::Last => vec!["--last".into()],
+        };
+
+        command.extend(vec![
+            "--message-count".into(),
+            format!("{}", self.message_count),
+        ]);
+
+        command.extend(vec!["--output-file".into(), self.output_file.clone()]);
+
+        command.extend(vec![
+            self.stream_name.clone(),
+            self.topic_name.clone(),
+            "1".into(),
+        ]);
+
+        command
+    }
+}
+
+#[async_trait]
+impl IggyCmdTestCase for TestMessagePollToFileCmd<'_> {
+    async fn prepare_server_state(&mut self, client: &dyn Client) {
+        let stream = client.create_stream(&self.stream_name, None).await;
+        assert!(stream.is_ok());
+
+        let stream_id = Identifier::from_str(self.stream_name.as_str());
+        assert!(stream_id.is_ok());
+        let stream_id = stream_id.unwrap();
+
+        let topic = client
+            .create_topic(
+                &stream_id,
+                &self.topic_name,
+                1,
+                Default::default(),
+                None,
+                None,
+                IggyExpiry::NeverExpire,
+                MaxTopicSize::ServerDefault,
+            )
+            .await;
+        assert!(topic.is_ok());
+
+        let topic_id = Identifier::from_str(self.topic_name.as_str());
+        assert!(topic_id.is_ok());
+        let topic_id = topic_id.unwrap();
+
+        let mut messages = self
+            .messages
+            .iter()
+            .map(|s| {
+                let payload = Bytes::from(s.as_bytes().to_vec());
+                Message::new(None, payload, Some(self.headers.clone()))
+            })
+            .collect::<Vec<_>>();
+
+        let send_status = client
+            .send_messages(
+                &stream_id,
+                &topic_id,
+                &Partitioning::partition_id(1),
+                &mut messages,
+            )
+            .await;
+        assert!(send_status.is_ok());
+    }
+
+    fn get_command(&self) -> IggyCmdCommand {
+        IggyCmdCommand::new()
+            .arg("message")
+            .arg("poll")
+            .args(self.to_args())
+            .with_env_credentials()
+    }
+
+    fn verify_command(&self, command_state: Assert) {
+        let polled_status = match self.message_count {
+            1 => "Polled 1 message".into(),
+            _ => format!("Polled {} messages", self.message_count),
+        };
+
+        let message_prefix = format!("Executing poll messages from topic ID: {} and stream with ID: {}\nPolled messages from topic with ID: {} and stream with ID: {} (from partition with ID: 1)\n{polled_status}",
+                                     self.topic_name, self.stream_name, self.topic_name, self.stream_name);
+        let message_file = format!("Storing messages to {} binary file", self.output_file);
+        let message_count = format!(
+            "Stored {} of total size [0-9]+ B to {} binary file",
+            match self.message_count {
+                1 => "1 message".into(),
+                _ => format!("{} messages", self.message_count),
+            },
+            self.output_file
+        );
+
+        command_state
+            .success()
+            .stdout(starts_with(message_prefix))
+            .stdout(contains(message_file))
+            .stdout(is_match(message_count).unwrap().count(1));
+    }
+
+    async fn verify_server_state(&self, client: &dyn Client) {
+        let stream_id = Identifier::from_str(self.stream_name.as_str());
+        assert!(stream_id.is_ok());
+        let stream_id = stream_id.unwrap();
+
+        let topic_id = Identifier::from_str(self.topic_name.as_str());
+        assert!(topic_id.is_ok());
+        let topic_id = topic_id.unwrap();
+
+        let topic = client.delete_topic(&stream_id, &topic_id).await;
+        assert!(topic.is_ok());
+
+        let stream = client.delete_stream(&stream_id).await;
+        assert!(stream.is_ok());
+
+        assert!(Path::new(&self.output_file).is_file());
+        if self.cleanup {
+            let file_removal = std::fs::remove_file(&self.output_file);
+            assert!(file_removal.is_ok());
+        }
+    }
+}
+
+#[tokio::test]
+#[parallel]
+pub async fn should_be_successful() {
+    let mut iggy_cmd_test = IggyCmdTest::default();
+
+    let test_messages: Vec<&str> = vec![
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+        "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+        "Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris",
+        "nisi ut aliquip ex ea commodo consequat",
+        "Duis aute irure dolor in reprehenderit in voluptate velit esse",
+        "cillum dolore eu fugiat nulla pariatur",
+        "Excepteur sint occaecat cupidatat non proident, sunt in culpa",
+        "qui officia deserunt mollit anim id est laborum",
+        "Sed ut perspiciatis unde omnis iste natus error sit voluptatem",
+        "accusantium doloremque laudantium, totam rem aperiam, eaque ipsa",
+    ];
+
+    let test_headers = HashMap::from([
+        (
+            HeaderKey::from_str("HeaderKey1").unwrap(),
+            HeaderValue::from_str("HeaderValue1").unwrap(),
+        ),
+        (
+            HeaderKey::from_str("HeaderKey2").unwrap(),
+            HeaderValue::from_str("HeaderValue2").unwrap(),
+        ),
+        (
+            HeaderKey::from_str("HeaderKey3").unwrap(),
+            HeaderValue::from_str("HeaderValue3").unwrap(),
+        ),
+    ]);
+
+    let test_parameters: Vec<(usize, PollingStrategy)> = vec![
+        (1, PollingStrategy::offset(0)),
+        (5, PollingStrategy::offset(0)),
+        (3, PollingStrategy::offset(3)),
+        (5, PollingStrategy::first()),
+        (4, PollingStrategy::last()),
+        (3, PollingStrategy::next()),
+    ];
+
+    iggy_cmd_test.setup().await;
+    for (message_count, strategy) in test_parameters {
+        let temp_file = tempfile::Builder::new().tempfile().unwrap();
+        let temp_path = temp_file.path().to_path_buf();
+        temp_file.close().unwrap();
+        let temp_path_str = temp_path.to_str().unwrap();
+
+        iggy_cmd_test
+            .execute_test(TestMessagePollToFileCmd::new(
+                "stream",
+                "topic",
+                &test_messages,
+                message_count,
+                strategy,
+                test_headers.clone(),
+                temp_path_str,
+                true,
+            ))
+            .await;
+    }
+}

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.16"
+version = "0.6.17"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "MIT"


### PR DESCRIPTION
Add option for message poll command which stores messages in binary
format in given file. This will allow to replay the messages with
message send command. Adapt integration tests to new change.
Improve status message while printing amount of polled messages.

This fixes #648
