### PR TITLE
Add "no_wait" mode for file synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,7 +4351,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.96"
+version = "0.4.100"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -464,7 +464,7 @@ message_expiry = "none"
 # Controls how the system waits for file write operations to complete.
 # Possible values:
 # - "wait": waits for the file operation to complete before proceeding.
-# - "nowait": proceeds without waiting for the file operation to finish, potentially increasing performance but at the cost of durability.
+# - "no_wait": proceeds without waiting for the file operation to finish, potentially increasing performance but at the cost of durability.
 server_confirmation = "wait"
 
 # Configures whether expired segments are archived (boolean) or just deleted without archiving.

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -338,6 +338,14 @@ path = "compatibility"
 # `false` allows the OS to manage write operations, which can improve performance.
 enforce_fsync = false
 
+# Maximum number of retries for a failed file operation (e.g., append, overwrite).
+# This defines how many times the system will attempt the operation before failing.
+max_file_operation_retries = 1
+
+# Delay between retries in case of a failed file operation.
+# This helps to avoid immediate repeated attempts and can reduce load.
+retry_delay = "1 s"
+
 # Runtime configuration.
 [system.runtime]
 # Path for storing runtime data.
@@ -451,6 +459,13 @@ size = "1 GB"
 # A time value in human-readable format determines the lifespan of messages.
 # Example: `message_expiry = "2 days 4 hours 15 minutes"` means messages will expire after that duration.
 message_expiry = "none"
+
+# Defines the file system confirmation behavior during state updates.
+# Controls how the system waits for file write operations to complete.
+# Possible values:
+# - "wait": waits for the file operation to complete before proceeding.
+# - "nowait": proceeds without waiting for the file operation to finish, potentially increasing performance but at the cost of durability.
+server_confirmation = "wait"
 
 # Configures whether expired segments are archived (boolean) or just deleted without archiving.
 archive_expired = false

--- a/integration/tests/streaming/messages.rs
+++ b/integration/tests/streaming/messages.rs
@@ -46,7 +46,8 @@ async fn should_persist_messages_and_then_load_them_by_timestamp() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU32::new(0)),
         IggyTimestamp::now(),
-    );
+    )
+    .await;
 
     let mut messages = Vec::with_capacity(messages_count as usize);
     let mut appended_messages = Vec::with_capacity(messages_count as usize);
@@ -119,12 +120,12 @@ async fn should_persist_messages_and_then_load_them_by_timestamp() {
         partition.partition_id,
     );
     partition
-        .append_messages(appendable_batch_info, messages)
+        .append_messages(appendable_batch_info, messages, None)
         .await
         .unwrap();
     let test_timestamp = IggyTimestamp::now();
     partition
-        .append_messages(appendable_batch_info_two, messages_two)
+        .append_messages(appendable_batch_info_two, messages_two, None)
         .await
         .unwrap();
 
@@ -183,7 +184,8 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU32::new(0)),
         IggyTimestamp::now(),
-    );
+    )
+    .await;
 
     let mut messages = Vec::with_capacity(messages_count as usize);
     let mut appended_messages = Vec::with_capacity(messages_count as usize);
@@ -229,7 +231,7 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         partition.partition_id,
     );
     partition
-        .append_messages(appendable_batch_info, messages)
+        .append_messages(appendable_batch_info, messages, None)
         .await
         .unwrap();
     assert_eq!(partition.unsaved_messages_count, 0);
@@ -249,7 +251,8 @@ async fn should_persist_messages_and_then_load_them_from_disk() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU32::new(0)),
         now,
-    );
+    )
+    .await;
     let partition_state = PartitionState {
         id: partition.partition_id,
         created_at: now,

--- a/integration/tests/streaming/partition.rs
+++ b/integration/tests/streaming/partition.rs
@@ -35,7 +35,8 @@ async fn should_persist_partition_with_segment() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
 
         partition.persist().await.unwrap();
 
@@ -66,7 +67,8 @@ async fn should_load_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.partition_path, with_segment).await;
 
@@ -85,7 +87,8 @@ async fn should_load_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             now,
-        );
+        )
+        .await;
         let partition_state = PartitionState {
             id: partition.partition_id,
             created_at: now,
@@ -139,7 +142,8 @@ async fn should_delete_existing_partition_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.partition_path, with_segment).await;
 
@@ -172,7 +176,8 @@ async fn should_purge_existing_partition_on_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
         partition.persist().await.unwrap();
         assert_persisted_partition(&partition.partition_path, with_segment).await;
         let messages = create_messages();
@@ -185,7 +190,7 @@ async fn should_purge_existing_partition_on_disk() {
             partition.partition_id,
         );
         partition
-            .append_messages(appendable_batch_info, messages)
+            .append_messages(appendable_batch_info, messages, None)
             .await
             .unwrap();
         let loaded_messages = partition.get_messages_by_offset(0, 100).await.unwrap();

--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -264,7 +264,7 @@ async fn should_persist_and_load_segment_with_messages_with_nowait_confirmation(
         .await
         .unwrap();
     segment
-        .persist_messages(Some(Confirmation::Nowait))
+        .persist_messages(Some(Confirmation::NoWait))
         .await
         .unwrap();
     sleep(Duration::from_millis(200)).await;

--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -1,6 +1,7 @@
 use crate::streaming::common::test_setup::TestSetup;
 use bytes::Bytes;
 use iggy::bytes_serializable::BytesSerializable;
+use iggy::confirmation::Confirmation;
 use iggy::models::messages::{MessageState, PolledMessage};
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::expiry::IggyExpiry;
@@ -11,7 +12,9 @@ use server::streaming::segments::segment;
 use server::streaming::segments::segment::{INDEX_EXTENSION, LOG_EXTENSION};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs;
+use tokio::time::sleep;
 
 #[tokio::test]
 async fn should_persist_segment() {
@@ -35,7 +38,8 @@ async fn should_persist_segment() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-        );
+        )
+        .await;
 
         setup
             .create_partition_directory(stream_id, topic_id, partition_id)
