### PR TITLE
Add skeleton for automated performance testing in CI

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,13 +1,9 @@
 name: performance
 on:
   workflow_dispatch:
-  # TODO(hubcio): uncomment when the workflow is ready
-  # pull_request:
-  #   branches:
-  #     - master
-  # push:
-  #   branches:
-  #     - master
+  push:
+    branches:
+      - master
 
 jobs:
   run_benchmarks:
@@ -15,44 +11,34 @@ jobs:
     env:
       IGGY_CI_BUILD: true
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          ref: master
-          fetch-depth: 0
+          toolchain: stable
+          override: true
 
       - name: Cache cargo & target directories
         uses: Swatinem/rust-cache@v2
         with:
           key: "v2"
 
-      - name: Build iggy-server
-        run: cargo build --release
-
-      - uses: JarvusInnovations/background-action@v1
-        name: Run iggy-server in background
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
-          run: |
-            target/release/iggy-server &
-          wait-on: tcp:localhost:8090
-          wait-for: 1m
-          log-output: true
-          log-output-if: timeout
-          tail: true
+          fetch-depth: 0
 
-      # Write 10 GB of data to the disk (10 producers * 1000 batches * 1000 messages in batch * 1000 bytes per message)
-      - name: Run send bench
-        timeout-minutes: 1
-        run: target/release/iggy-bench --verbose --warmup-time 0 send tcp
+      - name: Verify working directory
+        run: |
+          pwd
+          ls -la
 
-      # Read 10 GB of data from the disk
-      - name: Run poll bench
-        timeout-minutes: 1
-        run: target/release/iggy-bench --verbose poll tcp
+      - name: Run predefined benchmarks
+        timeout-minutes: 60
+        run: ./scripts/performance/run-standard-performance-suite.sh
 
-      - name: Stop iggy-server
-        timeout-minutes: 1
-        run: pkill -15 iggy-server && while pgrep -l iggy-server; do sleep 2; done;
-
-      - name: Print iggy-server logs
-        run: cat local_data/logs/iggy*
+      - name: Upload benchmark results
+        uses: actions/upload-artifact@v4
+        with:
+          name: performance_results
+          path: performance_results*

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bench_*
 /sdk/errors_table/
 /rust-clippy-results.sarif
 /Cross.toml
+/performance_results*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,8 @@ dependencies = [
  "async-trait",
  "clap",
  "colored",
+ "csv",
+ "derive-new",
  "derive_more",
  "figlet-rs",
  "futures",
@@ -1146,6 +1148,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1275,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 async-trait = "0.1.82"
 clap = { version = "4.5.17", features = ["derive"] }
 colored = "2.0.4"
+csv = "1.3.1"
+derive-new = "0.7.0"
 derive_more = "1.0.0"
 figlet-rs = "0.1.5"
 futures = "0.3.30"

--- a/bench/src/args/common.rs
+++ b/bench/src/args/common.rs
@@ -39,6 +39,13 @@ pub struct IggyBenchArgs {
     /// Skip server start
     #[arg(long, short = 'k', default_value_t = DEFAULT_SKIP_SERVER_START)]
     pub skip_server_start: bool,
+
+    /// Output directory, in which the benchmark results will be stored as `csv` and `toml` files.
+    /// Sample from the benchmark will be stored in a `csv` file on per-actor manner - each
+    /// producer/consumer will have its own file.
+    /// Actor summary, benchmark summary and parameters will be stored in a TOML file.
+    #[arg(long, short = 'o', default_value = None)]
+    pub output_directory: Option<String>,
 }
 
 fn validate_server_executable_path(v: &str) -> Result<String, String> {
@@ -132,5 +139,9 @@ impl IggyBenchArgs {
 
     pub fn warmup_time(&self) -> IggyDuration {
         self.warmup_time
+    }
+
+    pub fn output_directory(&self) -> Option<String> {
+        self.output_directory.clone()
     }
 }

--- a/bench/src/args/kind.rs
+++ b/bench/src/args/kind.rs
@@ -4,7 +4,7 @@ use super::props::BenchmarkKindProps;
 use super::transport::BenchmarkTransportCommand;
 use super::{common::IggyBenchArgs, simple::BenchmarkKind};
 use clap::{error::ErrorKind, CommandFactory, Parser, Subcommand};
-use core::panic;
+use serde::Serialize;
 use std::num::NonZeroU32;
 
 #[derive(Subcommand, Debug)]
@@ -97,7 +97,7 @@ impl BenchmarkKindProps for BenchmarkKindCommand {
 }
 
 /// Sending (writing) benchmark
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Serialize, Clone)]
 pub struct SendArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
