### PR TITLE
Refactor: Replace dyn Trait with Enum for Encryptor and Persister Types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "dtoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1695,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "fs_extra"
@@ -2318,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.71"
+version = "0.6.80"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -2820,6 +2832,32 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4342,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.112"
+version = "0.4.120"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4368,6 +4406,7 @@ dependencies = [
  "iggy",
  "jsonwebtoken",
  "mimalloc",
+ "mockall",
  "moka",
  "openssl",
  "opentelemetry",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,7 +65,7 @@ use iggy::cli::{
 use iggy::cli_command::{CliCommand, PRINT_TARGET};
 use iggy::client_provider::{self, ClientProviderConfig};
 use iggy::clients::client::IggyClient;
-use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
+use iggy::utils::crypto::{Aes256GcmEncryptor, EncryptorKind};
 use iggy::utils::personal_access_token_expiry::PersonalAccessTokenExpiry;
 use std::sync::Arc;
 use tracing::{event, Level};
@@ -339,11 +339,11 @@ async fn main() -> Result<(), IggyCmdError> {
     // Create credentials based on command line arguments and command
     let mut credentials = IggyCredentials::new(&cli_options, &iggy_args, command.login_required())?;
 
-    let encryptor: Option<Arc<dyn Encryptor>> = match iggy_args.encryption_key.is_empty() {
+    let encryptor = match iggy_args.encryption_key.is_empty() {
         true => None,
-        false => Some(Arc::new(
+        false => Some(Arc::new(EncryptorKind::Aes256Gcm(
             Aes256GcmEncryptor::from_base64_key(&iggy_args.encryption_key).unwrap(),
-        )),
+        ))),
     };
     let client_provider_config = Arc::new(ClientProviderConfig::from_args_set_autologin(
         iggy_args.clone(),

--- a/integration/tests/state/mod.rs
+++ b/integration/tests/state/mod.rs
@@ -1,6 +1,6 @@
-use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
+use iggy::utils::crypto::{Aes256GcmEncryptor, EncryptorKind};
 use server::state::file::FileState;
-use server::streaming::persistence::persister::FilePersister;
+use server::streaming::persistence::persister::{FilePersister, PersisterKind};
 use server::versioning::SemanticVersion;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -31,11 +31,12 @@ impl StateSetup {
         create_dir(&directory_path).await.unwrap();
 
         let version = SemanticVersion::from_str("1.2.3").unwrap();
-        let persister = FilePersister {};
-        let encryptor: Option<Arc<dyn Encryptor>> = match encryption_key {
-            Some(key) => Some(Arc::new(Aes256GcmEncryptor::new(key).unwrap())),
-            None => None,
-        };
+        let persister = PersisterKind::File(FilePersister {});
+        let encryptor = encryption_key.map(|key| {
+            Arc::new(EncryptorKind::Aes256Gcm(
+                Aes256GcmEncryptor::new(key).unwrap(),
+            ))
+        });
         let state = FileState::new(&log_path, &version, Arc::new(persister), encryptor);
 
         Self {

--- a/integration/tests/streaming/common/test_setup.rs
+++ b/integration/tests/streaming/common/test_setup.rs
@@ -1,5 +1,5 @@
 use server::configs::system::SystemConfig;
-use server::streaming::persistence::persister::FilePersister;
+use server::streaming::persistence::persister::{FilePersister, PersisterKind};
 use server::streaming::storage::SystemStorage;
 use std::sync::Arc;
 use tokio::fs;
@@ -20,7 +20,7 @@ impl TestSetup {
 
         let config = Arc::new(config);
         fs::create_dir(config.get_system_path()).await.unwrap();
-        let persister = FilePersister {};
+        let persister = PersisterKind::File(FilePersister {});
         let storage = Arc::new(SystemStorage::new(config.clone(), Arc::new(persister)));
         TestSetup { config, storage }
     }

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.71"
+version = "0.6.80"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"

--- a/sdk/src/clients/builder.rs
+++ b/sdk/src/clients/builder.rs
@@ -8,7 +8,7 @@ use crate::quic::client::QuicClient;
 use crate::quic::config::QuicClientConfigBuilder;
 use crate::tcp::client::TcpClient;
 use crate::tcp::config::TcpClientConfigBuilder;
-use crate::utils::crypto::Encryptor;
+use crate::utils::crypto::EncryptorKind;
 use crate::utils::duration::IggyDuration;
 use std::sync::Arc;
 use tracing::error;
@@ -18,7 +18,7 @@ use tracing::error;
 pub struct IggyClientBuilder {
     client: Option<Box<dyn Client>>,
     partitioner: Option<Arc<dyn Partitioner>>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
 }
 
 impl IggyClientBuilder {
@@ -49,7 +49,7 @@ impl IggyClientBuilder {
     }
 
     /// Use the custom encryptor implementation.
-    pub fn with_encryptor(mut self, encryptor: Arc<dyn Encryptor>) -> Self {
+    pub fn with_encryptor(mut self, encryptor: Arc<EncryptorKind>) -> Self {
         self.encryptor = Some(encryptor);
         self
     }

--- a/sdk/src/clients/client.rs
+++ b/sdk/src/clients/client.rs
@@ -31,7 +31,7 @@ use crate::partitioner::Partitioner;
 use crate::snapshot::{SnapshotCompression, SystemSnapshotType};
 use crate::tcp::client::TcpClient;
 use crate::utils::byte_size::IggyByteSize;
-use crate::utils::crypto::Encryptor;
+use crate::utils::crypto::EncryptorKind;
 use crate::utils::duration::IggyDuration;
 use crate::utils::expiry::IggyExpiry;
 use crate::utils::personal_access_token_expiry::PersonalAccessTokenExpiry;
@@ -55,7 +55,7 @@ use tracing::{debug, error, info};
 pub struct IggyClient {
     client: IggySharedMut<Box<dyn Client>>,
     partitioner: Option<Arc<dyn Partitioner>>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
 }
 
 impl Default for IggyClient {
@@ -96,7 +96,7 @@ impl IggyClient {
     pub fn create(
         client: Box<dyn Client>,
         partitioner: Option<Arc<dyn Partitioner>>,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        encryptor: Option<Arc<EncryptorKind>>,
     ) -> Self {
         if partitioner.is_some() {
             info!("Partitioner is enabled.");

--- a/sdk/src/clients/consumer.rs
+++ b/sdk/src/clients/consumer.rs
@@ -7,7 +7,7 @@ use crate::locking::{IggySharedMut, IggySharedMutFn};
 use crate::messages::poll_messages::{PollingKind, PollingStrategy};
 use crate::models::messages::{PolledMessage, PolledMessages};
 use crate::utils::byte_size::IggyByteSize;
-use crate::utils::crypto::Encryptor;
+use crate::utils::crypto::EncryptorKind;
 use crate::utils::duration::IggyDuration;
 use crate::utils::timestamp::IggyTimestamp;
 use bytes::Bytes;
@@ -81,7 +81,7 @@ pub struct IggyConsumer {
     current_offsets: Arc<DashMap<u32, AtomicU64>>,
     poll_future: Option<PollMessagesFuture>,
     buffered_messages: VecDeque<PolledMessage>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
     store_offset_sender: flume::Sender<(u32, u64)>,
     store_offset_after_each_message: bool,
     store_offset_after_all_messages: bool,
@@ -107,7 +107,7 @@ impl IggyConsumer {
         auto_commit: AutoCommit,
         auto_join_consumer_group: bool,
         create_consumer_group_if_not_exists: bool,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        encryptor: Option<Arc<EncryptorKind>>,
         retry_interval: IggyDuration,
         allow_replay: bool,
     ) -> Self {
@@ -866,7 +866,7 @@ pub struct IggyConsumerBuilder {
     auto_commit: AutoCommit,
     auto_join_consumer_group: bool,
     create_consumer_group_if_not_exists: bool,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
     retry_interval: IggyDuration,
     allow_replay: bool,
 }
@@ -880,7 +880,7 @@ impl IggyConsumerBuilder {
         stream_id: Identifier,
         topic_id: Identifier,
         partition_id: Option<u32>,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        encryptor: Option<Arc<EncryptorKind>>,
         polling_interval: Option<IggyDuration>,
     ) -> Self {
         Self {
@@ -990,7 +990,7 @@ impl IggyConsumerBuilder {
     }
 
     /// Sets the encryptor for decrypting the messages' payloads.
-    pub fn encryptor(self, encryptor: Arc<dyn Encryptor>) -> Self {
+    pub fn encryptor(self, encryptor: Arc<EncryptorKind>) -> Self {
         Self {
             encryptor: Some(encryptor),
             ..self

--- a/sdk/src/clients/producer.rs
+++ b/sdk/src/clients/producer.rs
@@ -6,7 +6,7 @@ use crate::identifier::{IdKind, Identifier};
 use crate::locking::{IggySharedMut, IggySharedMutFn};
 use crate::messages::send_messages::{Message, Partitioning};
 use crate::partitioner::Partitioner;
-use crate::utils::crypto::Encryptor;
+use crate::utils::crypto::EncryptorKind;
 use crate::utils::duration::IggyDuration;
 use crate::utils::expiry::IggyExpiry;
 use crate::utils::timestamp::IggyTimestamp;
@@ -35,7 +35,7 @@ pub struct IggyProducer {
     topic_name: String,
     batch_size: Option<usize>,
     partitioning: Option<Arc<Partitioning>>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
     partitioner: Option<Arc<dyn Partitioner>>,
     send_interval_micros: u64,
     create_stream_if_not_exists: bool,
@@ -60,7 +60,7 @@ impl IggyProducer {
         topic_name: String,
         batch_size: Option<usize>,
         partitioning: Option<Partitioning>,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        encryptor: Option<Arc<EncryptorKind>>,
         partitioner: Option<Arc<dyn Partitioner>>,
         interval: Option<IggyDuration>,
         create_stream_if_not_exists: bool,
@@ -423,7 +423,7 @@ pub struct IggyProducerBuilder {
     topic_name: String,
     batch_size: Option<usize>,
     partitioning: Option<Partitioning>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    encryptor: Option<Arc<EncryptorKind>>,
     partitioner: Option<Arc<dyn Partitioner>>,
     send_interval: Option<IggyDuration>,
     create_stream_if_not_exists: bool,
@@ -443,7 +443,7 @@ impl IggyProducerBuilder {
         stream_name: String,
         topic: Identifier,
         topic_name: String,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        encryptor: Option<Arc<EncryptorKind>>,
         partitioner: Option<Arc<dyn Partitioner>>,
     ) -> Self {
         Self {
@@ -514,7 +514,7 @@ impl IggyProducerBuilder {
     }
 
     /// Sets the encryptor for encrypting the messages' payloads.
-    pub fn encryptor(self, encryptor: Arc<dyn Encryptor>) -> Self {
+    pub fn encryptor(self, encryptor: Arc<EncryptorKind>) -> Self {
         Self {
             encryptor: Some(encryptor),
             ..self

--- a/sdk/src/utils/crypto.rs
+++ b/sdk/src/utils/crypto.rs
@@ -5,7 +5,25 @@ use aes_gcm::aead::{Aead, OsRng};
 use aes_gcm::{AeadCore, Aes256Gcm, KeyInit};
 use std::fmt::Debug;
 
-pub trait Encryptor: Send + Sync + Debug {
+#[derive(Debug)]
+pub enum EncryptorKind {
+    Aes256Gcm(Aes256GcmEncryptor),
+}
+
+impl EncryptorKind {
+    pub fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, IggyError> {
+        match self {
+            EncryptorKind::Aes256Gcm(e) => e.encrypt(data),
+        }
+    }
+    pub fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, IggyError> {
+        match self {
+            EncryptorKind::Aes256Gcm(e) => e.decrypt(data),
+        }
+    }
+}
+
+pub trait Encryptor {
     fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, IggyError>;
     fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, IggyError>;
 }
@@ -13,9 +31,6 @@ pub trait Encryptor: Send + Sync + Debug {
 pub struct Aes256GcmEncryptor {
     cipher: Aes256Gcm,
 }
-
-unsafe impl Send for Aes256GcmEncryptor {}
-unsafe impl Sync for Aes256GcmEncryptor {}
 
 impl Debug for Aes256GcmEncryptor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.112"
+version = "0.4.120"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"
@@ -89,6 +89,9 @@ ulid = "1.1.3"
 uuid = { version = "1.11.0", features = ["v7", "fast-rng", "zerocopy"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh32"] }
 zip = "2.2.2"
+
+[dev-dependencies]
+mockall = "0.13.1"
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 mimalloc = { version = "0.1", optional = true }

--- a/server/src/http/jwt/jwt_manager.rs
+++ b/server/src/http/jwt/jwt_manager.rs
@@ -2,7 +2,7 @@ use crate::configs::http::HttpJwtConfig;
 use crate::http::jwt::json_web_token::{GeneratedToken, JwtClaims, RevokedAccessToken};
 use crate::http::jwt::storage::TokenStorage;
 use crate::http::jwt::COMPONENT;
-use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::persister::PersisterKind;
 use error_set::ErrContext;
 use iggy::error::IggyError;
 use iggy::locking::IggySharedMut;
@@ -42,7 +42,7 @@ pub struct JwtManager {
 
 impl JwtManager {
     pub fn new(
-        persister: Arc<dyn Persister>,
+        persister: Arc<PersisterKind>,
         path: &str,
         issuer: IssuerOptions,
         validator: ValidatorOptions,
@@ -64,7 +64,7 @@ impl JwtManager {
     }
 
     pub fn from_config(
-        persister: Arc<dyn Persister>,
+        persister: Arc<PersisterKind>,
         path: &str,
         config: &HttpJwtConfig,
     ) -> Result<Self, IggyError> {

--- a/server/src/http/jwt/storage.rs
+++ b/server/src/http/jwt/storage.rs
@@ -1,7 +1,8 @@
-use crate::http::jwt::json_web_token::RevokedAccessToken;
 use crate::http::jwt::COMPONENT;
-use crate::streaming::persistence::persister::Persister;
 use crate::streaming::utils::file;
+use crate::{
+    http::jwt::json_web_token::RevokedAccessToken, streaming::persistence::persister::PersisterKind,
+};
 use anyhow::Context;
 use bytes::{BufMut, BytesMut};
 use error_set::ErrContext;
@@ -13,12 +14,12 @@ use tracing::{error, info};
 
 #[derive(Debug)]
 pub struct TokenStorage {
-    persister: Arc<dyn Persister>,
+    persister: Arc<PersisterKind>,
     path: String,
 }
 
 impl TokenStorage {
-    pub fn new(persister: Arc<dyn Persister>, path: &str) -> Self {
+    pub fn new(persister: Arc<PersisterKind>, path: &str) -> Self {
         Self {
             persister,
             path: path.to_owned(),

--- a/server/src/state/file.rs
+++ b/server/src/state/file.rs
@@ -1,6 +1,6 @@
 use crate::state::command::EntryCommand;
 use crate::state::{State, StateEntry, COMPONENT};
-use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::persister::PersisterKind;
 use crate::streaming::utils::file;
 use crate::versioning::SemanticVersion;
 use async_trait::async_trait;
@@ -9,7 +9,7 @@ use error_set::ErrContext;
 use iggy::bytes_serializable::BytesSerializable;
 use iggy::error::IggyError;
 use iggy::utils::byte_size::IggyByteSize;
-use iggy::utils::crypto::Encryptor;
+use iggy::utils::crypto::EncryptorKind;
 use iggy::utils::timestamp::IggyTimestamp;
 use std::fmt::Debug;
 use std::path::Path;
@@ -29,16 +29,16 @@ pub struct FileState {
     term: AtomicU64,
     version: u32,
     path: String,
-    persister: Arc<dyn Persister>,
-    encryptor: Option<Arc<dyn Encryptor>>,
+    persister: Arc<PersisterKind>,
+    encryptor: Option<Arc<EncryptorKind>>,
 }
 
 impl FileState {
     pub fn new(
         path: &str,
         version: &SemanticVersion,
-        persister: Arc<dyn Persister>,
-        encryptor: Option<Arc<dyn Encryptor>>,
+        persister: Arc<PersisterKind>,
+        encryptor: Option<Arc<EncryptorKind>>,
     ) -> Self {
         Self {
             current_index: AtomicU64::new(0),

--- a/server/src/streaming/partitions/storage.rs
+++ b/server/src/streaming/partitions/storage.rs
@@ -3,7 +3,7 @@ use crate::state::system::PartitionState;
 use crate::streaming::batching::batch_accumulator::BatchAccumulator;
 use crate::streaming::partitions::partition::{ConsumerOffset, Partition};
 use crate::streaming::partitions::COMPONENT;
-use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::persister::PersisterKind;
 use crate::streaming::segments::segment::{Segment, INDEX_EXTENSION, LOG_EXTENSION};
 use crate::streaming::storage::PartitionStorage;
 use crate::streaming::utils::file;
@@ -22,11 +22,11 @@ use tracing::{error, info, trace, warn};
 
 #[derive(Debug)]
 pub struct FilePartitionStorage {
-    persister: Arc<dyn Persister>,
+    persister: Arc<PersisterKind>,
 }
 
 impl FilePartitionStorage {
-    pub fn new(persister: Arc<dyn Persister>) -> Self {
+    pub fn new(persister: Arc<PersisterKind>) -> Self {
         Self { persister }
     }
 }

--- a/server/src/streaming/persistence/task.rs
+++ b/server/src/streaming/persistence/task.rs
@@ -1,4 +1,3 @@
-use crate::streaming::persistence::persister::Persister;
 use crate::streaming::persistence::COMPONENT;
 use bytes::Bytes;
 use error_set::ErrContext;
@@ -7,6 +6,8 @@ use iggy::error::IggyError;
 use std::{sync::Arc, time::Duration};
 use tokio::task;
 use tracing::error;
+
+use super::persister::PersisterKind;
 
 #[derive(Debug)]
 pub struct LogPersisterTask {
@@ -17,7 +18,7 @@ pub struct LogPersisterTask {
 impl LogPersisterTask {
     pub fn new(
         path: String,
-        persister: Arc<dyn Persister>,
+        persister: Arc<PersisterKind>,
         max_retries: u32,
         retry_sleep: Duration,
     ) -> Self {
@@ -55,7 +56,7 @@ impl LogPersisterTask {
 
     async fn persist_with_retries(
         path: &str,
-        persister: &Arc<dyn Persister>,
+        persister: &Arc<PersisterKind>,
         data: Bytes,
         max_retries: u32,
         retry_sleep: Duration,

--- a/server/src/streaming/segments/storage.rs
+++ b/server/src/streaming/segments/storage.rs
@@ -1,7 +1,7 @@
 use crate::streaming::batching::iterator::IntoMessagesIterator;
 use crate::streaming::batching::message_batch::RetainedMessageBatch;
 use crate::streaming::models::messages::RetainedMessage;
-use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::persister::PersisterKind;
 use crate::streaming::segments::index::{Index, IndexRange};
 use crate::streaming::segments::segment::Segment;
 use crate::streaming::segments::COMPONENT;
@@ -29,11 +29,11 @@ const BUF_READER_CAPACITY_BYTES: usize = 512 * 1000;
 
 #[derive(Debug)]
 pub struct FileSegmentStorage {
-    persister: Arc<dyn Persister>,
+    persister: Arc<PersisterKind>,
 }
 
 impl FileSegmentStorage {
-    pub fn new(persister: Arc<dyn Persister>) -> Self {
+    pub fn new(persister: Arc<PersisterKind>) -> Self {
         Self { persister }
     }
 }
@@ -594,7 +594,7 @@ impl SegmentStorage for FileSegmentStorage {
         }
     }
 
-    fn persister(&self) -> Arc<dyn Persister> {
+    fn persister(&self) -> Arc<PersisterKind> {
         self.persister.clone()
     }
 }

--- a/server/src/streaming/systems/storage.rs
+++ b/server/src/streaming/systems/storage.rs
@@ -1,4 +1,4 @@
-use crate::streaming::persistence::persister::Persister;
+use crate::streaming::persistence::persister::PersisterKind;
 use crate::streaming::storage::SystemInfoStorage;
 use crate::streaming::systems::info::SystemInfo;
 use crate::streaming::systems::COMPONENT;
@@ -14,12 +14,12 @@ use tracing::info;
 
 #[derive(Debug)]
 pub struct FileSystemInfoStorage {
-    persister: Arc<dyn Persister>,
+    persister: Arc<PersisterKind>,
     path: String,
 }
 
 impl FileSystemInfoStorage {
-    pub fn new(path: String, persister: Arc<dyn Persister>) -> Self {
+    pub fn new(path: String, persister: Arc<PersisterKind>) -> Self {
         Self { path, persister }
     }
 }

--- a/tools/src/data-seeder/main.rs
+++ b/tools/src/data-seeder/main.rs
@@ -7,7 +7,7 @@ use iggy::client::{Client, UserClient};
 use iggy::client_provider;
 use iggy::client_provider::ClientProviderConfig;
 use iggy::clients::client::IggyClient;
-use iggy::utils::crypto::{Aes256GcmEncryptor, Encryptor};
+use iggy::utils::crypto::{Aes256GcmEncryptor, EncryptorKind};
 use std::error::Error;
 use std::sync::Arc;
 use tracing::info;
@@ -37,11 +37,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with(tracing_subscriber::fmt::layer())
         .with(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("INFO")))
         .init();
-    let encryptor: Option<Arc<dyn Encryptor>> = match iggy_args.encryption_key.is_empty() {
+    let encryptor: Option<Arc<EncryptorKind>> = match iggy_args.encryption_key.is_empty() {
         true => None,
-        false => Some(Arc::new(
+        false => Some(Arc::new(EncryptorKind::Aes256Gcm(
             Aes256GcmEncryptor::from_base64_key(&iggy_args.encryption_key).unwrap(),
-        )),
+        ))),
     };
     info!("Selected transport: {}", iggy_args.transport);
     let username = args.username.clone();


### PR DESCRIPTION
Addresses part of #https://github.com/iggy-rs/iggy/issues/667

This PR refactors the codebase to replace the use of dyn Trait for Encryptor and Persister with enum types (EncryptorKind and PersisterKind)
