### PR TITLE
Fix server start time in stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4380,7 +4380,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.120"
+version = "0.4.121"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.120"
+version = "0.4.121"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/systems/stats.rs
+++ b/server/src/streaming/systems/stats.rs
@@ -63,7 +63,9 @@ impl System {
             stats.cpu_usage = process.cpu_usage();
             stats.memory_usage = process.memory().into();
             stats.run_time = IggyDuration::new_from_secs(process.run_time());
-            stats.start_time = process.start_time().into();
+            stats.start_time = IggyDuration::new_from_secs(process.start_time())
+                .as_micros()
+                .into();
 
             let disk_usage = process.disk_usage();
             stats.read_bytes = disk_usage.total_read_bytes.into();


### PR DESCRIPTION
Fix #1459 by converting the returned timestamp in seconds, to the commonly used in microseconds.