@@ -153,7 +153,7 @@ impl BenchmarkKindProps for SendArgs {
     }
 
     fn consumers(&self) -> u32 {
-        panic!("")
+        0
     }
 
     fn producers(&self) -> u32 {
@@ -173,7 +173,7 @@ impl BenchmarkKindProps for SendArgs {
     }
 
     fn number_of_consumer_groups(&self) -> u32 {
-        panic!("No consumer groups in send benchmark");
+        0
     }
 
     fn validate(&self) {
@@ -192,7 +192,7 @@ impl BenchmarkKindProps for SendArgs {
 }
 
 /// Sending and Polling benchmark with consumer group
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct ConsumerGroupArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
@@ -240,7 +240,7 @@ impl BenchmarkKindProps for ConsumerGroupArgs {
     }
 
     fn number_of_partitions(&self) -> u32 {
-        panic!("No partitions in consumer group benchmark");
+        0
     }
 
     fn consumers(&self) -> u32 {
@@ -248,15 +248,15 @@ impl BenchmarkKindProps for ConsumerGroupArgs {
     }
 
     fn producers(&self) -> u32 {
-        panic!("No producers in consumer group");
+        0
     }
 
     fn disable_parallel_producer_streams(&self) -> bool {
-        panic!("No parallel producer for consumer group");
+        false
     }
 
     fn disable_parallel_consumer_streams(&self) -> bool {
-        panic!("No parallel consumer for consumer group");
+        false
     }
 
     fn transport_command(&self) -> &BenchmarkTransportCommand {
@@ -290,7 +290,7 @@ impl BenchmarkKindProps for ConsumerGroupArgs {
 }
 
 /// Polling (reading) benchmark
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone, Serialize)]
 pub struct PollArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
@@ -350,7 +350,7 @@ impl BenchmarkKindProps for PollArgs {
     }
 
     fn producers(&self) -> u32 {
-        panic!("")
+        0
     }
 
     fn disable_parallel_producer_streams(&self) -> bool {
@@ -366,7 +366,7 @@ impl BenchmarkKindProps for PollArgs {
     }
 
     fn number_of_consumer_groups(&self) -> u32 {
-        panic!("No consumer groups in poll benchmark");
+        0
     }
 
     fn validate(&self) {
@@ -385,7 +385,7 @@ impl BenchmarkKindProps for PollArgs {
 }
 
 /// Parallel sending and polling benchmark
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct SendAndPollArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
@@ -469,7 +469,7 @@ impl BenchmarkKindProps for SendAndPollArgs {
     }
 
     fn number_of_consumer_groups(&self) -> u32 {
-        panic!("No consumer groups in send and poll benchmark");
+        0
     }
 
     fn validate(&self) {

--- a/bench/src/args/mod.rs
+++ b/bench/src/args/mod.rs
@@ -1,8 +1,8 @@
 pub mod common;
+pub mod kind;
 pub mod simple;
 
 mod defaults;
 mod examples;
-mod kind;
 mod props;
 mod transport;

--- a/bench/src/args/transport.rs
+++ b/bench/src/args/transport.rs
@@ -2,13 +2,28 @@ use super::defaults::*;
 use super::props::BenchmarkTransportProps;
 use clap::{Parser, Subcommand};
 use integration::test_server::Transport;
+use serde::{Serialize, Serializer};
 use std::num::NonZeroU32;
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand, Debug, Clone)]
 pub enum BenchmarkTransportCommand {
     Http(HttpArgs),
     Tcp(TcpArgs),
     Quic(QuicArgs),
+}
+
+impl Serialize for BenchmarkTransportCommand {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let variant_str = match self {
+            BenchmarkTransportCommand::Http(_) => "http",
+            BenchmarkTransportCommand::Tcp(_) => "tcp",
+            BenchmarkTransportCommand::Quic(_) => "quic",
+        };
+        serializer.serialize_str(variant_str)
+    }
 }
 
 impl BenchmarkTransportProps for BenchmarkTransportCommand {
@@ -41,7 +56,7 @@ impl BenchmarkTransportProps for BenchmarkTransportCommand {
     }
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct HttpArgs {
     /// Address of the HTTP iggy-server
     #[arg(long, default_value_t = DEFAULT_HTTP_SERVER_ADDRESS.to_owned())]
@@ -74,7 +89,7 @@ impl BenchmarkTransportProps for HttpArgs {
     }
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct TcpArgs {
     /// Address of the TCP iggy-server
     #[arg(long, default_value_t = DEFAULT_TCP_SERVER_ADDRESS.to_owned())]
@@ -107,7 +122,7 @@ impl BenchmarkTransportProps for TcpArgs {
     }
 }
 
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 pub struct QuicArgs {
     /// Address to which the QUIC client will bind
     #[arg(long, default_value_t = DEFAULT_QUIC_CLIENT_ADDRESS.to_owned())]

--- a/bench/src/benchmark_params.rs
+++ b/bench/src/benchmark_params.rs
@@ -1,0 +1,54 @@
+use std::io::Write;
+
+use crate::args::common::IggyBenchArgs;
+use iggy::utils::timestamp::IggyTimestamp;
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub struct BenchmarkParams {
+    timestamp_micros: i64,
+    benchmark_name: String,
+    transport: String,
+    messages_per_batch: u32,
+    message_batches: u32,
+    message_size: u32,
+    producers: u32,
+    consumers: u32,
+    streams: u32,
+    partitions: u32,
+    number_of_consumer_groups: u32,
+    disable_parallel_consumers: bool,
+    disable_parallel_producers: bool,
+}
+
+impl BenchmarkParams {
+    pub fn dump_to_toml(&self, output_directory: &str) {
+        let output_file = format!("{}/params.toml", output_directory);
+        let toml_str = toml::to_string(self).unwrap();
+        Write::write_all(
+            &mut std::fs::File::create(output_file).unwrap(),
+            toml_str.as_bytes(),
+        )
+        .unwrap();
+    }
+}
+
+impl From<&IggyBenchArgs> for BenchmarkParams {
+    fn from(args: &IggyBenchArgs) -> Self {
+        BenchmarkParams {
+            timestamp_micros: IggyTimestamp::now().as_micros() as i64,
+            benchmark_name: args.benchmark_kind.as_simple_kind().to_string(),
+            transport: args.transport().to_string(),
+            messages_per_batch: args.messages_per_batch(),
+            message_batches: args.message_batches(),
+            message_size: args.message_size(),
+            producers: args.producers(),
+            consumers: args.consumers(),
+            streams: args.number_of_streams(),
+            partitions: args.number_of_partitions(),
+            number_of_consumer_groups: args.number_of_consumer_groups(),
+            disable_parallel_consumers: args.disable_parallel_consumer_streams(),
+            disable_parallel_producers: args.disable_parallel_producer_streams(),
+        }
+    }
+}

--- a/bench/src/benchmark_result.rs
+++ b/bench/src/benchmark_result.rs
@@ -1,58 +1,21 @@
 use crate::args::simple::BenchmarkKind;
-use colored::Colorize;
-use iggy::utils::byte_size::IggyByteSize;
+use crate::statistics::actor_statistics::BenchmarkActorStatistics;
+use crate::statistics::aggregate_statistics::BenchmarkAggregateStatistics;
 use std::collections::HashSet;
-use std::{
-    fmt::{Display, Formatter},
-    time::Duration,
-};
-use tokio::time::Instant;
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BenchmarkResult {
     pub kind: BenchmarkKind,
-    pub start_timestamp: Instant,
-    pub end_timestamp: Instant,
-    pub average_latency: Duration,
-    pub latency_percentiles: LatencyPercentiles,
-    pub total_size_bytes: IggyByteSize,
-    pub total_messages: u64,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct LatencyPercentiles {
-    pub p50: Duration,
-    pub p90: Duration,
-    pub p95: Duration,
-    pub p99: Duration,
-    pub p999: Duration,
-}
-
-pub struct BenchmarkResults {
-    results: Vec<BenchmarkResult>,
-}
-
-impl From<Vec<BenchmarkResult>> for BenchmarkResults {
-    fn from(results: Vec<BenchmarkResult>) -> Self {
-        Self { results }
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-struct BenchmarkStatistics {
-    total_throughput: f64,
-    messages_per_second: f64,
-    average_p50_latency: f64,
-    average_p90_latency: f64,
-    average_p95_latency: f64,
-    average_p99_latency: f64,
-    average_p999_latency: f64,
-    average_latency: f64,
-    average_throughput: f64,
-    total_duration: f64,
+    pub statistics: BenchmarkActorStatistics,
 }
 
 #[derive(Debug, Clone)]
 struct ImpossibleBenchmarkKind;
+
+pub struct BenchmarkResults {
+    pub results: Vec<BenchmarkResult>,
+}
 
 impl BenchmarkResults {
     fn get_test_type(&self) -> Result<BenchmarkKind, ImpossibleBenchmarkKind> {
@@ -72,102 +35,32 @@ impl BenchmarkResults {
         }
     }
 
-    fn calculate_statistics<F>(&self, mut predicate: F) -> BenchmarkStatistics
+    fn calculate_statistics<F>(&self, predicate: F) -> Option<BenchmarkAggregateStatistics>
     where
-        F: FnMut(&&BenchmarkResult) -> bool,
+        F: Fn(&BenchmarkResult) -> bool,
     {
-        let total_size_bytes = self
+        let records: Vec<_> = self
             .results
             .iter()
-            .filter(&mut predicate)
-            .map(|r| r.total_size_bytes)
-            .sum::<IggyByteSize>();
-        let total_duration = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.end_timestamp - r.start_timestamp)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64();
-        let total_messages = self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.total_messages)
-            .sum::<u64>();
-        let average_p50_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.latency_percentiles.p50)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_p95_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.latency_percentiles.p95)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_p90_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.latency_percentiles.p90)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_p99_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.latency_percentiles.p99)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_p999_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.latency_percentiles.p999)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_latency = (self
-            .results
-            .iter()
-            .filter(&mut predicate)
-            .map(|r| r.average_latency)
-            .sum::<Duration>()
-            / self.results.len() as u32)
-            .as_secs_f64()
-            * 1000.0;
-        let average_throughput = total_size_bytes.as_bytes_u64() as f64
-            / total_duration
-            / 1e6
-            / self.results.len() as f64;
-        let total_throughput = total_size_bytes.as_bytes_u64() as f64 / total_duration / 1e6;
-        let messages_per_second = total_messages as f64 / total_duration;
+            .filter(|&result| predicate(result))
+            .map(|result| result.statistics.clone())
+            .collect();
+        BenchmarkAggregateStatistics::from_actors_statistics(&records)
+    }
 
-        BenchmarkStatistics {
-            total_throughput,
-            messages_per_second,
-            average_latency,
-            average_p50_latency,
-            average_p90_latency,
-            average_p95_latency,
-            average_p99_latency,
-            average_p999_latency,
-            average_throughput,
-            total_duration,
+    pub fn dump_to_toml(&self, output_directory: &str) {
+        let producer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Send);
+        if let Some(producer_statics) = producer_statics {
+            let file_path = format!("{}/producers_summary.toml", output_directory);
+
+            producer_statics.dump_to_toml(&file_path);
+        }
+
+        let consumer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Poll);
+        if let Some(consumer_statics) = consumer_statics {
+            let file_path = format!("{}/consumers_summary.toml", output_directory);
+
+            consumer_statics.dump_to_toml(&file_path);
         }
     }
 }
