### PR TITLE
Use embedded defaults when iggy-server config file is absent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.81"
+version = "0.4.82"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -133,9 +133,11 @@ The official images can be found [here](https://hub.docker.com/r/iggyrs/iggy), s
 
 ## Configuration
 
-The default configuration can be found in `server.toml` (the default one) or `server.json` file in `configs` directory.
+The default configuration can be found in `server.toml` file in `configs` directory.
 
-The configuration file is loaded from the current working directory, but you can specify the path to the configuration file by setting `IGGY_CONFIG_PATH` environment variable, for example `export IGGY_CONFIG_PATH=configs/server.json` (or other command depending on OS).
+The configuration file is loaded from the current working directory, but you can specify the path to the configuration file by setting `IGGY_CONFIG_PATH` environment variable, for example `export IGGY_CONFIG_PATH=configs/server.toml` (or other command depending on OS).
+
+When config file is not found, the default values from embedded server.toml file are used.
 
 For the detailed documentation of the configuration file, please refer to the [configuration](https://docs.iggy.rs/server/configuration) section.
 
@@ -226,6 +228,7 @@ Iggy comes with the Rust SDK, which is available on [crates.io](https://crates.i
 The SDK provides both, low-level client for the specific transport, which includes the message sending and polling along with all the administrative actions such as managing the streams, topics, users etc., as well as the high-level client, which abstracts the low-level details and provides the easy-to-use API for both, message producers and consumers.
 
 You can find the more examples, including the multi-tenant one under the `examples` directory.
+
 ```rust
 // Create the Iggy client
 let client = IggyClient::from_connection_string("iggy://user:secret@localhost:8090")?;
@@ -246,17 +249,17 @@ producer.send(messages).await?;
 
 // Create a consumer for the given stream and one of its topics
 let mut consumer = client
-	.consumer_group("my_app", "dev01", "events")?
-	.auto_commit(AutoCommit::IntervalOrWhen(
-		IggyDuration::from_str("1s")?,
-		AutoCommitWhen::ConsumingAllMessages,
-	))
-	.create_consumer_group_if_not_exists()
-	.auto_join_consumer_group()
-	.polling_strategy(PollingStrategy::next())
-	.poll_interval(IggyDuration::from_str("1ms")?)
-	.batch_size(1000)
-	.build();
+    .consumer_group("my_app", "dev01", "events")?
+    .auto_commit(AutoCommit::IntervalOrWhen(
+        IggyDuration::from_str("1s")?,
+        AutoCommitWhen::ConsumingAllMessages,
+    ))
+    .create_consumer_group_if_not_exists()
+    .auto_join_consumer_group()
+    .polling_strategy(PollingStrategy::next())
+    .poll_interval(IggyDuration::from_str("1ms")?)
+    .batch_size(1000)
+    .build();
 
 consumer.init().await?;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.81"
+version = "0.4.82"
 edition = "2021"
 build = "src/build.rs"
 


### PR DESCRIPTION
Allow iggy-server to start without an external server.toml configuration file by using an embedded default configuration.

Changes:
- Embed the default configuration from server.toml into the executable using `include_str!`.
- Modify the configuration loading process to start with the embedded defaults.
- If a configuration file exists at the specified path, merge it to override the embedded defaults.
- Merge environment variables prefixed with `IGGY_` to override previous settings.

This enhancement allows the server to start with sensible defaults when no external configuration file is provided, improving ease of use and deployment.
