### PR TITLE
Add rate limiting and browser chart opening features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-time"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9622f5c6fb50377516c70f65159e70b25465409760c6bd6d4e581318bf704e83"
+dependencies = [
+ "once_cell",
+ "portable-atomic",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,6 +578,7 @@ name = "bench"
 version = "0.1.2"
 dependencies = [
  "async-trait",
+ "atomic-time",
  "charming",
  "chrono",
  "clap",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -6,6 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 async-trait = "0.1.85"
+atomic-time = "0.1.5"
 charming = "0.4.0"
 chrono = "0.4.31"
 clap = { version = "4.5.26", features = ["derive"] }

--- a/bench/src/actors/producer.rs
+++ b/bench/src/actors/producer.rs
@@ -1,5 +1,6 @@
 use crate::analytics::metrics::individual::from_records;
 use crate::analytics::record::BenchmarkRecord;
+use crate::rate_limiter::RateLimiter;
 use iggy::client::MessageClient;
 use iggy::clients::client::IggyClient;
 use iggy::error::IggyError;
@@ -28,6 +29,7 @@ pub struct Producer {
     warmup_time: IggyDuration,
     sampling_time: IggyDuration,
     moving_average_window: u32,
+    rate_limiter: Option<RateLimiter>,
 }
 
 impl Producer {
@@ -43,6 +45,7 @@ impl Producer {
         warmup_time: IggyDuration,
         sampling_time: IggyDuration,
         moving_average_window: u32,
+        rate_limiter: Option<RateLimiter>,
     ) -> Self {
         Producer {
             client_factory,
@@ -55,6 +58,7 @@ impl Producer {
             warmup_time,
             sampling_time,
             moving_average_window,
+            rate_limiter,
         }
     }
 
@@ -117,6 +121,10 @@ impl Producer {
         let mut latencies: Vec<Duration> = Vec::with_capacity(message_batches as usize);
         let mut records = Vec::with_capacity(message_batches as usize);
         for i in 1..=message_batches {
+            // Apply rate limiting if configured
+            if let Some(limiter) = &self.rate_limiter {
+                limiter.throttle(batch_total_bytes).await;
+            }
             let before_send = Instant::now();
             client
                 .send_messages(&stream_id, &topic_id, &partitioning, &mut messages)

--- a/bench/src/analytics/time_series/calculators/latency.rs
+++ b/bench/src/analytics/time_series/calculators/latency.rs
@@ -8,6 +8,7 @@ use tracing::warn;
 pub struct LatencyTimeSeriesCalculator;
 
 impl TimeSeriesCalculation for LatencyTimeSeriesCalculator {
+    // This implementation is using delta latency and average latencies per bucket
     fn calculate(&self, records: &[BenchmarkRecord], bucket_size: IggyDuration) -> TimeSeries {
         if records.len() < 2 {
             warn!("Not enough records to calculate latency");

--- a/bench/src/benchmarks/consumer_group_benchmark.rs
+++ b/bench/src/benchmarks/consumer_group_benchmark.rs
@@ -2,6 +2,7 @@ use crate::{
     actors::consumer::Consumer,
     args::common::IggyBenchArgs,
     benchmarks::{CONSUMER_GROUP_BASE_ID, CONSUMER_GROUP_NAME_PREFIX},
+    rate_limiter::RateLimiter,
 };
 use async_trait::async_trait;
 use iggy::{client::ConsumerGroupClient, clients::client::IggyClient, error::IggyError};
@@ -97,6 +98,9 @@ impl Benchmarkable for ConsumerGroupBenchmark {
                 self.args.sampling_time(),
                 self.args.moving_average_window(),
                 self.args.polling_kind(),
+                self.args
+                    .rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
             );
             let future = Box::pin(async move { consumer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/benchmarks/poll_benchmark.rs
+++ b/bench/src/benchmarks/poll_benchmark.rs
@@ -1,6 +1,7 @@
 use super::benchmark::{BenchmarkFutures, Benchmarkable};
 use crate::actors::consumer::Consumer;
 use crate::args::common::IggyBenchArgs;
+use crate::rate_limiter::RateLimiter;
 use async_trait::async_trait;
 use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
 use integration::test_server::ClientFactory;
@@ -56,6 +57,9 @@ impl Benchmarkable for PollMessagesBenchmark {
                 args.sampling_time(),
                 args.moving_average_window(),
                 self.args.polling_kind(),
+                self.args
+                    .rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
             );
 
             let future = Box::pin(async move { consumer.run().await });

--- a/bench/src/benchmarks/send_and_poll_benchmark.rs
+++ b/bench/src/benchmarks/send_and_poll_benchmark.rs
@@ -2,6 +2,7 @@ use super::benchmark::{BenchmarkFutures, Benchmarkable};
 use crate::actors::consumer::Consumer;
 use crate::actors::producer::Producer;
 use crate::args::common::IggyBenchArgs;
+use crate::rate_limiter::RateLimiter;
 use async_trait::async_trait;
 use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
 use integration::test_server::ClientFactory;
@@ -55,6 +56,9 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 warmup_time,
                 self.args.sampling_time(),
                 self.args.moving_average_window(),
+                self.args
+                    .rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);
@@ -76,6 +80,9 @@ impl Benchmarkable for SendAndPollMessagesBenchmark {
                 self.args.sampling_time(),
                 self.args.moving_average_window(),
                 self.args.polling_kind(),
+                self.args
+                    .rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
             );
             let future = Box::pin(async move { consumer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/benchmarks/send_benchmark.rs
+++ b/bench/src/benchmarks/send_benchmark.rs
@@ -1,6 +1,7 @@
 use super::benchmark::{BenchmarkFutures, Benchmarkable};
 use crate::actors::producer::Producer;
 use crate::args::common::IggyBenchArgs;
+use crate::rate_limiter::RateLimiter;
 use async_trait::async_trait;
 use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
 use integration::test_server::ClientFactory;
@@ -60,6 +61,8 @@ impl Benchmarkable for SendMessagesBenchmark {
                 warmup_time,
                 args.sampling_time(),
                 args.moving_average_window(),
+                args.rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
             );
             let future = Box::pin(async move { producer.run().await });
             futures.as_mut().unwrap().push(future);

--- a/bench/src/main.rs
+++ b/bench/src/main.rs
@@ -3,6 +3,7 @@ mod analytics;
 mod args;
 mod benchmarks;
 mod plot;
+mod rate_limiter;
 mod runner;
 mod utils;
 

--- a/bench/src/rate_limiter/mod.rs
+++ b/bench/src/rate_limiter/mod.rs
@@ -1,0 +1,61 @@
+use atomic_time::AtomicInstant;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+/// Thread-safe rate limiter using linger-based algorithm
+pub struct RateLimiter {
+    bytes_per_second: u64,
+    last_operation: AtomicInstant,
+}
+
+impl RateLimiter {
+    pub fn new(bytes_per_second: u64) -> Self {
+        Self {
+            bytes_per_second,
+            last_operation: AtomicInstant::now(),
+        }
+    }
+
+    /// Throttles the caller based on the configured rate limit
+    pub async fn throttle(&self, bytes: u64) {
+        let now = Instant::now();
+        let last_op = self.last_operation.load(Ordering::Relaxed);
+
+        let time_per_byte = 1.0 / self.bytes_per_second as f64;
+
+        let target_duration = Duration::from_secs_f64(bytes as f64 * time_per_byte);
+
+        let elapsed = now.duration_since(last_op);
+
+        if elapsed < target_duration {
+            let sleep_duration = target_duration - elapsed;
+            self.last_operation
+                .store(now + sleep_duration, Ordering::Relaxed);
+            sleep(sleep_duration).await;
+        } else {
+            self.last_operation.store(now, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_rate_limiter() {
+        let limiter = RateLimiter::new(1000); // 1000 bytes per second
+        let start = Instant::now();
+
+        // Try to send 100 bytes 5 times
+        for _ in 0..5 {
+            limiter.throttle(100).await;
+        }
+
+        // Should take approximately 0.5 seconds (500ms) to send 500 bytes at 1000 bytes/sec
+        let elapsed = start.elapsed();
+        assert!(elapsed >= Duration::from_millis(450)); // Allow some wiggle room
+        assert!(elapsed <= Duration::from_millis(550));
+    }
+}

--- a/bench/src/runner.rs
+++ b/bench/src/runner.rs
@@ -28,6 +28,7 @@ impl BenchmarkRunner {
 
     pub async fn run(&mut self) -> Result<(), IggyError> {
         let mut args = self.args.take().unwrap();
+        let should_open_charts = args.open_charts;
         self.test_server = start_server_if_needed(&mut args).await;
 
         let transport = args.transport();
@@ -81,11 +82,23 @@ impl BenchmarkRunner {
             report.dump_to_json(&full_output_path);
 
             // Generate the plots
-            plot_chart(&report, &full_output_path, ChartType::Throughput).map_err(|e| {
+            plot_chart(
+                &report,
+                &full_output_path,
+                ChartType::Throughput,
+                should_open_charts,
+            )
+            .map_err(|e| {
                 error!("Failed to generate plots: {e}");
                 IggyError::CannotWriteToFile
             })?;
-            plot_chart(&report, &full_output_path, ChartType::Latency).map_err(|e| {
+            plot_chart(
+                &report,
+                &full_output_path,
+                ChartType::Latency,
+                should_open_charts,
+            )
+            .map_err(|e| {
                 error!("Failed to generate plots: {e}");
                 IggyError::CannotWriteToFile
             })?;


### PR DESCRIPTION
This commit introduces a rate limiting feature for both producers and
consumers, allowing users to specify a rate limit in bytes per second.
The rate limiter is implemented using a linger-based algorithm to ensure
smooth throughput control.

Additionally, a new command-line argument is added to open generated
charts in the browser automatically after the benchmark is completed.

The changes also include updates to the latency calculation logic,
switching from average latency to worst latency per bucket for more
accurate performance insights.