@@ -176,14 +69,16 @@ impl Display for BenchmarkResults {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Ok(test_type) = self.get_test_type() {
             if test_type == BenchmarkKind::SendAndPoll {
-                let producer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Send);
-                let consumer_statics = self.calculate_statistics(|x| x.kind == BenchmarkKind::Poll);
+                let producer_statics = self
+                    .calculate_statistics(|x| x.kind == BenchmarkKind::Send)
+                    .unwrap();
+                let consumer_statics = self
+                    .calculate_statistics(|x| x.kind == BenchmarkKind::Poll)
+                    .unwrap();
 
-                let producer_info = format!("Producer results: total throughput: {:.2} MB/s, {:.0} messages/s, average throughput: {:.2} MB/s, average p50 latency: {:.2} ms, average p90 latency: {:.2} ms, average p95 latency: {:.2} ms, average p99 latency: {:.2} ms, average p999 latency: {:.2} ms, average latency: {:.2} ms, total duration: {:.2} s",
-                producer_statics.total_throughput, producer_statics.messages_per_second, producer_statics.average_throughput, producer_statics.average_p50_latency, producer_statics.average_p90_latency, producer_statics.average_p95_latency, producer_statics.average_p99_latency, producer_statics.average_p999_latency, producer_statics.average_latency, producer_statics.total_duration).green();
+                let producer_info = producer_statics.formatted_string("Producer");
+                let consumer_info = consumer_statics.formatted_string("Consumer");
 
-                let consumer_info = format!("Consumer results: total throughput: {:.2} MB/s, {:.0} messages/s, average throughput: {:.2} MB/s, average p50 latency: {:.2} ms, average p90 latency: {:.2} ms, average p95 latency: {:.2} ms, average p99 latency: {:.2} ms, average p999 latency: {:.2} ms, average latency: {:.2} ms, total duration: {:.2} s",
-                consumer_statics.total_throughput, consumer_statics.messages_per_second, consumer_statics.average_throughput, consumer_statics.average_p50_latency, consumer_statics.average_p90_latency, consumer_statics.average_p95_latency, consumer_statics.average_p99_latency, consumer_statics.average_p999_latency, consumer_statics.average_latency, consumer_statics.total_duration).green();
                 writeln!(f, "{}, {}", producer_info, consumer_info)?;
             }
         }
@@ -192,9 +87,7 @@ impl Display for BenchmarkResults {
             x.kind == BenchmarkKind::Send || x.kind == BenchmarkKind::Poll
         });
 
-        let summary_info = format!("Results: total throughput: {:.2} MB/s, {:.0} messages/s, average throughput: {:.2} MB/s, average p50 latency: {:.2} ms, average p90 latency: {:.2} ms, average p95 latency: {:.2} ms, average p99 latency: {:.2} ms, average p999 latency: {:.2} ms, average latency: {:.2} ms, total duration: {:.2} s",
-        results.total_throughput, results.messages_per_second, results.average_throughput, results.average_p50_latency, results.average_p90_latency, results.average_p95_latency, results.average_p99_latency, results.average_p999_latency, results.average_latency, results.total_duration).green();
-
+        let summary_info = results.unwrap().formatted_string("Results");
         writeln!(f, "{}", summary_info)
     }
 }

--- a/bench/src/benchmark_runner.rs
+++ b/bench/src/benchmark_runner.rs
@@ -1,4 +1,5 @@
 use crate::args::common::IggyBenchArgs;
+use crate::benchmark_params::BenchmarkParams;
 use crate::benchmark_result::BenchmarkResults;
 use crate::benchmarks::benchmark::Benchmarkable;
 use crate::server_starter::start_server_if_needed;
@@ -47,12 +48,17 @@ impl BenchmarkRunner {
 
         // Sleep just to see result prints after all the join handles are done and tcp connections are closed
         sleep(Duration::from_millis(10)).await;
-        let results: BenchmarkResults = results.into();
+
+        let results = BenchmarkResults { results };
         benchmark.display_settings();
-        results
-            .to_string()
-            .split('\n')
-            .for_each(|result| info!("{}", result));
+        info!("{results}");
+
+        if let Some(output_directory) = benchmark.args().output_directory() {
+            results.dump_to_toml(&output_directory);
+            let params = BenchmarkParams::from(benchmark.args());
+            params.dump_to_toml(&output_directory);
+        }
+
         Ok(())
     }
 }

