### PR TITLE
Add max topic size option, improve benchmark output, add new bench kinds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "bench"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "atomic-time",
@@ -2412,7 +2412,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmark-report"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "byte-unit",
  "charming",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bench"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/bench/report/Cargo.toml
+++ b/bench/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-benchmark-report"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Benchmark report and chart generation library for iggy-bench binary and iggy-benchmarks-dashboard web app"
 license = "Apache-2.0"

--- a/bench/report/src/plotting/text/subtext.rs
+++ b/bench/report/src/plotting/text/subtext.rs
@@ -116,8 +116,10 @@ impl BenchmarkParams {
             ));
         }
 
+        let partitions = format!("{} partitions", self.partitions);
+
         format!(
-            "{actors_info}  •  {messages_per_batch} msg/batch  •  {message_batches} batches  •  {message_size} bytes/msg  •  {user_data_print}",
+            "{actors_info}  •  {partitions}  •  {messages_per_batch} msg/batch  •  {message_batches} batches  •  {message_size} bytes/msg  •  {user_data_print}",
         )
     }
 }

--- a/bench/report/src/plotting/text/title.rs
+++ b/bench/report/src/plotting/text/title.rs
@@ -1,21 +1,15 @@
-use crate::{
-    benchmark_kind::BenchmarkKind, plotting::chart_kind::ChartKind, report::BenchmarkReport,
-};
+use crate::{plotting::chart_kind::ChartKind, report::BenchmarkReport};
 
 /// Returns a title for a benchmark report
 impl BenchmarkReport {
     pub fn title(&self, kind: ChartKind) -> String {
-        let kind_str = match self.params.benchmark_kind {
-            BenchmarkKind::Send => "Send",
-            BenchmarkKind::Poll => "Poll",
-            BenchmarkKind::SendAndPoll => "Send and Poll",
-            BenchmarkKind::ConsumerGroupPoll => "Consumer Group Poll",
-        };
-
         if let Some(remark) = &self.params.remark {
-            format!("{} - {} Benchmark ({})", kind, kind_str, remark)
+            format!(
+                "{} - {} Benchmark ({})",
+                kind, self.params.benchmark_kind, remark
+            )
         } else {
-            format!("{} - {} Benchmark", kind, kind_str)
+            format!("{} - {} Benchmark", kind, self.params.benchmark_kind)
         }
     }
 }

--- a/bench/report/src/types/benchmark_kind.rs
+++ b/bench/report/src/types/benchmark_kind.rs
@@ -26,7 +26,13 @@ pub enum BenchmarkKind {
     #[display("Send And Poll")]
     #[serde(rename = "send_and_poll")]
     SendAndPoll,
+    #[display("Consumer Group Send")]
+    #[serde(rename = "consumer_group_send")]
+    ConsumerGroupSend,
     #[display("Consumer Group Poll")]
     #[serde(rename = "consumer_group_poll")]
     ConsumerGroupPoll,
+    #[display("Consumer Group Send And Poll")]
+    #[serde(rename = "consumer_group_send_and_poll")]
+    ConsumerGroupSendAndPoll,
 }