@@ -73,7 +77,8 @@ async fn should_load_existing_segment_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-        );
+        )
+        .await;
         setup
             .create_partition_directory(stream_id, topic_id, partition_id)
             .await;
@@ -100,7 +105,8 @@ async fn should_load_existing_segment_from_disk() {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
-        );
+        )
+        .await;
         loaded_segment.load().await.unwrap();
         let loaded_messages = loaded_segment.get_messages(0, 10).await.unwrap();
 
@@ -137,7 +143,8 @@ async fn should_persist_and_load_segment_with_messages() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
-    );
+    )
+    .await;
 
     setup
         .create_partition_directory(stream_id, topic_id, partition_id)
@@ -173,7 +180,7 @@ async fn should_persist_and_load_segment_with_messages() {
         .append_batch(batch_size, messages_count as u32, &messages)
         .await
         .unwrap();
-    segment.persist_messages().await.unwrap();
+    segment.persist_messages(None).await.unwrap();
     let mut loaded_segment = segment::Segment::create(
         stream_id,
         topic_id,
@@ -188,7 +195,95 @@ async fn should_persist_and_load_segment_with_messages() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
-    );
+    )
+    .await;
+    loaded_segment.load().await.unwrap();
+    let messages = loaded_segment
+        .get_messages(0, messages_count as u32)
+        .await
+        .unwrap();
+    assert_eq!(messages.len(), messages_count as usize);
+}
+
+#[tokio::test]
+async fn should_persist_and_load_segment_with_messages_with_nowait_confirmation() {
+    let setup = TestSetup::init().await;
+    let stream_id = 1;
+    let topic_id = 2;
+    let partition_id = 3;
+    let start_offset = 0;
+    let mut segment = segment::Segment::create(
+        stream_id,
+        topic_id,
+        partition_id,
+        start_offset,
+        setup.config.clone(),
+        setup.storage.clone(),
+        IggyExpiry::NeverExpire,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+    )
+    .await;
+
+    setup
+        .create_partition_directory(stream_id, topic_id, partition_id)
+        .await;
+    segment.persist().await.unwrap();
+    assert_persisted_segment(
+        &setup
+            .config
+            .get_partition_path(stream_id, topic_id, partition_id),
+        start_offset,
+    )
+    .await;
+    let messages_count = 10;
+    let mut messages = Vec::new();
+    let mut batch_size = IggyByteSize::default();
+    for i in 0..messages_count {
+        let message = create_message(i, "test", IggyTimestamp::now());
+
+        let retained_message = Arc::new(RetainedMessage {
+            id: message.id,
+            offset: message.offset,
+            timestamp: message.timestamp,
+            checksum: message.checksum,
+            message_state: message.state,
+            headers: message.headers.map(|headers| headers.to_bytes()),
+            payload: message.payload.clone(),
+        });
+        batch_size += retained_message.get_size_bytes();
+        messages.push(retained_message);
+    }
+
+    segment
+        .append_batch(batch_size, messages_count as u32, &messages)
+        .await
+        .unwrap();
+    segment
+        .persist_messages(Some(Confirmation::Nowait))
+        .await
+        .unwrap();
+    sleep(Duration::from_millis(200)).await;
+    let mut loaded_segment = segment::Segment::create(
+        stream_id,
+        topic_id,
+        partition_id,
+        start_offset,
+        setup.config.clone(),
+        setup.storage.clone(),
+        IggyExpiry::NeverExpire,
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+        Arc::new(AtomicU64::new(0)),
+    )
+    .await;
     loaded_segment.load().await.unwrap();
     let messages = loaded_segment
         .get_messages(0, messages_count as u32)
@@ -220,7 +315,8 @@ async fn given_all_expired_messages_segment_should_be_expired() {
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
-    );
+    )
+    .await;
 
     setup
         .create_partition_directory(stream_id, topic_id, partition_id)
@@ -258,7 +354,7 @@ async fn given_all_expired_messages_segment_should_be_expired() {
         .append_batch(batch_size, messages_count as u32, &messages)
         .await
         .unwrap();
-    segment.persist_messages().await.unwrap();
+    segment.persist_messages(None).await.unwrap();
 
     segment.is_closed = true;
     let is_expired = segment.is_expired(now).await;
@@ -288,7 +384,8 @@ async fn given_at_least_one_not_expired_message_segment_should_not_be_expired() 
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
         Arc::new(AtomicU64::new(0)),
-    );
+    )
+    .await;
 
     setup
         .create_partition_directory(stream_id, topic_id, partition_id)
@@ -343,7 +440,7 @@ async fn given_at_least_one_not_expired_message_segment_should_not_be_expired() 
         .append_batch(not_expired_message_size, 1, &not_expired_messages)
         .await
         .unwrap();
-    segment.persist_messages().await.unwrap();
+    segment.persist_messages(None).await.unwrap();
 
     let is_expired = segment.is_expired(now).await;
     assert!(!is_expired);