--- a/bench/src/benchmarks/consumer_group_benchmark.rs
+++ b/bench/src/benchmarks/consumer_group_benchmark.rs
@@ -82,11 +82,14 @@ impl Benchmarkable for ConsumerGroupBenchmark {
         let message_batches = self.args.message_batches();
         let warmup_time = self.args.warmup_time();
         let mut futures: BenchmarkFutures = Ok(Vec::with_capacity((consumers) as usize));
+        let output_directory = self.args.output_directory();
 
         for consumer_id in 1..=consumers {
             let consumer_group_id =
                 start_consumer_group_id + 1 + (consumer_id % consumer_groups_count);
             let stream_id = start_stream_id + 1 + (consumer_id % consumer_groups_count);
+            let output_directory = output_directory.clone();
+
             let consumer = Consumer::new(
                 self.client_factory.clone(),
                 consumer_id,
@@ -95,6 +98,7 @@ impl Benchmarkable for ConsumerGroupBenchmark {
                 messages_per_batch,
                 message_batches,
                 warmup_time,
+                output_directory,
             );
             let future = Box::pin(async move { consumer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/benchmarks/poll_benchmark.rs
+++ b/bench/src/benchmarks/poll_benchmark.rs
@@ -30,6 +30,7 @@ impl Benchmarkable for PollMessagesBenchmark {
         info!("Creating {} client(s)...", clients_count);
         let messages_per_batch = self.args.messages_per_batch();
         let message_batches = self.args.message_batches();
+        let output_directory = self.args.output_directory();
 
         let mut futures: BenchmarkFutures = Ok(Vec::with_capacity(clients_count as usize));
         for client_id in 1..=clients_count {
@@ -45,6 +46,7 @@ impl Benchmarkable for PollMessagesBenchmark {
                 false => start_stream_id + 1,
             };
             let warmup_time = args.warmup_time();
+            let output_directory = output_directory.clone();
 
             let consumer = Consumer::new(
                 client_factory,
@@ -54,6 +56,7 @@ impl Benchmarkable for PollMessagesBenchmark {
                 messages_per_batch,
                 message_batches,
                 warmup_time,
+                output_directory,
             );
 
             let future = Box::pin(async move { consumer.run().await });

--- a/bench/src/benchmarks/send_and_poll_benchmark.rs
+++ b/bench/src/benchmarks/send_and_poll_benchmark.rs
@@ -62,6 +62,8 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
         let message_size = self.args.message_size();
         let partitions_count = self.args.number_of_partitions();
         let warmup_time = self.args.warmup_time();
+        let output_directory = self.args.output_directory();
+
         let mut futures: BenchmarkFutures =
             Ok(Vec::with_capacity((producers + consumers) as usize));
         for producer_id in 1..=producers {
@@ -69,7 +71,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 true => start_stream_id + producer_id,
                 false => start_stream_id + 1,
             };
-
+            let output_directory = output_directory.clone();
             let producer = Producer::new(
                 self.client_factory.clone(),
                 producer_id,
@@ -79,6 +81,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 message_batches,
                 message_size,
                 warmup_time,
+                output_directory,
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);
@@ -89,6 +92,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 true => start_stream_id + consumer_id,
                 false => start_stream_id + 1,
             };
+            let output_directory = output_directory.clone();
             let consumer = Consumer::new(
                 self.client_factory.clone(),
                 consumer_id,
@@ -97,6 +101,7 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 messages_per_batch,
                 message_batches,
                 warmup_time,
+                output_directory,
             );
             let future = Box::pin(async move { consumer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/benchmarks/send_benchmark.rs
+++ b/bench/src/benchmarks/send_benchmark.rs
@@ -42,6 +42,7 @@ impl Benchmarkable for SendMessagesBenchmark {
             let args = args.clone();
             let start_stream_id = args.start_stream_id();
             let client_factory = client_factory.clone();
+            let output_directory = args.output_directory.clone();
 
             let parallel_producer_streams = !args.disable_parallel_producer_streams();
             let stream_id = match parallel_producer_streams {
@@ -58,6 +59,7 @@ impl Benchmarkable for SendMessagesBenchmark {
                 message_batches,
                 message_size,
                 warmup_time,
+                output_directory,
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -1,4 +1,5 @@
 mod args;
+mod benchmark_params;
 mod benchmark_result;
 mod benchmark_runner;
 mod benchmarks;
@@ -6,6 +7,7 @@ mod client_factory;
 mod consumer;
 mod producer;
 mod server_starter;
+mod statistics;
 
 use crate::{args::common::IggyBenchArgs, benchmark_runner::BenchmarkRunner};
 use clap::Parser;

--- a/bench/src/producer.rs
+++ b/bench/src/producer.rs
@@ -1,11 +1,14 @@
 use crate::args::simple::BenchmarkKind;
-use crate::benchmark_result::{BenchmarkResult, LatencyPercentiles};
+use crate::benchmark_result::BenchmarkResult;
+use crate::statistics::actor_statistics::BenchmarkActorStatistics;
+use crate::statistics::record::BenchmarkRecord;
 use iggy::client::MessageClient;
 use iggy::clients::client::IggyClient;
 use iggy::error::IggyError;
 use iggy::messages::send_messages::{Message, Partitioning};
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::duration::IggyDuration;
+use iggy::utils::sizeable::Sizeable;
 use integration::test_server::{login_root, ClientFactory};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -18,10 +21,11 @@ pub struct Producer {
     producer_id: u32,
     stream_id: u32,
     partitions_count: u32,
-    messages_per_batch: u32,
     message_batches: u32,
+    messages_per_batch: u32,
     message_size: u32,
     warmup_time: IggyDuration,
+    output_directory: Option<String>,
 }
 
 impl Producer {
@@ -35,6 +39,7 @@ impl Producer {
         message_batches: u32,
         message_size: u32,
         warmup_time: IggyDuration,
+        output_directory: Option<String>,
     ) -> Self {
         Producer {
             client_factory,
@@ -45,13 +50,19 @@ impl Producer {
             message_batches,
             message_size,
             warmup_time,
+            output_directory,
         }
     }
 
     pub async fn run(&self) -> Result<BenchmarkResult, IggyError> {
         let topic_id: u32 = 1;
         let default_partition_id: u32 = 1;
-        let total_messages = (self.messages_per_batch * self.message_batches) as u64;
+        let partitions_count = self.partitions_count;
+        let message_batches = self.message_batches;
+        let messages_per_batch = self.messages_per_batch;
+        let message_size = self.message_size;
+
+        let total_messages = (messages_per_batch * message_batches) as u64;
         let client = self.client_factory.create_client().await;
         let client = IggyClient::create(client, None, None);
         login_root(&client).await;
@@ -59,94 +70,110 @@ impl Producer {
             "Producer #{} → preparing the test messages...",
             self.producer_id
         );
-        let payload = Self::create_payload(self.message_size);
-        let mut messages = Vec::with_capacity(self.messages_per_batch as usize);
-        for _ in 0..self.messages_per_batch {
+        let payload = Self::create_payload(message_size);
+        let mut batch_user_data_bytes = 0;
+        let mut batch_total_bytes = 0;
+        let mut messages = Vec::with_capacity(messages_per_batch as usize);
+        for _ in 0..messages_per_batch {
             let message = Message::from_str(&payload).unwrap();
+            batch_user_data_bytes += message.length as u64;
+            batch_total_bytes += message.get_size_bytes().as_bytes_u64();
             messages.push(message);
         }
+        let batch_user_data_bytes = batch_user_data_bytes;
+        let batch_total_bytes = batch_total_bytes;
 
         let stream_id = self.stream_id.try_into()?;
         let topic_id = topic_id.try_into()?;
-        let partitioning = match self.partitions_count {
+        let partitioning = match partitions_count {
             0 => panic!("Partition count must be greater than 0"),
             1 => Partitioning::partition_id(default_partition_id),
             2.. => Partitioning::balanced(),
         };
-        info!(
-            "Producer #{} → warming up for {}...",
-            self.producer_id, self.warmup_time
-        );
-        let warmup_end = Instant::now() + self.warmup_time.get_duration();
-        while Instant::now() < warmup_end {
-            client
-                .send_messages(&stream_id, &topic_id, &partitioning, &mut messages)
-                .await?;
+
+        if self.warmup_time.get_duration() != Duration::from_millis(0) {
+            info!(
+                "Producer #{} → warming up for {}...",
+                self.producer_id, self.warmup_time
+            );
+            let warmup_end = Instant::now() + self.warmup_time.get_duration();
+            while Instant::now() < warmup_end {
+                client
+                    .send_messages(&stream_id, &topic_id, &partitioning, &mut messages)
+                    .await?;
+            }
         }
 
         info!(
             "Producer #{} → sending {} messages in {} batches of {} messages...",
-            self.producer_id, total_messages, self.message_batches, self.messages_per_batch
+            self.producer_id, total_messages, message_batches, messages_per_batch
         );
 
         let start_timestamp = Instant::now();
-        let mut latencies: Vec<Duration> = Vec::with_capacity(self.message_batches as usize);
-        for _ in 0..self.message_batches {
-            let latency_start = Instant::now();
+        let mut latencies: Vec<Duration> = Vec::with_capacity(message_batches as usize);
+        let mut records: Vec<BenchmarkRecord> = Vec::with_capacity(message_batches as usize);
+        for i in 1..=message_batches {
+            let before_send = Instant::now();
             client
                 .send_messages(&stream_id, &topic_id, &partitioning, &mut messages)
                 .await?;
-            let latency_end = latency_start.elapsed();
-            latencies.push(latency_end);
+            let latency = before_send.elapsed();
+
+            let messages_processed = (i * messages_per_batch) as u64;
+            let batches_processed = i as u64;
+            let total_user_data_bytes = batches_processed * batch_user_data_bytes;
+            let total_bytes = batches_processed * batch_total_bytes;
+
+            latencies.push(latency);
+            records.push(BenchmarkRecord::new(
+                start_timestamp.elapsed().as_micros() as u64,
+                latency.as_micros() as u64,
+                messages_processed,
+                batches_processed,
+                total_user_data_bytes,
+                total_bytes,
+            ));
         }
-        let end_timestamp = Instant::now();
+        let statistics = BenchmarkActorStatistics::from_records(&records);
 
-        latencies.sort();
-        let last_idx = latencies.len() - 1;
-        let p50 = latencies[last_idx / 2];
-        let p90 = latencies[last_idx * 9 / 10];
-        let p95 = latencies[last_idx * 95 / 100];
-        let p99 = latencies[last_idx * 99 / 100];
-        let p999 = latencies[last_idx * 999 / 1000];
-        let latency_percentiles = LatencyPercentiles {
-            p50,
-            p90,
-            p95,
-            p99,
-            p999,
-        };
+        if let Some(output_directory) = &self.output_directory {
+            std::fs::create_dir_all(format!("{}/raw_data", output_directory)).unwrap();
 
-        let duration = end_timestamp - start_timestamp;
-        let average_latency: Duration = latencies.iter().sum::<Duration>() / latencies.len() as u32;
-        let total_size_bytes = IggyByteSize::from(total_messages * self.message_size as u64);
-        let average_throughput =
-            total_size_bytes.as_bytes_u64() as f64 / duration.as_secs_f64() / 1e6;
+            // Dump raw data to file
+            let results_file = format!(
+                "{}/raw_data/producer_{}_data.csv",
+                output_directory, self.producer_id
+            );
+            info!(
+                "Producer #{} → writing the results to {}...",
+                self.producer_id, results_file
+            );
 
-        info!(
-            "Producer #{} → sent {} messages in {} batches of {} messages in {:.2} s, total size: {}, average throughput: {:.2} MB/s, p50 latency: {:.2} ms, p90 latency: {:.2} ms, p95 latency: {:.2} ms, p99 latency: {:.2} ms, p999 latency: {:.2} ms, average latency: {:.2} ms",
+            let mut writer = csv::Writer::from_path(results_file).unwrap();
+            for sample in records {
+                writer.serialize(sample).unwrap();
+            }
+            writer.flush().unwrap();
+
+            // Dump summary to file
+            let summary_file = format!(
+                "{}/raw_data/producer_{}_summary.toml",
+                output_directory, self.producer_id
+            );
+            statistics.dump_to_toml(&summary_file);
+        }
+
+        Self::log_producer_statistics(
             self.producer_id,
             total_messages,
-            self.message_batches,
-            self.messages_per_batch,
-            duration.as_secs_f64(),
-            total_size_bytes.as_human_string(),
-            average_throughput,
-            p50.as_secs_f64() * 1000.0,
-            p90.as_secs_f64() * 1000.0,
-            p95.as_secs_f64() * 1000.0,
-            p99.as_secs_f64() * 1000.0,
-            p999.as_secs_f64() * 1000.0,
-            average_latency.as_secs_f64() * 1000.0
+            message_batches,
+            messages_per_batch,
+            &statistics,
         );
 
         Ok(BenchmarkResult {
             kind: BenchmarkKind::Send,
-            start_timestamp,
-            end_timestamp,
-            average_latency,
-            latency_percentiles,
-            total_size_bytes,
-            total_messages,
+            statistics,
         })
     }
 
@@ -158,5 +185,33 @@ impl Producer {
         }
 
         payload
+    }
+
+    fn log_producer_statistics(
+        producer_id: u32,
+        total_messages: u64,
+        message_batches: u32,
+        messages_per_batch: u32,
+        stats: &BenchmarkActorStatistics,
+    ) {
+        info!(
+            "Producer #{} → sent {} messages in {} batches of {} messages in {:.2} s, total size: {}, average throughput: {:.2} MB/s, \
+    p50 latency: {:.2} ms, p90 latency: {:.2} ms, p95 latency: {:.2} ms, p99 latency: {:.2} ms, p999 latency: {:.2} ms, \
+    average latency: {:.2} ms, median latency: {:.2} ms",
+            producer_id,
+            total_messages,
+            message_batches,
+            messages_per_batch,
+            stats.total_time_secs,
+            IggyByteSize::from(stats.total_bytes),
+            stats.throughput_megabytes_per_second,
+            stats.p50_latency_ms,
+            stats.p90_latency_ms,
+            stats.p95_latency_ms,
+            stats.p99_latency_ms,
+            stats.p999_latency_ms,
+            stats.avg_latency_ms,
+            stats.median_latency_ms
+        );
     }
 }

--- a/bench/src/statistics/actor_statistics.rs
+++ b/bench/src/statistics/actor_statistics.rs
@@ -1,0 +1,117 @@
+use super::record::BenchmarkRecord;
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct BenchmarkActorStatistics {
+    pub total_time_secs: f64,
+    pub total_user_data_bytes: u64,
+    pub total_bytes: u64,
+    pub total_messages: u64,
+    pub throughput_megabytes_per_second: f64,
+    pub throughput_messages_per_second: f64,
+    pub p50_latency_ms: f64,
+    pub p90_latency_ms: f64,
+    pub p95_latency_ms: f64,
+    pub p99_latency_ms: f64,
+    pub p999_latency_ms: f64,
+    pub avg_latency_ms: f64,
+    pub median_latency_ms: f64,
+}
+
+impl BenchmarkActorStatistics {
+    pub fn from_records(records: &[BenchmarkRecord]) -> Self {
+        if records.is_empty() {
+            return BenchmarkActorStatistics {
+                total_time_secs: 0.0,
+                total_user_data_bytes: 0,
+                total_bytes: 0,
+                total_messages: 0,
+                throughput_megabytes_per_second: 0.0,
+                throughput_messages_per_second: 0.0,
+                p50_latency_ms: 0.0,
+                p90_latency_ms: 0.0,
+                p95_latency_ms: 0.0,
+                p99_latency_ms: 0.0,
+                p999_latency_ms: 0.0,
+                avg_latency_ms: 0.0,
+                median_latency_ms: 0.0,
+            };
+        }
+
+        let total_time_secs = records.last().unwrap().elapsed_time_us as f64 / 1_000_000.0;
+
+        let total_user_data_bytes: u64 = records.iter().last().unwrap().user_data_bytes;
+        let total_bytes: u64 = records.iter().last().unwrap().total_bytes;
+        let total_messages: u64 = records.iter().last().unwrap().messages;
+
+        let throughput_megabytes_per_second = if total_time_secs > 0.0 {
+            (total_bytes as f64) / 1_000_000.0 / total_time_secs
+        } else {
+            0.0
+        };
+
+        let throughput_messages_per_second = if total_time_secs > 0.0 {
+            (total_messages as f64) / total_time_secs
+        } else {
+            0.0
+        };
+
+        let mut latencies_ms: Vec<f64> = records
+            .iter()
+            .map(|r| r.latency_us as f64 / 1_000.0)
+            .collect();
+        latencies_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let p50_latency_ms = calculate_percentile(&latencies_ms, 50.0);
+        let p90_latency_ms = calculate_percentile(&latencies_ms, 90.0);
+        let p95_latency_ms = calculate_percentile(&latencies_ms, 95.0);
+        let p99_latency_ms = calculate_percentile(&latencies_ms, 99.0);
+        let p999_latency_ms = calculate_percentile(&latencies_ms, 99.9);
+
+        let avg_latency_ms = latencies_ms.iter().sum::<f64>() / latencies_ms.len() as f64;
+        let len = latencies_ms.len() / 2;
+        let median_latency_ms = if latencies_ms.len() % 2 == 0 {
+            (latencies_ms[len - 1] + latencies_ms[len]) / 2.0
+        } else {
+            latencies_ms[len]
+        };
+
+        BenchmarkActorStatistics {
+            total_time_secs,
+            total_user_data_bytes,
+            total_bytes,
+            total_messages,
+            throughput_megabytes_per_second,
+            throughput_messages_per_second,
+            p50_latency_ms,
+            p90_latency_ms,
+            p95_latency_ms,
+            p99_latency_ms,
+            p999_latency_ms,
+            avg_latency_ms,
+            median_latency_ms,
+        }
+    }
+
+    pub fn dump_to_toml(&self, file_name: &str) {
+        let toml_str = toml::to_string(self).unwrap();
+        std::fs::write(file_name, toml_str).unwrap();
+    }
+}
+
+fn calculate_percentile(sorted_data: &[f64], percentile: f64) -> f64 {
+    if sorted_data.is_empty() {
+        return 0.0;
+    }
+
+    let rank = percentile / 100.0 * (sorted_data.len() - 1) as f64;
+    let lower = rank.floor() as usize;
+    let upper = rank.ceil() as usize;
+
+    if upper >= sorted_data.len() {
+        return sorted_data[sorted_data.len() - 1];
+    }
+
+    let weight = rank - lower as f64;
+    sorted_data[lower] * (1.0 - weight) + sorted_data[upper] * weight
+}

--- a/bench/src/statistics/aggregate_statistics.rs
+++ b/bench/src/statistics/aggregate_statistics.rs
@@ -1,0 +1,92 @@
+use std::io::Write;
+
+use super::actor_statistics::BenchmarkActorStatistics;
+use colored::{ColoredString, Colorize};
+use serde::Serialize;
+
+#[derive(Debug, Serialize, Clone, PartialEq)]
+pub struct BenchmarkAggregateStatistics {
+    pub total_throughput_megabytes_per_second: f64,
+    pub total_throughput_messages_per_second: f64,
+    pub average_throughput_megabytes_per_second: f64,
+    pub average_throughput_messages_per_second: f64,
+    pub average_p50_latency_ms: f64,
+    pub average_p90_latency_ms: f64,
+    pub average_p95_latency_ms: f64,
+    pub average_p99_latency_ms: f64,
+    pub average_p999_latency_ms: f64,
+    pub average_avg_latency_ms: f64,
+    pub average_median_latency_ms: f64,
+}
+
+impl BenchmarkAggregateStatistics {
+    pub fn from_actors_statistics(stats: &[BenchmarkActorStatistics]) -> Option<Self> {
+        if stats.is_empty() {
+            return None;
+        }
+        let count = stats.len() as f64;
+
+        // Compute total throughput
+        let total_throughput_megabytes_per_second: f64 = stats
+            .iter()
+            .map(|r| r.throughput_megabytes_per_second)
+            .sum();
+
+        let total_throughput_messages_per_second: f64 =
+            stats.iter().map(|r| r.throughput_messages_per_second).sum();
+
+        // Compute average throughput
+        let average_throughput_megabytes_per_second = total_throughput_megabytes_per_second / count;
+
+        let average_throughput_messages_per_second = total_throughput_messages_per_second / count;
+
+        // Compute average latencies
+        let average_p50_latency_ms = stats.iter().map(|r| r.p50_latency_ms).sum::<f64>() / count;
+        let average_p90_latency_ms = stats.iter().map(|r| r.p90_latency_ms).sum::<f64>() / count;
+        let average_p95_latency_ms = stats.iter().map(|r| r.p95_latency_ms).sum::<f64>() / count;
+        let average_p99_latency_ms = stats.iter().map(|r| r.p99_latency_ms).sum::<f64>() / count;
+        let average_p999_latency_ms = stats.iter().map(|r| r.p999_latency_ms).sum::<f64>() / count;
+        let average_avg_latency_ms = stats.iter().map(|r| r.avg_latency_ms).sum::<f64>() / count;
+        let average_median_latency_ms =
+            stats.iter().map(|r| r.median_latency_ms).sum::<f64>() / count;
+
+        Some(BenchmarkAggregateStatistics {
+            total_throughput_megabytes_per_second,
+            total_throughput_messages_per_second,
+            average_throughput_megabytes_per_second,
+            average_throughput_messages_per_second,
+            average_p50_latency_ms,
+            average_p90_latency_ms,
+            average_p95_latency_ms,
+            average_p99_latency_ms,
+            average_p999_latency_ms,
+            average_avg_latency_ms,
+            average_median_latency_ms,
+        })
+    }
+
+    pub fn formatted_string(&self, prefix: &str) -> ColoredString {
+        format!(
+            "{prefix}: Total throughput: {:.2} MB/s, {:.0} messages/s, average throughput: {:.2} MB/s, average p50 latency: {:.2} ms, average p90 latency: {:.2} ms, average p95 latency: {:.2} ms, average p99 latency: {:.2} ms, average p999 latency: {:.2} ms, average latency: {:.2} ms, median latency: {:.2} ms",
+            self.total_throughput_megabytes_per_second,
+            self.total_throughput_messages_per_second,
+            self.average_throughput_megabytes_per_second,
+            self.average_p50_latency_ms,
+            self.average_p90_latency_ms,
+            self.average_p95_latency_ms,
+            self.average_p99_latency_ms,
+            self.average_p999_latency_ms,
+            self.average_avg_latency_ms,
+            self.average_median_latency_ms
+        ).green()
+    }
+
+    pub fn dump_to_toml(&self, file_name: &str) {
+        let toml_str = toml::to_string(self).unwrap();
+        Write::write_all(
+            &mut std::fs::File::create(file_name).unwrap(),
+            toml_str.as_bytes(),
+        )
+        .unwrap();
+    }
+}

--- a/bench/src/statistics/mod.rs
+++ b/bench/src/statistics/mod.rs
@@ -1,0 +1,3 @@
+pub mod actor_statistics;
+pub mod aggregate_statistics;
+pub mod record;

--- a/bench/src/statistics/record.rs
+++ b/bench/src/statistics/record.rs
@@ -1,0 +1,12 @@
+use derive_new::new;
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Serialize, new)]
+pub struct BenchmarkRecord {
+    pub elapsed_time_us: u64,
+    pub latency_us: u64,
+    pub messages: u64,
+    pub message_batches: u64,
+    pub user_data_bytes: u64,
+    pub total_bytes: u64,
+}

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -477,7 +477,6 @@ max_entries = 1000
 # Maximum age of ID entries in the deduplication cache in human-readable format.
 expiry = "1 m"
 
-
 # Recovery configuration in case of lost data
 [system.recovery]
 # Controls whether streams/topics/partitions should be recreated if the expected data for existing state is missing (boolean).

--- a/scripts/performance/run-standard-performance-suite.sh
+++ b/scripts/performance/run-standard-performance-suite.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+# shellcheck disable=SC1091
+
+IGGY_BENCH_CMD=""
+if [ -z "$1" ]; then
+    IGGY_BENCH_CMD="target/release/iggy-bench"
+else
+    IGGY_BENCH_CMD="$1"
+fi
+
+echo "Using iggy-bench binary: ${IGGY_BENCH_CMD}"
+
+set -euo pipefail
+
+# Load utility functions
+source "$(dirname "$0")/../utils.sh"
+source "$(dirname "$0")/utils.sh"
+
+
+# Trap SIGINT (Ctrl+C) and execute the on_exit function, do the same on script exit
+trap on_exit_bench SIGINT
+trap on_exit_bench EXIT
+
+# Build the project
+echo "Building project..."
+cargo build --release
+
+# Remove old performance results
+echo "Cleaning old performance results..."
+rm -rf performance_results || true
+
+# Construct standard performance suites, each should process 8 GB of data
+STANDARD_SEND=$(construct_bench_command "$IGGY_BENCH_CMD" "send" 8 1000 1000 1000 tcp)        # 8 producers, 8 streams, 1000 byte messages, 1000 messages per batch, 1000 message batches, tcp
+STANDARD_POLL=$(construct_bench_command "$IGGY_BENCH_CMD" "poll" 8 1000 1000 1000 tcp)         # 8 consumers, 8 streams, 1000 byte messages, 1000 messages per batch, 1000 message batches, tcp
+SMALL_BATCH_SEND=$(construct_bench_command "$IGGY_BENCH_CMD" "send" 8 1000 100 10000 tcp)    # 8 producers, 8 streams, 1000 byte messages, 100 messages per batch, 10000 message batches, tcp
+SMALL_BATCH_POLL=$(construct_bench_command "$IGGY_BENCH_CMD" "poll" 8 1000 100 10000 tcp)     # 8 consumers, 8 streams, 1000 byte messages, 100 messages per batch, 10000 message batches, tcp
+
+# SMALL_BATCH_SMALL_MSG_SEND=$(construct_bench_command "$IGGY_BENCH_CMD" "send" 8 20 100 500000 tcp)    # Uncomment and adjust if needed
+# SMALL_BATCH_SMALL_MSG_POLL=$(construct_bench_command "$IGGY_BENCH_CMD" "poll" 8 20 100 500000 tcp)  # Uncomment and adjust if needed
+# SINGLE_MESSAGE_BATCH_SMALL_MSG_SEND=$(construct_bench_command "$IGGY_BENCH_CMD" "send" 8 20 1 50000000 tcp)  # Uncomment and adjust if needed
+# SINGLE_MESSAGE_BATCH_SMALL_MSG_POLL=$(construct_bench_command "$IGGY_BENCH_CMD" "poll" 8 20 1 50000000 tcp)  # Uncomment and adjust if needed
+
+# Make an array of the suites
+SUITES=(
+    "${STANDARD_SEND}"
+    "${STANDARD_POLL}"
+    "${SMALL_BATCH_SEND}"
+    "${SMALL_BATCH_POLL}"
+    # "${SMALL_BATCH_SMALL_MSG_SEND}"
+    # "${SMALL_BATCH_SMALL_MSG_POLL}"
+)
+
+# Run the suites, iterate over two elements at a time
+for (( i=0; i<${#SUITES[@]} ; i+=2 )) ; do
+    SEND_BENCH="${SUITES[i]}"
+    POLL_BENCH="${SUITES[i+1]}"
+
+    # Remove old local_data
+    echo "Cleaning old local_data..."
+    rm -rf local_data || true
+
+    # Start iggy-server
+    echo "Starting iggy-server..."
+    target/release/iggy-server &> /dev/null &
+    sleep 2
+    echo
+
+    # Start send bench
+    echo "Running ${SEND_BENCH}"
+    send_results=$(eval "${SEND_BENCH}" | grep -e "Results:")
+    echo
+    echo "Send results:"
+    echo "${send_results}"
+    echo
+    sleep 1
+
+    # Start poll bench
+    echo "Running ${POLL_BENCH}"
+    poll_results=$(eval "${POLL_BENCH}" | grep -e "Results:")
+    echo
+    echo "Poll results:"
+    echo "${poll_results}"
+    echo
+    sleep 1
+
+    # Gracefully stop the server
+    echo "Stopping iggy-server..."
+    send_signal "iggy-server" "TERM"
+done
+
+exit 0

--- a/scripts/performance/utils.sh
+++ b/scripts/performance/utils.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+# Example bench command:
+# target/release/iggy-bench send --producers 8 --streams 8 --message-size 1000 --messages-per-batch 1000 --message-batches 1000 tcp
+
+COMMON_ARGS="--warmup-time 0"
+
+# Function to get the current git tag or commit
+function get_git_commit_or_tag() {
+    local dir=$1
+
+    if [ -d "$dir" ]; then
+        pushd "$dir" > /dev/null || exit 1
+
+        if git rev-parse --git-dir > /dev/null 2>&1; then
+            local commit_hash
+            commit_hash=$(git rev-parse --short HEAD)
+            local tag
+            tag=$(git describe --exact-match --tags HEAD 2> /dev/null)
+
+            popd > /dev/null || exit 1
+
+            if [ -n "$tag" ]; then
+                echo "$tag"
+            else
+                echo "$commit_hash"
+            fi
+        else
+            echo "Error: Not a git repository." >&2
+            popd > /dev/null || exit 1
+            return 1
+        fi
+    else
+        echo "Error: Directory '$dir' does not exist." >&2
+        return 1
+    fi
+}
+
+# Function to construct a bench command (send or poll)
+function construct_bench_command() {
+    local bench_command=$1
+    local type=$2
+    local count=$3
+    local message_size=$4
+    local messages_per_batch=$5
+    local message_batches=$6
+    local protocol=$7
+
+    # Validate the type
+    if [[ "$type" != "send" && "$type" != "poll" ]]; then
+        echo "Error: Invalid type '$type'. Must be 'send' or 'poll'." >&2
+        return 1
+    fi
+
+    # Set variables based on type
+    if [[ "$type" == "send" ]]; then
+        local role="producers"
+    else
+        local role="consumers"
+    fi
+
+    local streams=${count}
+
+    local superdir
+    superdir="performance_results_$(get_git_commit_or_tag .)" || { echo "Failed to get git commit or tag."; exit 1; }
+    local output_directory="${superdir}/${type}_${count}${type:0:1}_${message_size}_${messages_per_batch}_${message_batches}_${protocol}"
+
+    echo "$bench_command \
+    $COMMON_ARGS \
+    --output-directory $output_directory \
+    ${type} \
+    --${role} ${count} \
+    --streams ${streams} \
+    --message-size ${message_size} \
+    --messages-per-batch ${messages_per_batch} \
+    --message-batches ${message_batches} \
+    ${protocol}"
+}

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -180,11 +180,11 @@ wait_for_process "iggy-server" 10
 # Display results
 echo
 echo "Send results:"
-grep -e "Results: total throughput" "${BENCH_SEND_LOG_FILE}"
+grep -e "Results: " "${BENCH_SEND_LOG_FILE}"
 
 echo
 echo "Poll results:"
-grep -e "Results: total throughput" "${BENCH_POLL_LOG_FILE}"
+grep -e "Results: " "${BENCH_POLL_LOG_FILE}"
 
 echo
 echo "Flamegraph svg (send) saved to ${FLAMEGRAPH_SEND_SVG}"

--- a/scripts/run-benches.sh
+++ b/scripts/run-benches.sh
@@ -26,23 +26,25 @@ sleep 1
 
 # Start tcp send bench
 echo "Running iggy-bench send tcp..."
-send_results=$(target/release/iggy-bench send tcp | grep -e "Results: total throughput")
+send_results=$(target/release/iggy-bench send tcp | grep -e "Results:")
 sleep 1
-
-# Start tcp poll bench
-echo "Running iggy-bench poll tcp..."
-poll_results=$(target/release/iggy-bench poll tcp | grep -e "Results: total throughput")
-
-# Gracefully stop the server
-send_signal "iggy-server" "TERM"
 
 # Display results
 echo
 echo "Send results:"
 echo "${send_results}"
 echo
+
+# Start tcp poll bench
+echo "Running iggy-bench poll tcp..."
+poll_results=$(target/release/iggy-bench poll tcp | grep -e "Results: total throughput")
+
 echo "Poll results:"
 echo "${poll_results}"
 echo
+
+# Gracefully stop the server
+send_signal "iggy-server" "TERM"
+wait_for_process "iggy-server" 5
 
 exit 0


### PR DESCRIPTION
This commit is a base for future performance testing in CI.

- Set up GitHub workflow to run performance benchmarks on push to master
- Enhance benchmarking tools to collect and serialize detaile statistics,
  now iggy-bench can output data to csv and toml files
- Introduce scripts for executing standard performance suites
  and handling results - run-standard-performance-suite.sh
- Ensure performance results are properly cached and artifacts are uploaded

Desired outcome of whole feature is be able to present the results of
benchmarks in grafana.