--- a/bench/report/src/types/params.rs
+++ b/bench/report/src/types/params.rs
@@ -33,6 +33,13 @@ impl BenchmarkParams {
             BenchmarkKind::SendAndPoll => {
                 format!("{} producers/{} consumers", self.producers, self.consumers)
             }
+            BenchmarkKind::ConsumerGroupSend => format!(
+                "{} producers/{} consumer groups",
+                self.producers, self.number_of_consumer_groups
+            ),
+            BenchmarkKind::ConsumerGroupSendAndPoll => {
+                format!("{} producers/{} consumers", self.producers, self.consumers)
+            }
             BenchmarkKind::ConsumerGroupPoll => {
                 format!(
                     "{} consumers/{} consumer groups",

--- a/bench/src/args/kind.rs
+++ b/bench/src/args/kind.rs
@@ -7,6 +7,7 @@ use super::props::BenchmarkKindProps;
 use super::transport::BenchmarkTransportCommand;
 use clap::Subcommand;
 use iggy::messages::poll_messages::PollingKind;
+use iggy::utils::byte_size::IggyByteSize;
 use iggy_benchmark_report::benchmark_kind::BenchmarkKind;
 
 #[derive(Subcommand, Debug)]
@@ -82,6 +83,10 @@ impl BenchmarkKindProps for BenchmarkKindCommand {
 
     fn polling_kind(&self) -> PollingKind {
         self.inner().polling_kind()
+    }
+
+    fn max_topic_size(&self) -> Option<IggyByteSize> {
+        self.inner().max_topic_size()
     }
 
     fn inner(&self) -> &dyn BenchmarkKindProps {

--- a/bench/src/args/kinds/consumer_group_poll.rs
+++ b/bench/src/args/kinds/consumer_group_poll.rs
@@ -3,7 +3,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{error::ErrorKind, CommandFactory, Parser};
-use iggy::messages::poll_messages::PollingKind;
+use iggy::{messages::poll_messages::PollingKind, utils::byte_size::IggyByteSize};
 use std::num::NonZeroU32;
 use tracing::warn;
 
@@ -114,5 +114,9 @@ impl BenchmarkKindProps for ConsumerGroupArgs {
 
     fn polling_kind(&self) -> PollingKind {
         self.polling_kind
+    }
+
+    fn max_topic_size(&self) -> Option<IggyByteSize> {
+        None
     }
 }

--- a/bench/src/args/kinds/poll.rs
+++ b/bench/src/args/kinds/poll.rs
@@ -3,7 +3,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{error::ErrorKind, CommandFactory, Parser};
-use iggy::messages::poll_messages::PollingKind;
+use iggy::{messages::poll_messages::PollingKind, utils::byte_size::IggyByteSize};
 use std::num::NonZeroU32;
 
 /// Polling (reading) benchmark
@@ -102,5 +102,9 @@ impl BenchmarkKindProps for PollArgs {
 
     fn polling_kind(&self) -> PollingKind {
         PollingKind::Offset
+    }
+
+    fn max_topic_size(&self) -> Option<IggyByteSize> {
+        None
     }
 }

--- a/bench/src/args/kinds/send.rs
+++ b/bench/src/args/kinds/send.rs
@@ -3,7 +3,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{error::ErrorKind, CommandFactory, Parser};
-use iggy::messages::poll_messages::PollingKind;
+use iggy::{messages::poll_messages::PollingKind, utils::byte_size::IggyByteSize};
 use std::num::NonZeroU32;
 
 /// Sending (writing) benchmark
@@ -39,6 +39,10 @@ pub struct SendArgs {
     /// Flag, disables parallel producers
     #[arg(long, default_value_t = DEFAULT_DISABLE_PARALLEL_PRODUCER_STREAMS)]
     pub disable_parallel_producers: bool,
+
+    /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GB". If not provided then the server default will be used.
+    #[arg(long)]
+    pub max_topic_size: Option<IggyByteSize>,
 }
 
 impl BenchmarkKindProps for SendArgs {
@@ -84,6 +88,10 @@ impl BenchmarkKindProps for SendArgs {
 
     fn number_of_consumer_groups(&self) -> u32 {
         0
+    }
+
+    fn max_topic_size(&self) -> Option<IggyByteSize> {
+        self.max_topic_size
     }
 
     fn validate(&self) {

--- a/bench/src/args/kinds/send_and_poll.rs
+++ b/bench/src/args/kinds/send_and_poll.rs
@@ -3,7 +3,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{error::ErrorKind, CommandFactory, Parser};
-use iggy::messages::poll_messages::PollingKind;
+use iggy::{messages::poll_messages::PollingKind, utils::byte_size::IggyByteSize};
 use std::num::NonZeroU32;
 
 /// Parallel sending and polling benchmark
@@ -47,6 +47,10 @@ pub struct SendAndPollArgs {
     /// Flag, disables parallel consumers
     #[arg(long, default_value_t = DEFAULT_DISABLE_PARALLEL_CONSUMER_STREAMS)]
     pub disable_parallel_consumers: bool,
+
+    /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GB". If not provided then the server default will be used.
+    #[arg(long)]
+    pub max_topic_size: Option<IggyByteSize>,
 }
 
 impl BenchmarkKindProps for SendAndPollArgs {
@@ -92,6 +96,10 @@ impl BenchmarkKindProps for SendAndPollArgs {
 
     fn number_of_consumer_groups(&self) -> u32 {
         0
+    }
+
+    fn max_topic_size(&self) -> Option<IggyByteSize> {
+        self.max_topic_size
     }
 
     fn validate(&self) {

--- a/bench/src/args/props.rs
+++ b/bench/src/args/props.rs
@@ -1,5 +1,5 @@
 use super::transport::BenchmarkTransportCommand;
-use iggy::messages::poll_messages::PollingKind;
+use iggy::{messages::poll_messages::PollingKind, utils::byte_size::IggyByteSize};
 use integration::test_server::Transport;
 
 pub trait BenchmarkKindProps {
@@ -15,6 +15,7 @@ pub trait BenchmarkKindProps {
     fn disable_parallel_consumer_streams(&self) -> bool;
     fn transport_command(&self) -> &BenchmarkTransportCommand;
     fn polling_kind(&self) -> PollingKind;
+    fn max_topic_size(&self) -> Option<IggyByteSize>;
     fn validate(&self);
     fn inner(&self) -> &dyn BenchmarkKindProps
     where


### PR DESCRIPTION
This commit introduces a new option to specify the maximum topic size in a human-readable format, such as "1GiB" or "2MB". This allows users to customize the topic size for benchmarks, with the server default being used if not specified. Additionally, the benchmark charts subtext format has been updated to include the number of partitions.

Besides that, commit introduces new benchmark kinds: ConsumerGroupSend and ConsumerGroupSendAndPoll which are not yet implemented.