--- a/integration/tests/streaming/stream.rs
+++ b/integration/tests/streaming/stream.rs
@@ -134,7 +134,7 @@ async fn should_purge_existing_stream_on_disk() {
             .map(|msg| msg.get_size_bytes())
             .sum::<IggyByteSize>();
         topic
-            .append_messages(batch_size, Partitioning::partition_id(1), messages)
+            .append_messages(batch_size, Partitioning::partition_id(1), messages, None)
             .await
             .unwrap();
         let loaded_messages = topic

--- a/integration/tests/streaming/topic.rs
+++ b/integration/tests/streaming/topic.rs
@@ -42,6 +42,7 @@ async fn should_persist_topics_with_partitions_directories_and_info_file() {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap();
 
         topic.persist().await.unwrap();
@@ -79,6 +80,7 @@ async fn should_load_existing_topic_from_disk() {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap();
         topic.persist().await.unwrap();
         assert_persisted_topic(
@@ -98,7 +100,8 @@ async fn should_load_existing_topic_from_disk() {
             Arc::new(AtomicU32::new(0)),
             setup.config.clone(),
             setup.storage.clone(),
-        );
+        )
+        .await;
         let topic_state = TopicState {
             id: topic_id,
             name,
@@ -155,6 +158,7 @@ async fn should_delete_existing_topic_from_disk() {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap();
         topic.persist().await.unwrap();
         assert_persisted_topic(
@@ -194,6 +198,7 @@ async fn should_purge_existing_topic_on_disk() {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap();
         topic.persist().await.unwrap();
         assert_persisted_topic(
@@ -210,7 +215,7 @@ async fn should_purge_existing_topic_on_disk() {
             .map(|msg| msg.get_size_bytes())
             .sum::<IggyByteSize>();
         topic
-            .append_messages(batch_size, Partitioning::partition_id(1), messages)
+            .append_messages(batch_size, Partitioning::partition_id(1), messages, None)
             .await
             .unwrap();
         let loaded_messages = topic

--- a/integration/tests/streaming/topic_messages.rs
+++ b/integration/tests/streaming/topic_messages.rs
@@ -84,7 +84,7 @@ async fn assert_polling_messages(cache: CacheConfig, expect_enabled_cache: bool)
         .map(|m| m.get_size_bytes())
         .sum::<IggyByteSize>();
     topic
-        .append_messages(batch_size, partitioning, messages)
+        .append_messages(batch_size, partitioning, messages, None)
         .await
         .unwrap();
 
@@ -129,6 +129,7 @@ async fn given_key_none_messages_should_be_appended_to_the_next_partition_using_
                 batch_size,
                 partitioning.clone(),
                 vec![get_message(i as u128, &payload)],
+                None,
             )
             .await
             .unwrap();
@@ -154,6 +155,7 @@ async fn given_key_partition_id_messages_should_be_appended_to_the_chosen_partit
                 batch_size,
                 partitioning.clone(),
                 vec![get_message(i as u128, &payload)],
+                None,
             )
             .await
             .unwrap();
@@ -183,6 +185,7 @@ async fn given_key_messages_key_messages_should_be_appended_to_the_calculated_pa
                 batch_size,
                 partitioning,
                 vec![get_message(entity_id as u128, &payload)],
+                None,
             )
             .await
             .unwrap();
@@ -241,6 +244,7 @@ async fn init_topic(setup: &TestSetup, partitions_count: u32) -> Topic {
         MaxTopicSize::ServerDefault,
         1,
     )
+    .await
     .unwrap();
     topic.persist().await.unwrap();
     topic

--- a/sdk/src/confirmation.rs
+++ b/sdk/src/confirmation.rs
@@ -1,0 +1,32 @@
+use std::{fmt, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+pub enum Confirmation {
+    #[default]
+    Wait,
+    Nowait,
+}
+
+impl FromStr for Confirmation {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "wait" => Ok(Confirmation::Wait),
+            "nowait" => Ok(Confirmation::Nowait),
+            _ => Err(format!("Invalid confirmation type: {}", s)),
+        }
+    }
+}
+
+impl fmt::Display for Confirmation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Confirmation::Wait => "wait",
+            Confirmation::Nowait => "nowait",
+        };
+        write!(f, "{}", s)
+    }
+}

--- a/sdk/src/confirmation.rs
+++ b/sdk/src/confirmation.rs
@@ -1,32 +1,36 @@
-use std::{fmt, str::FromStr};
-
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString};
 
-#[derive(Clone, Default, Deserialize, Serialize, Debug)]
+#[derive(Clone, Copy, Debug, Default, Display, Serialize, Deserialize, EnumString, PartialEq)]
+#[strum(serialize_all = "snake_case")]
 pub enum Confirmation {
     #[default]
     Wait,
-    Nowait,
+    NoWait,
 }
 
-impl FromStr for Confirmation {
-    type Err = String;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "wait" => Ok(Confirmation::Wait),
-            "nowait" => Ok(Confirmation::Nowait),
-            _ => Err(format!("Invalid confirmation type: {}", s)),
-        }
+    #[test]
+    fn test_to_string() {
+        assert_eq!(Confirmation::Wait.to_string(), "wait");
+        assert_eq!(Confirmation::NoWait.to_string(), "no_wait");
     }
-}
 
-impl fmt::Display for Confirmation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let s = match self {
-            Confirmation::Wait => "wait",
-            Confirmation::Nowait => "nowait",
-        };
-        write!(f, "{}", s)
+    #[test]
+    fn test_from_str() {
+        assert_eq!(Confirmation::from_str("wait").unwrap(), Confirmation::Wait);
+        assert_eq!(
+            Confirmation::from_str("no_wait").unwrap(),
+            Confirmation::NoWait
+        );
+    }
+
+    #[test]
+    fn test_default() {
+        assert_eq!(Confirmation::default(), Confirmation::Wait);
     }
 }

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -13,6 +13,7 @@ pub mod client_provider;
 pub mod clients;
 pub mod command;
 pub mod compression;
+pub mod confirmation;
 pub mod consumer;
 pub mod consumer_groups;
 pub mod consumer_offsets;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.96"
+version = "0.4.100"
 edition = "2021"
 build = "src/build.rs"
 

