### PR TITLE
Add mimalloc support to iggy-server and make it default allocator for musl env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2670,6 +2680,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "mime"
@@ -4243,7 +4262,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.92"
+version = "0.4.93"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4268,6 +4287,7 @@ dependencies = [
  "futures",
  "iggy",
  "jsonwebtoken",
+ "mimalloc",
  "moka",
  "openssl",
  "opentelemetry",
@@ -4291,7 +4311,6 @@ dependencies = [
  "strum",
  "sysinfo 0.33.0",
  "thiserror 2.0.9",
- "tikv-jemallocator",
  "tokio",
  "tokio-native-tls",
  "toml",
@@ -4667,26 +4686,6 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "server"
-version = "0.4.92"
+version = "0.4.93"
 edition = "2021"
 build = "src/build.rs"
 
 [features]
 default = []
-jemalloc = ["dep:tikv-jemallocator"]
+mimalloc = ["dep:mimalloc"]
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dependencies]
@@ -90,7 +90,10 @@ xxhash-rust = { version = "0.8.12", features = ["xxh32"] }
 zip = "2.2.0"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", optional = true }
+mimalloc = { version = "0.1", optional = true }
+
+[target.'cfg(target_env = "musl")'.dependencies]
+mimalloc = { version = "0.1", features = ["override"] }
 
 [build-dependencies]
 figment = { version = "0.10.18", features = ["json", "toml", "env"] }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,12 +1,9 @@
-#[cfg(all(target_env = "msvc", feature = "jemalloc"))]
-compile_error!("'jemalloc' feature cannot be used when MSVC is being used");
+#[cfg(any(feature = "mimalloc", target_env = "musl"))]
+use mimalloc::MiMalloc;
 
-#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
-use tikv_jemallocator::Jemalloc;
-
-#[cfg(all(not(target_env = "msvc"), feature = "jemalloc"))]
+#[cfg(any(feature = "mimalloc", target_env = "musl"))]
 #[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+static GLOBAL: MiMalloc = MiMalloc;
 
 pub mod archiver;
 pub mod args;


### PR DESCRIPTION
This commit introduces support for the mimalloc allocator as an optional
feature in the server package. The Cargo.toml and Cargo.lock files have
been updated to include mimalloc and its dependencies. Additionally, the
server version is incremented to 0.4.93.

This closes #1347.
