### PR TITLE
Improve materialize_batch_and_maybe_update_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4262,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.84"
+version = "0.4.85"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/streaming/batching/batch_accumulator.rs
+++ b/server/src/streaming/batching/batch_accumulator.rs
@@ -71,35 +71,35 @@ impl BatchAccumulator {
     pub fn materialize_batch_and_maybe_update_state(&mut self) -> (bool, RetainedMessageBatch) {
         let batch_base_offset = self.base_offset;
         let batch_last_offset_delta = (self.current_offset - self.base_offset) as u32;
-        let batch_max_timestamp = self.messages.last().unwrap().timestamp;
         let split_point = std::cmp::min(self.capacity as usize, self.messages.len());
-        let (batch, remainder) = self.messages.as_slice().split_at(split_point);
+
         let mut bytes = BytesMut::with_capacity(self.current_size.as_bytes_u64() as usize);
-        for message in batch {
+        let last_batch_timestamp = self
+            .messages
+            .get(split_point - 1)
+            .map_or(0, |msg| msg.timestamp);
+        for message in self.messages.drain(..split_point) {
             message.extend(&mut bytes);
         }
 
-        let mut remaining_messages = Vec::with_capacity(remainder.len());
-        let has_remainder = !remainder.is_empty();
+        let has_remainder = !self.messages.is_empty();
         if has_remainder {
-            self.base_offset = remainder.first().unwrap().offset;
-            self.current_size = remainder
+            self.base_offset = self.messages.first().unwrap().offset;
+            self.current_size = self
+                .messages
                 .iter()
                 .map(|msg| msg.get_size_bytes())
                 .sum::<IggyByteSize>();
-            self.current_offset = remainder.last().unwrap().offset;
-            self.current_timestamp = remainder.last().unwrap().timestamp;
-            for message in remainder {
-                remaining_messages.push(message.clone());
-            }
-            self.messages = remaining_messages;
+            self.current_offset = self.messages.last().unwrap().offset;
+            self.current_timestamp = self.messages.last().unwrap().timestamp;
         }
+
         let batch_payload = bytes.freeze();
         let batch_payload_len = IggyByteSize::from(batch_payload.len() as u64);
         let batch = RetainedMessageBatch::new(
             batch_base_offset,
             batch_last_offset_delta,
-            batch_max_timestamp,
+            last_batch_timestamp,
             batch_payload_len,
             batch_payload,
         );


### PR DESCRIPTION
Refactor materialize_batch_and_maybe_update_state to use drain for processing message batches, eliminating unnecessary copies of self.messages and enhancing performance.

Iggy bench results for **messages_required_to_save = 1**(via `cargo run --release --bin iggy-bench -- send tcp`)

new function:
```
2024-12-07T15:31:12.909732Z  INFO iggy_bench::benchmark_runner: Results: Total throughput: 971.09 MB/s, 948330 messages/s, average throughput: 97.11 MB/s, average p50 latency: 9.00 ms, average p90 latency: 17.96 ms, average p95 latency: 22.11 ms, average p99 latency: 31.07 ms, average p999 latency: 74.38 ms, average latency: 10.55 ms, median latency: 9.00 ms
```

old:
```
2024-12-07T15:24:44.084381Z  INFO iggy_bench::benchmark_runner: Results: Total throughput: 129.75 MB/s, 126708 messages/s, average throughput: 12.97 MB/s, average p50 latency: 35.13 ms, average p90 latency: 104.77 ms, average p95 latency: 283.10 ms, average p99 latency: 1101.02 ms, average p999 latency: 2727.17 ms, average latency: 78.92 ms, median latency: 35.13 ms
```

**messages_required_to_save=5000:**

new
```
5000 2024-12-08T05:26:41.258931Z  INFO iggy_bench::benchmark_runner: Results: Total throughput: 1678.50 MB/s, 1639159 messages/s, average throughput: 167.85 MB/s, average p50 latency: 4.16 ms, average p90 latency: 11.71 ms, average p95 latency: 15.38 ms, average p99 latency: 25.87 ms, average p999 latency: 88.84 ms, average latency: 6.10 ms, median latency: 4.16 ms
```

old:
```
2024-12-08T05:34:17.895922Z  INFO iggy_bench::benchmark_runner: Results: Total throughput: 1591.14 MB/s, 1553850 messages/s, average throughput: 159.11 MB/s, average p50 latency: 4.47 ms, average p90 latency: 13.01 ms, average p95 latency: 17.10 ms, average p99 latency: 28.18 ms, average p999 latency: 44.04 ms, average latency: 6.44 ms, median latency: 4.47 ms
```

The new function significantly improves performance for low values of messages_required_to_save, especially in throughput and latency. For higher values, the performance gap narrows