### PR TITLE
Fix named ID on the client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.80"
+version = "0.6.81"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.80"
+version = "0.6.81"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -2,6 +2,7 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::error::IggyError;
 use crate::utils::byte_size::IggyByteSize;
 use crate::utils::sizeable::Sizeable;
+use crate::utils::text::to_lowercase_non_whitespace;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -150,13 +151,14 @@ impl Identifier {
         })
     }
 
-    /// Creates a new identifier from the given string value. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
+    /// Creates a new identifier from the given string value. The name will always be converted to lowercase and all whitespaces will be replaced with dots.
     pub fn named(value: &str) -> Result<Self, IggyError> {
         let length = value.len();
         if length == 0 || length > 255 {
             return Err(IggyError::InvalidIdentifier);
         }
 
+        let value = to_lowercase_non_whitespace(value);
         Ok(Self {
             kind: IdKind::String,
             #[allow(clippy::cast_possible_truncation)]


### PR DESCRIPTION
This fixes #1456 by ensuring that the named `Identifier` will be set correctly on the client-side. In the future, we might allow the user to provide any name without the additional conversion, case-invariant checks etc.