### PR TITLE
Add cache metrics to `Stats` and p9999 latency tracking to `BenchmarkReport`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
 
 [[package]]
 name = "bench"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "async-trait",
  "atomic-time",
@@ -585,6 +585,7 @@ dependencies = [
  "figlet-rs",
  "futures",
  "hostname",
+ "human-repr",
  "iggy",
  "iggy-benchmark-report",
  "integration",
@@ -939,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952013545c9c6dca60f491602655b795c6c062ab180c9cb0bccb83135461861"
+checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
 dependencies = [
  "clap",
 ]
@@ -2065,6 +2066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "human-repr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58b778a5761513caf593693f8951c97a5b610841e754788400f32102eefdff1"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2363,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.91"
+version = "0.6.92"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -2412,13 +2419,14 @@ dependencies = [
 
 [[package]]
 name = "iggy-benchmark-report"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "byte-unit",
  "charming",
  "colored",
  "derive-new",
  "derive_more",
+ "human-repr",
  "serde",
  "serde_json",
  "sysinfo",
@@ -4157,9 +4165,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4474,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.130"
+version = "0.4.131"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -4496,6 +4504,7 @@ dependencies = [
  "figment",
  "flume",
  "futures",
+ "human-repr",
  "iggy",
  "jsonwebtoken",
  "mimalloc",
@@ -5045,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
 dependencies = [
  "indexmap 2.7.1",
  "serde",
@@ -5615,18 +5624,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd5da49bdf1f30054cfe0b8ce2958b8fbeb67c4d82c8967a598af481bef255c"
+checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5971,9 +5980,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.25"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad699df48212c6cc6eb4435f35500ac6fd3b9913324f938aea302022ce19d310"
+checksum = "7e49d2d35d3fad69b39b94139037ecfb4f359f08958b9c11e7315ce770462419"
 dependencies = [
  "memchr",
 ]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bench"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -13,6 +13,7 @@ clap = { version = "4.5.26", features = ["derive"] }
 figlet-rs = "0.1.5"
 futures = "0.3.31"
 hostname = "0.4.0"
+human-repr = "1.1.0"
 iggy = { path = "../sdk" }
 iggy-benchmark-report = { path = "report" }
 integration = { path = "../integration" }

--- a/bench/report/Cargo.toml
+++ b/bench/report/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-benchmark-report"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Benchmark report and chart generation library for iggy-bench binary and iggy-benchmarks-dashboard web app"
 license = "Apache-2.0"
@@ -11,6 +11,7 @@ charming = "0.4.0"
 colored = "3.0.0"
 derive-new = "0.7.0"
 derive_more = { version = "1.0.0", features = ["full"] }
+human-repr = "1.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sysinfo = "0.33.1"

--- a/bench/report/src/plotting/text/subtext.rs
+++ b/bench/report/src/plotting/text/subtext.rs
@@ -3,6 +3,7 @@ use crate::{
     group_metrics_kind::GroupMetricsKind, params::BenchmarkParams, report::BenchmarkReport,
 };
 use byte_unit::{Byte, UnitType};
+use human_repr::HumanCount;
 
 impl BenchmarkReport {
     pub fn subtext(&self) -> String {
@@ -74,13 +75,14 @@ impl BenchmarkGroupMetrics {
 
     fn format_latency(&self) -> String {
         format!(
-            "{} Latency  •  Avg: {:.2} ms  •  Med: {:.2} ms  •  P95: {:.2} ms  •  P99: {:.2} ms  •  P999: {:.2} ms",
+            "{} Latency  •  Avg: {:.2} ms  •  Med: {:.2} ms  •  P95: {:.2} ms  •  P99: {:.2} ms  •  P999: {:.2} ms  •  P9999: {:.2} ms",
             self.summary.kind,
             self.summary.average_latency_ms,
             self.summary.average_median_latency_ms,
             self.summary.average_p95_latency_ms,
             self.summary.average_p99_latency_ms,
-            self.summary.average_p999_latency_ms
+            self.summary.average_p999_latency_ms,
+            self.summary.average_p9999_latency_ms
         )
     }
 }
@@ -92,9 +94,8 @@ impl BenchmarkParams {
         let messages_per_batch = self.messages_per_batch as u64;
         let message_size = self.message_size as u64;
 
-        let sent: u64 = message_batches * messages_per_batch * message_size * self.producers as u64;
-        let polled: u64 =
-            message_batches * messages_per_batch * message_size * self.consumers as u64;
+        let sent = message_batches * messages_per_batch * message_size * self.producers as u64;
+        let polled = message_batches * messages_per_batch * message_size * self.consumers as u64;
 
         let mut user_data_print = String::new();
 
@@ -115,6 +116,9 @@ impl BenchmarkParams {
                 Byte::from_u64(sent).get_appropriate_unit(UnitType::Decimal),
             ));
         }
+
+        let message_batches = message_batches.human_count_bare();
+        let messages_per_batch = messages_per_batch.human_count_bare();
 
         let partitions = format!("{} partitions", self.partitions);
 

--- a/bench/report/src/prints.rs
+++ b/bench/report/src/prints.rs
@@ -1,4 +1,5 @@
 use colored::{Color, ColoredString, Colorize};
+use human_repr::HumanCount;
 use tracing::info;
 
 use crate::{
@@ -18,18 +19,20 @@ impl BenchmarkReport {
         let message_size = self.params.message_size;
         let producers = self.params.producers;
         let consumers = self.params.consumers;
+        let partitions = self.params.partitions;
         println!();
-        let params_print = format!("Benchmark: {}, total messages: {}, total size: {} bytes, {} streams, {} messages per batch, {} batches, {} bytes per message, {} producers, {} consumers\n",
+        let params_print = format!("Benchmark: {}, {} producers, {} consumers, {} streams, {} partitions, {} total messages, {} messages per batch, {} batches, {} per message, {} total size\n",
             kind,
-            total_messages,
-            total_size_bytes,
-            streams,
-            messages_per_batch,
-            message_batches,
-            message_size,
             producers,
             consumers,
-        ).blue();
+            streams,
+            partitions,
+            total_messages.human_count_bare(),
+            messages_per_batch.human_count_bare(),
+            message_batches.human_count_bare(),
+            message_size.human_count_bytes(),
+            total_size_bytes.human_count_bytes(),
+            ).blue();
 
         info!("{}", params_print);
 
@@ -61,15 +64,28 @@ impl BenchmarkGroupMetrics {
         let p95 = format!("{:.2}", self.summary.average_p95_latency_ms);
         let p99 = format!("{:.2}", self.summary.average_p99_latency_ms);
         let p999 = format!("{:.2}", self.summary.average_p999_latency_ms);
+        let p9999 = format!("{:.2}", self.summary.average_p9999_latency_ms);
         let avg = format!("{:.2}", self.summary.average_latency_ms);
         let median = format!("{:.2}", self.summary.average_median_latency_ms);
 
         format!(
             "{}: Total throughput: {} MB/s, {} messages/s, average throughput per {}: {} MB/s, \
             p50 latency: {} ms, p90 latency: {} ms, p95 latency: {} ms, \
-            p99 latency: {} ms, p999 latency: {} ms, average latency: {} ms, \
+            p99 latency: {} ms, p999 latency: {} ms, p9999 latency: {} ms, average latency: {} ms, \
             median latency: {} ms",
-            prefix, total_mb, total_msg, actor, avg_mb, p50, p90, p95, p99, p999, avg, median,
+            prefix,
+            total_mb,
+            total_msg,
+            actor,
+            avg_mb,
+            p50,
+            p90,
+            p95,
+            p99,
+            p999,
+            p9999,
+            avg,
+            median,
         )
         .color(color)
     }

--- a/bench/report/src/types/group_metrics_summary.rs
+++ b/bench/report/src/types/group_metrics_summary.rs
@@ -24,6 +24,8 @@ pub struct BenchmarkGroupMetricsSummary {
     #[serde(serialize_with = "round_float")]
     pub average_p999_latency_ms: f64,
     #[serde(serialize_with = "round_float")]
+    pub average_p9999_latency_ms: f64,
+    #[serde(serialize_with = "round_float")]
     pub average_latency_ms: f64,
     #[serde(serialize_with = "round_float")]
     pub average_median_latency_ms: f64,

--- a/bench/report/src/types/individual_metrics_summary.rs
+++ b/bench/report/src/types/individual_metrics_summary.rs
@@ -28,6 +28,8 @@ pub struct BenchmarkIndividualMetricsSummary {
     #[serde(serialize_with = "round_float")]
     pub p999_latency_ms: f64,
     #[serde(serialize_with = "round_float")]
+    pub p9999_latency_ms: f64,
+    #[serde(serialize_with = "round_float")]
     pub avg_latency_ms: f64,
     #[serde(serialize_with = "round_float")]
     pub median_latency_ms: f64,

--- a/bench/src/actors/consumer.rs
+++ b/bench/src/actors/consumer.rs
@@ -1,6 +1,7 @@
 use crate::analytics::metrics::individual::from_records;
 use crate::analytics::record::BenchmarkRecord;
 use crate::rate_limiter::RateLimiter;
+use human_repr::HumanCount;
 use iggy::client::{ConsumerGroupClient, MessageClient};
 use iggy::clients::client::IggyClient;
 use iggy::consumer::Consumer as IggyConsumer;
@@ -149,12 +150,19 @@ impl Consumer {
         if let Some(cg_id) = self.consumer_group_id {
             info!(
                 "Consumer #{}, part of consumer group #{} → polling {} messages in {} batches of {} messages...",
-                self.consumer_id, cg_id, total_messages, message_batches, messages_per_batch
+                self.consumer_id,
+                cg_id,
+                total_messages.human_count_bare(),
+                message_batches.human_count_bare(),
+                messages_per_batch.human_count_bare()
             );
         } else {
             info!(
                 "Consumer #{} → polling {} messages in {} batches of {} messages...",
-                self.consumer_id, total_messages, message_batches, messages_per_batch
+                self.consumer_id,
+                total_messages.human_count_bare(),
+                message_batches.human_count_bare(),
+                messages_per_batch.human_count_bare()
             );
         }
 
@@ -282,11 +290,11 @@ impl Consumer {
         info!(
             "Consumer #{} → polled {} messages, {} batches of {} messages in {:.2} s, total size: {}, average throughput: {:.2} MB/s, \
     p50 latency: {:.2} ms, p90 latency: {:.2} ms, p95 latency: {:.2} ms, p99 latency: {:.2} ms, p999 latency: {:.2} ms, \
-    average latency: {:.2} ms, median latency: {:.2} ms",
+    p9999 latency: {:.2} ms, average latency: {:.2} ms, median latency: {:.2} ms",
             consumer_id,
-            total_messages,
-            message_batches,
-            messages_per_batch,
+            total_messages.human_count_bare(),
+            message_batches.human_count_bare(),
+            messages_per_batch.human_count_bare(),
             stats.summary.total_time_secs,
             IggyByteSize::from(stats.summary.total_user_data_bytes),
             stats.summary.throughput_megabytes_per_second,
@@ -295,6 +303,7 @@ impl Consumer {
             stats.summary.p95_latency_ms,
             stats.summary.p99_latency_ms,
             stats.summary.p999_latency_ms,
+            stats.summary.p9999_latency_ms,
             stats.summary.avg_latency_ms,
             stats.summary.median_latency_ms
         );

--- a/bench/src/actors/producer.rs
+++ b/bench/src/actors/producer.rs
@@ -1,6 +1,7 @@
 use crate::analytics::metrics::individual::from_records;
 use crate::analytics::record::BenchmarkRecord;
 use crate::rate_limiter::RateLimiter;
+use human_repr::HumanCount;
 use iggy::client::MessageClient;
 use iggy::clients::client::IggyClient;
 use iggy::error::IggyError;
@@ -114,7 +115,10 @@ impl Producer {
 
         info!(
             "Producer #{} → sending {} messages in {} batches of {} messages...",
-            self.producer_id, total_messages, message_batches, messages_per_batch
+            self.producer_id,
+            total_messages.human_count_bare(),
+            message_batches.human_count_bare(),
+            messages_per_batch.human_count_bare()
         );
 
         let start_timestamp = Instant::now();
@@ -185,7 +189,7 @@ impl Producer {
     ) {
         info!(
             "Producer #{} → sent {} messages in {} batches of {} messages in {:.2} s, total size: {}, average throughput: {:.2} MB/s, \
-    p50 latency: {:.2} ms, p90 latency: {:.2} ms, p95 latency: {:.2} ms, p99 latency: {:.2} ms, p999 latency: {:.2} ms, \
+    p50 latency: {:.2} ms, p90 latency: {:.2} ms, p95 latency: {:.2} ms, p99 latency: {:.2} ms, p999 latency: {:.2} ms, p9999 latency: {:.2} ms, \
     average latency: {:.2} ms, median latency: {:.2} ms",
             producer_id,
             total_messages,
@@ -199,6 +203,7 @@ impl Producer {
             stats.summary.p95_latency_ms,
             stats.summary.p99_latency_ms,
             stats.summary.p999_latency_ms,
+            stats.summary.p9999_latency_ms,
             stats.summary.avg_latency_ms,
             stats.summary.median_latency_ms
         );

--- a/bench/src/analytics/metrics/group.rs
+++ b/bench/src/analytics/metrics/group.rs
@@ -59,6 +59,11 @@ pub fn from_individual_metrics(
         stats.iter().map(|r| r.summary.p99_latency_ms).sum::<f64>() / count;
     let average_p999_latency_ms: f64 =
         stats.iter().map(|r| r.summary.p999_latency_ms).sum::<f64>() / count;
+    let average_p9999_latency_ms: f64 = stats
+        .iter()
+        .map(|r| r.summary.p9999_latency_ms)
+        .sum::<f64>()
+        / count;
     let average_avg_latency_ms =
         stats.iter().map(|r| r.summary.avg_latency_ms).sum::<f64>() / count;
     let average_median_latency_ms = stats
@@ -112,6 +117,7 @@ pub fn from_individual_metrics(
         average_p95_latency_ms,
         average_p99_latency_ms,
         average_p999_latency_ms,
+        average_p9999_latency_ms,
         average_latency_ms: average_avg_latency_ms,
         average_median_latency_ms,
     };

--- a/bench/src/analytics/metrics/individual.rs
+++ b/bench/src/analytics/metrics/individual.rs
@@ -34,6 +34,7 @@ pub fn from_records(
                 p95_latency_ms: 0.0,
                 p99_latency_ms: 0.0,
                 p999_latency_ms: 0.0,
+                p9999_latency_ms: 0.0,
                 avg_latency_ms: 0.0,
                 median_latency_ms: 0.0,
             },
@@ -72,6 +73,7 @@ pub fn from_records(
     let p95_latency_ms = calculate_percentile(&latencies_ms, 95.0);
     let p99_latency_ms = calculate_percentile(&latencies_ms, 99.0);
     let p999_latency_ms = calculate_percentile(&latencies_ms, 99.9);
+    let p9999_latency_ms = calculate_percentile(&latencies_ms, 99.99);
 
     let avg_latency_ms = latencies_ms.iter().sum::<f64>() / latencies_ms.len() as f64;
     let len = latencies_ms.len() / 2;
@@ -109,6 +111,7 @@ pub fn from_records(
             p95_latency_ms,
             p99_latency_ms,
             p999_latency_ms,
+            p9999_latency_ms,
             avg_latency_ms,
             median_latency_ms,
         },

--- a/bench/src/args/common.rs
+++ b/bench/src/args/common.rs
@@ -454,11 +454,11 @@ fn recreate_bench_command(args: &IggyBenchArgs) -> String {
     }
 
     if let Some(rate_limit) = args.rate_limit() {
-        parts.push(format!("--rate-limit {}", rate_limit));
+        parts.push(format!("--rate-limit \'{}\'", rate_limit));
     }
 
     if let Some(max_topic_size) = args.max_topic_size() {
-        parts.push(format!("--max-topic-size {}", max_topic_size));
+        parts.push(format!("--max-topic-size \'{}\'", max_topic_size));
     }
 
     // Add transport and server address, skipping if default

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.91"
+version = "0.6.92"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"

--- a/sdk/src/models/stats.rs
+++ b/sdk/src/models/stats.rs
@@ -1,5 +1,6 @@
 use crate::utils::{byte_size::IggyByteSize, duration::IggyDuration, timestamp::IggyTimestamp};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// `Stats` represents the statistics and details of the server and running process.
 #[derive(Debug, Serialize, Deserialize)]
@@ -52,6 +53,86 @@ pub struct Stats {
     pub iggy_server_version: String,
     /// The semantic version of the Iggy server in the numeric format e.g. 1.2.3 -> 100200300 (major * 1000000 + minor * 1000 + patch).
     pub iggy_server_semver: Option<u32>,
+    /// Cache metrics per partition
+    #[serde(with = "cache_metrics_serializer")]
+    pub cache_metrics: HashMap<CacheMetricsKey, CacheMetrics>,
+}
+
+/// Key for identifying a specific partition's cache metrics
+#[derive(Debug, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct CacheMetricsKey {
+    /// Stream ID
+    pub stream_id: u32,
+    /// Topic ID
+    pub topic_id: u32,
+    /// Partition ID
+    pub partition_id: u32,
+}
+
+impl CacheMetricsKey {
+    fn to_string_key(&self) -> String {
+        format!("{}-{}-{}", self.stream_id, self.topic_id, self.partition_id)
+    }
+}
+
+/// Cache metrics for a specific partition
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct CacheMetrics {
+    /// Number of cache hits
+    pub hits: u64,
+    /// Number of cache misses
+    pub misses: u64,
+    /// Hit ratio (hits / (hits + misses))
+    pub hit_ratio: f32,
+}
+
+mod cache_metrics_serializer {
+    use super::*;
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::collections::HashMap;
+
+    pub fn serialize<S>(
+        metrics: &HashMap<CacheMetricsKey, CacheMetrics>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let string_map: HashMap<String, &CacheMetrics> = metrics
+            .iter()
+            .map(|(k, v)| (k.to_string_key(), v))
+            .collect();
+        string_map.serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<HashMap<CacheMetricsKey, CacheMetrics>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let string_map: HashMap<String, CacheMetrics> = HashMap::deserialize(deserializer)?;
+        let mut result = HashMap::new();
+        for (key_str, value) in string_map {
+            let parts: Vec<&str> = key_str.split('-').collect();
+            if parts.len() != 3 {
+                continue;
+            }
+            if let (Ok(stream_id), Ok(topic_id), Ok(partition_id)) = (
+                parts[0].parse::<u32>(),
+                parts[1].parse::<u32>(),
+                parts[2].parse::<u32>(),
+            ) {
+                let key = CacheMetricsKey {
+                    stream_id,
+                    topic_id,
+                    partition_id,
+                };
+                result.insert(key, value);
+            }
+        }
+        Ok(result)
+    }
 }
 
 impl Default for Stats {
@@ -81,6 +162,7 @@ impl Default for Stats {
             kernel_version: "unknown_kernel_version".to_string(),
             iggy_server_version: "unknown_iggy_version".to_string(),
             iggy_server_semver: None,
+            cache_metrics: HashMap::new(),
         }
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.130"
+version = "0.4.131"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"
@@ -32,6 +32,7 @@ figlet-rs = "0.1.5"
 figment = { version = "0.10.19", features = ["toml", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
+human-repr = "1.1.0"
 iggy = { path = "../sdk" }
 jsonwebtoken = "9.3.0"
 moka = { version = "0.12.9", features = ["future"] }

--- a/server/src/binary/mapper.rs
+++ b/server/src/binary/mapper.rs
@@ -46,7 +46,21 @@ pub fn map_stats(stats: &Stats) -> Bytes {
     bytes.put_slice(stats.kernel_version.as_bytes());
     bytes.put_u32_le(stats.iggy_server_version.len() as u32);
     bytes.put_slice(stats.iggy_server_version.as_bytes());
-    bytes.put_u32_le(stats.iggy_server_semver.unwrap_or(0));
+    if let Some(semver) = stats.iggy_server_semver {
+        bytes.put_u32_le(semver);
+    }
+
+    bytes.put_u32_le(stats.cache_metrics.len() as u32);
+    for (key, metrics) in &stats.cache_metrics {
+        bytes.put_u32_le(key.stream_id);
+        bytes.put_u32_le(key.topic_id);
+        bytes.put_u32_le(key.partition_id);
+
+        bytes.put_u64_le(metrics.hits);
+        bytes.put_u64_le(metrics.misses);
+        bytes.put_f32_le(metrics.hit_ratio);
+    }
+
     bytes.freeze()
 }
 

--- a/server/src/channels/commands/print_sysinfo.rs
+++ b/server/src/channels/commands/print_sysinfo.rs
@@ -3,6 +3,7 @@ use crate::{
     streaming::systems::system::SharedSystem,
 };
 use flume::{Receiver, Sender};
+use human_repr::HumanCount;
 use iggy::utils::duration::IggyDuration;
 use tokio::time::{self};
 use tracing::{error, info, warn};
@@ -58,7 +59,17 @@ impl ServerCommand<SysInfoPrintCommand> for SysInfoPrintExecutor {
             / stats.total_memory.as_bytes_u64() as f64)
             * 100f64;
 
-        info!("CPU: {:.2}% / {:.2}% (IggyUsage/Total), Mem: {:.2}% / {} / {} / {} (Free/IggyUsage/TotalUsed/Total), Clients: {}, Messages processed: {}, Read: {}, Written: {}, Uptime: {}",
+        let cache_hits = stats
+            .cache_metrics
+            .iter()
+            .fold(0, |acc, (_, metrics)| acc + metrics.hits);
+        let cache_misses = stats
+            .cache_metrics
+            .iter()
+            .fold(0, |acc, (_, metrics)| acc + metrics.misses);
+        let cache_ratio = cache_hits as f64 / (cache_hits + cache_misses) as f64;
+
+        info!("CPU: {:.2}% / {:.2}% (IggyUsage/Total), Mem: {:.2}% / {} / {} / {} (Free/IggyUsage/TotalUsed/Total), Clients: {}, Messages processed: {}, Read: {}, Written: {}, Cache: {}/{}/{:.2} (Hits/Misses/Ratio), Uptime: {}",
               stats.cpu_usage,
               stats.total_cpu_usage,
               free_memory_percent,
@@ -66,9 +77,12 @@ impl ServerCommand<SysInfoPrintCommand> for SysInfoPrintExecutor {
               stats.total_memory - stats.available_memory,
               stats.total_memory,
               stats.clients_count,
-              stats.messages_count,
+              stats.messages_count.human_count_bare(),
               stats.read_bytes,
               stats.written_bytes,
+              cache_hits.human_count_bare(),
+              cache_misses.human_count_bare(),
+              cache_ratio,
               stats.run_time);
     }
 

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -107,7 +107,7 @@ impl Partition {
             .get_messages_by_offset(start_offset, adjusted_count)
             .await
             .with_error_context(|_| format!(
-                "{COMPONENT} - failed to get messages by offset, patititon: {}, timestamp: {}, start offset: {}",
+                "{COMPONENT} - failed to get messages by offset, partititon: {}, timestamp: {}, start offset: {}",
                 self, timestamp, start_offset,
             ))?
             .into_iter()
@@ -290,8 +290,10 @@ impl Partition {
         );
 
         if start_offset >= first_buffered_offset {
+            cache.record_hit();
             return Some(self.load_messages_from_cache(start_offset, end_offset));
         }
+        cache.record_miss();
         None
     }
 

--- a/server/src/streaming/partitions/partition.rs
+++ b/server/src/streaming/partitions/partition.rs
@@ -7,6 +7,7 @@ use crate::streaming::segments::segment::Segment;
 use crate::streaming::storage::SystemStorage;
 use dashmap::DashMap;
 use iggy::consumer::ConsumerKind;
+use iggy::models::stats::CacheMetrics;
 use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::duration::IggyDuration;
 use iggy::utils::expiry::IggyExpiry;
@@ -169,6 +170,23 @@ impl Partition {
         }
 
         partition
+    }
+
+    pub fn get_cache_metrics(&self) -> CacheMetrics {
+        if let Some(cache) = self.cache.as_ref() {
+            let cache_metrics = cache.get_metrics();
+            CacheMetrics {
+                hits: cache_metrics.hits,
+                misses: cache_metrics.misses,
+                hit_ratio: cache_metrics.hit_ratio,
+            }
+        } else {
+            CacheMetrics {
+                hits: 0,
+                misses: 0,
+                hit_ratio: 0.0,
+            }
+        }
     }
 }
 

--- a/server/src/streaming/systems/stats.rs
+++ b/server/src/streaming/systems/stats.rs
@@ -3,8 +3,9 @@ use crate::versioning::SemanticVersion;
 use crate::VERSION;
 use iggy::error::IggyError;
 use iggy::locking::IggySharedMutFn;
-use iggy::models::stats::Stats;
+use iggy::models::stats::{CacheMetricsKey, Stats};
 use iggy::utils::duration::IggyDuration;
+use std::collections::HashMap;
 use std::sync::OnceLock;
 use sysinfo::{Pid, ProcessesToUpdate, System as SysinfoSystem};
 use tokio::sync::Mutex;
@@ -37,6 +38,21 @@ impl System {
         let kernel_version =
             sysinfo::System::kernel_version().unwrap_or("unknown_kernel_version".to_string());
 
+        let mut cache_metrics = HashMap::new();
+        for stream in self.streams.values() {
+            for topic in stream.topics.values() {
+                for partition in topic.partitions.values() {
+                    let key = CacheMetricsKey {
+                        stream_id: stream.stream_id,
+                        topic_id: topic.topic_id,
+                        partition_id: partition.read().await.partition_id,
+                    };
+                    let metrics = partition.read().await.get_cache_metrics();
+                    cache_metrics.insert(key, metrics);
+                }
+            }
+        }
+
         let mut stats = Stats {
             process_id,
             total_cpu_usage,
@@ -51,6 +67,7 @@ impl System {
             iggy_server_semver: SemanticVersion::current()
                 .ok()
                 .and_then(|v| v.get_numeric_version().ok()),
+            cache_metrics,
             ..Default::default()
         };
 


### PR DESCRIPTION
This commit introduces cache metrics tracking and p9999 latency measurement to improve performance monitoring and analysis. The `human-repr` crate is added to enhance readability of large numbers in logs and reports.

- Updated `Cargo.toml` and `Cargo.lock` to include `human-repr` dependency.
- Added cache metrics collection and serialization in both client and server.
- Implemented p9999 latency tracking in benchmark reports and analytics.
- Enhanced logging with human-readable counts and sizes using `human-repr`.
- Refactored code to accommodate new metrics and improve clarity.