--- a/server/src/binary/handlers/messages/send_messages_handler.rs
+++ b/server/src/binary/handlers/messages/send_messages_handler.rs
@@ -20,8 +20,9 @@ pub async fn handle(
     let topic_id = command.topic_id.clone();
     let partitioning = command.partitioning.clone();
     let messages = command.messages;
+    // TODO(haze): Add confirmation level after testing is complete
     system
-        .append_messages(session, stream_id, topic_id, partitioning, messages)
+        .append_messages(session, stream_id, topic_id, partitioning, messages, None)
         .await
         .with_error_context(|_| {
             format!(

--- a/server/src/configs/defaults.rs
+++ b/server/src/configs/defaults.rs
@@ -436,6 +436,12 @@ impl Default for SegmentConfig {
             cache_indexes: SERVER_CONFIG.system.segment.cache_indexes,
             message_expiry: SERVER_CONFIG.system.segment.message_expiry.parse().unwrap(),
             archive_expired: SERVER_CONFIG.system.segment.archive_expired,
+            server_confirmation: SERVER_CONFIG
+                .system
+                .segment
+                .server_confirmation
+                .parse()
+                .unwrap(),
         }
     }
 }
@@ -444,6 +450,9 @@ impl Default for StateConfig {
     fn default() -> StateConfig {
         StateConfig {
             enforce_fsync: SERVER_CONFIG.system.state.enforce_fsync,
+            max_file_operation_retries: SERVER_CONFIG.system.state.max_file_operation_retries
+                as u32,
+            retry_delay: SERVER_CONFIG.system.state.retry_delay.parse().unwrap(),
         }
     }
 }

--- a/server/src/configs/displays.rs
+++ b/server/src/configs/displays.rs
@@ -11,7 +11,7 @@ use crate::configs::{
     server::{MessageSaverConfig, ServerConfig},
     system::{
         CacheConfig, CompressionConfig, EncryptionConfig, LoggingConfig, PartitionConfig,
-        SegmentConfig, StreamConfig, SystemConfig, TopicConfig,
+        SegmentConfig, StateConfig, StreamConfig, SystemConfig, TopicConfig,
     },
     tcp::{TcpConfig, TcpSocketConfig, TcpTlsConfig},
 };
@@ -267,8 +267,8 @@ impl Display for SegmentConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{{ size_bytes: {}, cache_indexes: {}, message_expiry: {}, archive_expired: {} }}",
-            self.size, self.cache_indexes, self.message_expiry, self.archive_expired
+            "{{ size_bytes: {}, cache_indexes: {}, message_expiry: {}, archive_expired: {}, server_confirmation: {} }}",
+            self.size, self.cache_indexes, self.message_expiry, self.archive_expired, self.server_confirmation,
         )
     }
 }
@@ -336,6 +336,16 @@ impl Display for TelemetryLogsConfig {
     }
 }
 
+impl Display for StateConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{{ enforce_fsync: {}, max_file_operation_retries: {}, retry_delay: {} }}",
+            self.enforce_fsync, self.max_file_operation_retries, self.retry_delay,
+        )
+    }
+}
+
 impl Display for TelemetryTracesConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -350,7 +360,7 @@ impl Display for SystemConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
           f,
-          "{{ path: {}, logging: {}, cache: {}, stream: {}, topic: {}, partition: {}, segment: {}, encryption: {} }}",
+          "{{ path: {}, logging: {}, cache: {}, stream: {}, topic: {}, partition: {}, segment: {}, encryption: {}, state: {} }}",
           self.path,
           self.logging,
           self.cache,
@@ -358,7 +368,8 @@ impl Display for SystemConfig {
           self.topic,
           self.partition,
           self.segment,
-          self.encryption
+          self.encryption,
+          self.state,
       )
     }
 }

--- a/server/src/configs/system.rs
+++ b/server/src/configs/system.rs
@@ -1,4 +1,5 @@
 use crate::configs::resource_quota::MemoryResourceQuota;
+use iggy::confirmation::Confirmation;
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::expiry::IggyExpiry;
 use iggy::utils::topic_size::MaxTopicSize;
@@ -122,11 +123,17 @@ pub struct SegmentConfig {
     #[serde_as(as = "DisplayFromStr")]
     pub message_expiry: IggyExpiry,
     pub archive_expired: bool,
+    #[serde_as(as = "DisplayFromStr")]
+    pub server_confirmation: Confirmation,
 }
 
+#[serde_as]
 #[derive(Debug, Deserialize, Serialize)]
 pub struct StateConfig {
     pub enforce_fsync: bool,
+    pub max_file_operation_retries: u32,
+    #[serde_as(as = "DisplayFromStr")]
+    pub retry_delay: IggyDuration,
 }
 
 impl SystemConfig {

--- a/server/src/http/messages.rs
+++ b/server/src/http/messages.rs
@@ -84,6 +84,7 @@ async fn send_messages(
     let command_topic_id = command.topic_id;
     let partitioning = command.partitioning;
     let system = state.system.read().await;
+    // TODO(haze): Add confirmation level after testing is complete
     system
         .append_messages(
             &Session::stateless(identity.user_id, identity.ip_address),
@@ -91,6 +92,7 @@ async fn send_messages(
             command_topic_id,
             partitioning,
             messages,
+            None,
         )
         .await
         .with_error_context(|_| {

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -6,6 +6,7 @@ use crate::streaming::partitions::COMPONENT;
 use crate::streaming::polling_consumer::PollingConsumer;
 use crate::streaming::segments::segment::Segment;
 use error_set::ErrContext;
+use iggy::confirmation::Confirmation;
 use iggy::messages::send_messages::Message;
 use iggy::models::messages::POLLED_MESSAGE_METADATA;
 use iggy::utils::timestamp::IggyTimestamp;
@@ -406,6 +407,7 @@ impl Partition {
         &mut self,
         appendable_batch_info: AppendableBatchInfo,
         messages: Vec<Message>,
+        confirmation: Option<Confirmation>,
     ) -> Result<(), IggyError> {
         {
             let last_segment = self.segments.last_mut().ok_or(IggyError::SegmentNotFound)?;
@@ -518,7 +520,7 @@ impl Partition {
                     self.partition_id
                 );
 
-                last_segment.persist_messages().await.unwrap();
+                last_segment.persist_messages(confirmation).await.unwrap();
                 self.unsaved_messages_count = 0;
             }
         }
@@ -542,7 +544,7 @@ impl Partition {
         // Make sure all of the messages from the accumulator are persisted
         // no leftover from one round trip.
         while last_segment.unsaved_messages.is_some() {
-            last_segment.persist_messages().await.unwrap();
+            last_segment.persist_messages(None).await.unwrap();
         }
         self.unsaved_messages_count = 0;
         Ok(())
@@ -582,7 +584,7 @@ mod tests {
 
     #[tokio::test]
     async fn given_disabled_message_deduplication_all_messages_should_be_appended() {
-        let mut partition = create_partition(false);
+        let mut partition = create_partition(false).await;
         let messages = create_messages();
         let messages_count = messages.len() as u32;
         let appendable_batch_info = AppendableBatchInfo {
@@ -593,7 +595,7 @@ mod tests {
             partition_id: partition.partition_id,
         };
         partition
-            .append_messages(appendable_batch_info, messages)
+            .append_messages(appendable_batch_info, messages, None)
             .await
             .unwrap();
 
@@ -606,7 +608,7 @@ mod tests {
 
     #[tokio::test]
     async fn given_enabled_message_deduplication_only_messages_with_unique_id_should_be_appended() {
-        let mut partition = create_partition(true);
+        let mut partition = create_partition(true).await;
         let messages = create_messages();
         let messages_count = messages.len() as u32;
         let unique_messages_count = 3;
@@ -618,7 +620,7 @@ mod tests {
             partition_id: partition.partition_id,
         };
         partition
-            .append_messages(appendable_batch_info, messages)
+            .append_messages(appendable_batch_info, messages, None)
             .await
             .unwrap();
 
@@ -629,7 +631,7 @@ mod tests {
         assert_eq!(loaded_messages.len(), unique_messages_count);
     }
 
-    fn create_partition(deduplication_enabled: bool) -> Partition {
+    async fn create_partition(deduplication_enabled: bool) -> Partition {
         let storage = Arc::new(get_test_system_storage());
         let stream_id = 1;
         let topic_id = 2;
@@ -657,5 +659,6 @@ mod tests {
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
         )
+        .await
     }
 }

--- a/server/src/streaming/partitions/partition.rs
+++ b/server/src/streaming/partitions/partition.rs
@@ -69,7 +69,7 @@ impl ConsumerOffset {
 
 impl Partition {
     #[allow(clippy::too_many_arguments)]
-    pub fn create(
+    pub async fn create(
         stream_id: u32,
         topic_id: u32,
         partition_id: u32,
@@ -160,7 +160,8 @@ impl Partition {
                 partition.messages_count_of_parent_stream.clone(),
                 partition.messages_count_of_parent_topic.clone(),
                 partition.messages_count.clone(),
-            );
+            )
+            .await;
             partition.segments.push(segment);
             partition
                 .segments_count_of_parent_stream
@@ -202,8 +203,8 @@ mod tests {
     use std::sync::atomic::{AtomicU32, AtomicU64};
     use std::sync::Arc;
 
-    #[test]
-    fn should_be_created_with_a_single_segment_given_valid_parameters() {
+    #[tokio::test]
+    async fn should_be_created_with_a_single_segment_given_valid_parameters() {
         let storage = Arc::new(get_test_system_storage());
         let stream_id = 1;
         let topic_id = 2;
@@ -226,7 +227,8 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
 
         assert_eq!(partition.stream_id, stream_id);
         assert_eq!(partition.topic_id, topic_id);
@@ -243,8 +245,8 @@ mod tests {
         assert!(consumer_offsets.is_empty());
     }
 
-    #[test]
-    fn should_not_initialize_cache_given_zero_capacity() {
+    #[tokio::test]
+    async fn should_not_initialize_cache_given_zero_capacity() {
         let storage = Arc::new(get_test_system_storage());
         let partition = Partition::create(
             1,
@@ -266,12 +268,13 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
         assert!(partition.cache.is_none());
     }
 
-    #[test]
-    fn should_not_initialize_segments_given_false_with_segment_parameter() {
+    #[tokio::test]
+    async fn should_not_initialize_segments_given_false_with_segment_parameter() {
         let storage = Arc::new(get_test_system_storage());
         let topic_id = 1;
         let partition = Partition::create(
@@ -288,7 +291,8 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU32::new(0)),
             IggyTimestamp::now(),
-        );
+        )
+        .await;
         assert!(partition.segments.is_empty());
     }
 }

--- a/server/src/streaming/partitions/segments.rs
+++ b/server/src/streaming/partitions/segments.rs
@@ -63,7 +63,8 @@ impl Partition {
             self.messages_count_of_parent_stream.clone(),
             self.messages_count_of_parent_topic.clone(),
             self.messages_count.clone(),
-        );
+        )
+        .await;
         new_segment.persist().await.with_error_context(|_| {
             format!("{COMPONENT} - failed to persist new segment: {new_segment}",)
         })?;

--- a/server/src/streaming/partitions/storage.rs
+++ b/server/src/streaming/partitions/storage.rs
@@ -95,7 +95,8 @@ impl PartitionStorage for FilePartitionStorage {
                 partition.messages_count_of_parent_stream.clone(),
                 partition.messages_count_of_parent_topic.clone(),
                 partition.messages_count.clone(),
-            );
+            )
+            .await;
 
             let index_path = segment.index_path.to_owned();
             let log_path = segment.log_path.to_owned();

--- a/server/src/streaming/persistence/mod.rs
+++ b/server/src/streaming/persistence/mod.rs
@@ -1,3 +1,4 @@
 pub mod persister;
+pub mod task;
 
 pub const COMPONENT: &str = "STREAMING_PERSISTENCE";

--- a/server/src/streaming/persistence/task.rs
+++ b/server/src/streaming/persistence/task.rs
@@ -1,0 +1,116 @@
+use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::COMPONENT;
+use bytes::Bytes;
+use error_set::ErrContext;
+use flume::{unbounded, Receiver, Sender};
+use iggy::error::IggyError;
+use std::{sync::Arc, time::Duration};
+use tokio::task;
+use tracing::error;
+
+#[derive(Debug)]
+pub struct LogPersisterTask {
+    _sender: Option<Sender<Bytes>>,
+    _task_handle: Option<task::JoinHandle<()>>,
+}
+
+impl LogPersisterTask {
+    pub fn new(
+        path: String,
+        persister: Arc<dyn Persister>,
+        max_retries: u32,
+        retry_sleep: Duration,
+    ) -> Self {
+        let (sender, receiver): (Sender<Bytes>, Receiver<Bytes>) = unbounded();
+
+        let task_handle = task::spawn(async move {
+            loop {
+                match receiver.recv_async().await {
+                    Ok(data) => {
+                        if let Err(e) = Self::persist_with_retries(
+                            &path,
+                            &persister,
+                            data,
+                            max_retries,
+                            retry_sleep,
+                        )
+                        .await
+                        {
+                            error!("{COMPONENT} - Final failure to persist data: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        error!("{COMPONENT} - Error receiving data from channel: {}", e);
+                        return;
+                    }
+                }
+            }
+        });
+
+        LogPersisterTask {
+            _sender: Some(sender),
+            _task_handle: Some(task_handle),
+        }
+    }
+
+    async fn persist_with_retries(
+        path: &str,
+        persister: &Arc<dyn Persister>,
+        data: Bytes,
+        max_retries: u32,
+        retry_sleep: Duration,
+    ) -> Result<(), String> {
+        let mut retries = 0;
+
+        while retries < max_retries {
+            match persister.append(path, &data).await {
+                Ok(_) => return Ok(()),
+                Err(e) => {
+                    error!(
+                        "Could not append to persister (attempt {}): {}",
+                        retries + 1,
+                        e
+                    );
+                    retries += 1;
+                    tokio::time::sleep(retry_sleep).await;
+                }
+            }
+        }
+
+        Err(format!(
+            "{COMPONENT} - failed to persist data after {} retries",
+            max_retries
+        ))
+    }
+
+    pub async fn send(&self, data: Bytes) -> Result<(), IggyError> {
+        if let Some(sender) = &self._sender {
+            sender
+                .send_async(data)
+                .await
+                .with_error_context(|err| {
+                    format!("{COMPONENT} - failed to send data to async channel, err: {err}")
+                })
+                .map_err(|_| IggyError::CannotSaveMessagesToSegment)
+        } else {
+            Err(IggyError::CannotSaveMessagesToSegment)
+        }
+    }
+}
+
+impl Drop for LogPersisterTask {
+    fn drop(&mut self) {
+        self._sender.take();
+
+        if let Some(handle) = self._task_handle.take() {
+            tokio::spawn(async move {
+                if let Err(e) = handle.await {
+                    error!(
+                        "{COMPONENT} - error while shutting down task in Drop: {:?}",
+                        e
+                    );
+                }
+            });
+        }
+    }
+}

--- a/server/src/streaming/segments/index.rs
+++ b/server/src/streaming/segments/index.rs
@@ -84,7 +84,7 @@ mod tests {
     use std::sync::atomic::AtomicU64;
     use std::sync::Arc;
 
-    fn create_segment() -> Segment {
+    async fn create_segment() -> Segment {
         let storage = Arc::new(get_test_system_storage());
         let stream_id = 1;
         let topic_id = 2;
@@ -113,6 +113,7 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
             Arc::new(AtomicU64::new(0)),
         )
+        .await
     }
 
     fn create_test_indices(segment: &mut Segment) {
@@ -146,9 +147,9 @@ mod tests {
         segment.indexes.as_mut().unwrap().extend(indexes);
     }
 
-    #[test]
-    fn should_find_both_indices() {
-        let mut segment = create_segment();
+    #[tokio::test]
+    async fn should_find_both_indices() {
+        let mut segment = create_segment().await;
         create_test_indices(&mut segment);
         let result = segment
             .load_highest_lower_bound_index(segment.indexes.as_ref().unwrap(), 15, 45)
@@ -158,9 +159,9 @@ mod tests {
         assert_eq!(result.end.offset, 50);
     }
 
-    #[test]
-    fn start_and_end_index_should_be_equal() {
-        let mut segment = create_segment();
+    #[tokio::test]
+    async fn start_and_end_index_should_be_equal() {
+        let mut segment = create_segment().await;
         create_test_indices(&mut segment);
         let result_end_range = segment
             .load_highest_lower_bound_index(segment.indexes.as_ref().unwrap(), 65, 100)
@@ -176,9 +177,9 @@ mod tests {
         assert_eq!(result_start_range.end.offset, 5);
     }
 
-    #[test]
-    fn should_clamp_last_index_when_out_of_range() {
-        let mut segment = create_segment();
+    #[tokio::test]
+    async fn should_clamp_last_index_when_out_of_range() {
+        let mut segment = create_segment().await;
         create_test_indices(&mut segment);
         let result = segment
             .load_highest_lower_bound_index(segment.indexes.as_ref().unwrap(), 5, 100)
@@ -188,9 +189,9 @@ mod tests {
         assert_eq!(result.end.offset, 65);
     }
 
-    #[test]
-    fn should_return_err_when_both_indices_out_of_range() {
-        let mut segment = create_segment();
+    #[tokio::test]
+    async fn should_return_err_when_both_indices_out_of_range() {
+        let mut segment = create_segment().await;
         create_test_indices(&mut segment);
 
         let result =

--- a/server/src/streaming/segments/messages.rs
+++ b/server/src/streaming/segments/messages.rs
@@ -288,7 +288,7 @@ impl Segment {
         }
         let confirmation = match confirmation {
             Some(val) => val,
-            None => self.config.segment.server_confirmation.clone(),
+            None => self.config.segment.server_confirmation,
         };
         let saved_bytes = storage.save_batches(self, batch, confirmation).await?;
         storage.save_index(&self.index_path, index).await.with_error_context(|_| format!(

--- a/server/src/streaming/segments/messages.rs
+++ b/server/src/streaming/segments/messages.rs
@@ -5,6 +5,7 @@ use crate::streaming::models::messages::RetainedMessage;
 use crate::streaming::segments::index::{Index, IndexRange};
 use crate::streaming::segments::segment::Segment;
 use error_set::ErrContext;
+use iggy::confirmation::Confirmation;
 use iggy::error::IggyError;
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::sizeable::Sizeable;
@@ -254,7 +255,10 @@ impl Segment {
         index
     }
 
-    pub async fn persist_messages(&mut self) -> Result<usize, IggyError> {
+    pub async fn persist_messages(
+        &mut self,
+        confirmation: Option<Confirmation>,
+    ) -> Result<usize, IggyError> {
         let storage = self.storage.segment.clone();
         if self.unsaved_messages.is_none() {
             return Ok(0);
@@ -282,7 +286,11 @@ impl Segment {
         if has_remainder {
             self.unsaved_messages = Some(batch_accumulator);
         }
-        let saved_bytes = storage.save_batches(self, batch).await?;
+        let confirmation = match confirmation {
+            Some(val) => val,
+            None => self.config.segment.server_confirmation.clone(),
+        };
+        let saved_bytes = storage.save_batches(self, batch, confirmation).await?;
         storage.save_index(&self.index_path, index).await.with_error_context(|_| format!(
             "STREAMING_SEGMENT - failed to save index, stream ID: {}, topic ID: {}, partition ID: {}, path: {}",
             self.stream_id, self.topic_id, self.partition_id, self.index_path,

--- a/server/src/streaming/segments/storage.rs
+++ b/server/src/streaming/segments/storage.rs
@@ -267,7 +267,7 @@ impl SegmentStorage for FileSegmentStorage {
 
         let save_result = match confirmation {
             Confirmation::Wait => self.persister.append(&segment.log_path, &bytes).await,
-            Confirmation::Nowait => segment.persister_task.send(bytes.into()).await,
+            Confirmation::NoWait => segment.persister_task.send(bytes.into()).await,
         };
 
         save_result

--- a/server/src/streaming/streams/storage.rs
+++ b/server/src/streaming/streams/storage.rs
@@ -75,7 +75,8 @@ impl StreamStorage for FileStreamStorage {
                 stream.segments_count.clone(),
                 stream.config.clone(),
                 stream.storage.clone(),
-            );
+            )
+            .await;
             unloaded_topics.push(topic);
         }
 
@@ -115,7 +116,8 @@ impl StreamStorage for FileStreamStorage {
                     stream.segments_count.clone(),
                     stream.config.clone(),
                     stream.storage.clone(),
-                );
+                )
+                .await;
                 topic.persist().await.with_error_context(|_| {
                     format!("{COMPONENT} - failed to persist topic: {topic}")
                 })?;

--- a/server/src/streaming/streams/topics.rs
+++ b/server/src/streaming/streams/topics.rs
@@ -69,7 +69,8 @@ impl Stream {
             compression_algorithm,
             max_topic_size,
             replication_factor,
-        )?;
+        )
+        .await?;
         topic
             .persist()
             .await

--- a/server/src/streaming/systems/messages.rs
+++ b/server/src/streaming/systems/messages.rs
@@ -4,6 +4,7 @@ use crate::streaming::systems::system::System;
 use crate::streaming::systems::COMPONENT;
 use bytes::Bytes;
 use error_set::ErrContext;
+use iggy::confirmation::Confirmation;
 use iggy::consumer::Consumer;
 use iggy::messages::poll_messages::PollingStrategy;
 use iggy::messages::send_messages::Message;
@@ -103,6 +104,7 @@ impl System {
         topic_id: Identifier,
         partitioning: Partitioning,
         messages: Vec<Message>,
+        confirmation: Option<Confirmation>,
     ) -> Result<(), IggyError> {
         self.ensure_authenticated(session)?;
         let topic = self.find_topic(session, &stream_id, &topic_id).with_error_context(|_| format!("{COMPONENT} - topic not found for stream_id: {stream_id}, topic_id: {topic_id}"))?;
@@ -148,7 +150,7 @@ impl System {
         }
         let messages_count = messages.len() as u64;
         topic
-            .append_messages(batch_size_bytes, partitioning, messages)
+            .append_messages(batch_size_bytes, partitioning, messages, confirmation)
             .await?;
         self.metrics.increment_messages(messages_count);
         Ok(())

--- a/server/src/streaming/topics/consumer_groups.rs
+++ b/server/src/streaming/topics/consumer_groups.rs
@@ -211,7 +211,7 @@ mod tests {
     async fn should_be_created_given_valid_parameters() {
         let group_id = 1;
         let name = "test";
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         let topic_id = topic.topic_id;
         let result = topic.create_consumer_group(Some(group_id), name).await;
         assert!(result.is_ok());
@@ -240,7 +240,7 @@ mod tests {
     async fn should_not_be_created_given_already_existing_group_with_same_id() {
         let group_id = 1;
         let name = "test";
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         let result = topic.create_consumer_group(Some(group_id), name).await;
         assert!(result.is_ok());
         assert_eq!(topic.consumer_groups.len(), 1);
@@ -255,7 +255,7 @@ mod tests {
     async fn should_not_be_created_given_already_existing_group_with_same_name() {
         let group_id = 1;
         let name = "test";
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         let result = topic.create_consumer_group(Some(group_id), name).await;
         assert!(result.is_ok());
         assert_eq!(topic.consumer_groups.len(), 1);
@@ -274,7 +274,7 @@ mod tests {
     async fn should_be_deleted_given_already_existing_group_with_same_id() {
         let group_id = 1;
         let name = "test";
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         let result = topic.create_consumer_group(Some(group_id), name).await;
         assert!(result.is_ok());
         assert_eq!(topic.consumer_groups.len(), 1);
@@ -289,7 +289,7 @@ mod tests {
     async fn should_not_be_deleted_given_non_existing_group_with_same_id() {
         let group_id = 1;
         let name = "test";
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         let result = topic.create_consumer_group(Some(group_id), name).await;
         assert!(result.is_ok());
         assert_eq!(topic.consumer_groups.len(), 1);
@@ -306,7 +306,7 @@ mod tests {
         let group_id = 1;
         let name = "test";
         let member_id = 1;
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         topic
             .create_consumer_group(Some(group_id), name)
             .await
@@ -329,7 +329,7 @@ mod tests {
         let group_id = 1;
         let name = "test";
         let member_id = 1;
-        let mut topic = get_topic();
+        let mut topic = get_topic().await;
         topic
             .create_consumer_group(Some(group_id), name)
             .await
@@ -351,7 +351,7 @@ mod tests {
         assert!(members.is_empty())
     }
 
-    fn get_topic() -> Topic {
+    async fn get_topic() -> Topic {
         let storage = Arc::new(get_test_system_storage());
         let stream_id = 1;
         let id = 2;
@@ -378,6 +378,7 @@ mod tests {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap()
     }
 }

--- a/server/src/streaming/topics/partitions.rs
+++ b/server/src/streaming/topics/partitions.rs
@@ -18,7 +18,7 @@ impl Topic {
         self.partitions.len() as u32
     }
 
-    pub fn add_partitions(&mut self, count: u32) -> Result<Vec<u32>, IggyError> {
+    pub async fn add_partitions(&mut self, count: u32) -> Result<Vec<u32>, IggyError> {
         if count == 0 {
             return Ok(vec![]);
         }
@@ -44,7 +44,8 @@ impl Topic {
                 self.size_bytes.clone(),
                 self.segments_count_of_parent_stream.clone(),
                 IggyTimestamp::now(),
-            );
+            )
+            .await;
             self.partitions
                 .insert(partition_id, IggySharedMut::new(partition));
             partition_ids.push(partition_id)
@@ -54,7 +55,7 @@ impl Topic {
     }
 
     pub async fn add_persisted_partitions(&mut self, count: u32) -> Result<Vec<u32>, IggyError> {
-        let partition_ids = self.add_partitions(count).with_error_context(|_| {
+        let partition_ids = self.add_partitions(count).await.with_error_context(|_| {
             format!("{COMPONENT} - failed to add partitions, count: {count}")
         })?;
         for partition_id in &partition_ids {

--- a/server/src/streaming/topics/persistence.rs
+++ b/server/src/streaming/topics/persistence.rs
@@ -36,7 +36,7 @@ impl Topic {
             let mut partition = partition.write().await;
             let partition_id = partition.partition_id;
             for segment in partition.get_segments_mut() {
-                saved_messages_number += segment.persist_messages().await.with_error_context(|_| format!("{COMPONENT} - failed to persist messages in segment, partition ID: {partition_id}"))?;
+                saved_messages_number += segment.persist_messages(None).await.with_error_context(|_| format!("{COMPONENT} - failed to persist messages in segment, partition ID: {partition_id}"))?;
             }
         }
 

--- a/server/src/streaming/topics/storage.rs
+++ b/server/src/streaming/topics/storage.rs
@@ -96,7 +96,8 @@ impl TopicStorage for FileTopicStorage {
                 topic.size_bytes.clone(),
                 topic.segments_count_of_parent_stream.clone(),
                 partition_state.created_at,
-            );
+            )
+            .await;
             unloaded_partitions.push(partition);
         }
 
@@ -149,7 +150,8 @@ impl TopicStorage for FileTopicStorage {
                     topic.size_bytes.clone(),
                     topic.segments_count_of_parent_stream.clone(),
                     partition_state.created_at,
-                );
+                )
+                .await;
                 partition.persist().await.with_error_context(|_| {
                     format!("{COMPONENT} - failed to persist partiton: {partition}")
                 })?;

--- a/server/src/streaming/topics/topic.rs
+++ b/server/src/streaming/topics/topic.rs
@@ -49,7 +49,7 @@ pub struct Topic {
 
 impl Topic {
     #[allow(clippy::too_many_arguments)]
-    pub fn empty(
+    pub async fn empty(
         stream_id: u32,
         topic_id: u32,
         name: &str,
@@ -74,11 +74,12 @@ impl Topic {
             MaxTopicSize::ServerDefault,
             1,
         )
+        .await
         .unwrap()
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn create(
+    pub async fn create(
         stream_id: u32,
         topic_id: u32,
         name: &str,
@@ -125,7 +126,7 @@ impl Topic {
             message_expiry, topic.message_expiry
         );
 
-        topic.add_partitions(partitions_count)?;
+        topic.add_partitions(partitions_count).await?;
         Ok(topic)
     }
 
@@ -296,6 +297,7 @@ mod tests {
             max_topic_size,
             replication_factor,
         )
+        .await
         .unwrap();
 
         assert_eq!(topic.stream_id, stream_id);


### PR DESCRIPTION
This PR introduces a new "no_wait" mode to the file synchronization process. The "nowait" mode allows file operations to proceed without waiting for certain synchronization steps to complete, improving performance in scenarios where blocking is unnecessary