### PR TITLE
Fix consumer group member partition assignments for no partitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.92"
+version = "0.6.93"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -4482,7 +4482,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.131"
+version = "0.4.140"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.92"
+version = "0.6.93"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"

--- a/sdk/src/models/messages.rs
+++ b/sdk/src/models/messages.rs
@@ -22,7 +22,7 @@ pub const POLLED_MESSAGE_METADATA: u32 = 8 + 1 + 8 + 4;
 /// - `messages`: the collection of messages.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PolledMessages {
-    /// The identifier of the partition.
+    /// The identifier of the partition. If it's '0', then there's no partition assigned to the consumer group member.
     pub partition_id: u32,
     /// The current offset of the partition.
     pub current_offset: u64,

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.131"
+version = "0.4.140"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/topics/consumer_offsets.rs
+++ b/server/src/streaming/topics/consumer_offsets.rs
@@ -15,10 +15,13 @@ impl Topic {
         partition_id: Option<u32>,
         client_id: u32,
     ) -> Result<(), IggyError> {
-        let (polling_consumer, partition_id) = self
+        let Some((polling_consumer, partition_id)) = self
             .resolve_consumer_with_partition_id(&consumer, client_id, partition_id, false)
             .await
-            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer ID: {}, client ID: {}, partition ID: {:?}", consumer.id, client_id, partition_id))?;
+            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer ID: {}, client ID: {}, partition ID: {:?}", consumer.id, client_id, partition_id))? else {
+            return Err(IggyError::ConsumerOffsetNotFound(client_id));
+        };
+
         let partition = self.get_partition(partition_id).with_error_context(|_| {
             format!("{COMPONENT} - failed to get partition with id: {partition_id}")
         })?;
@@ -48,10 +51,13 @@ impl Topic {
         partition_id: Option<u32>,
         client_id: u32,
     ) -> Result<Option<ConsumerOffsetInfo>, IggyError> {
-        let (polling_consumer, partition_id) = self
+        let Some((polling_consumer, partition_id)) = self
             .resolve_consumer_with_partition_id(consumer, client_id, partition_id, false)
             .await
-            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer: {consumer}, client ID: {client_id}, partition ID: {:?}", partition_id))?;
+            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer: {consumer}, client ID: {client_id}, partition ID: {:?}", partition_id))? else {
+            return Ok(None);
+        };
+
         let partition = self.get_partition(partition_id).with_error_context(|_| {
             format!("{COMPONENT} - failed to get partition with id: {partition_id}")
         })?;
@@ -79,10 +85,13 @@ impl Topic {
         partition_id: Option<u32>,
         client_id: u32,
     ) -> Result<(), IggyError> {
-        let (polling_consumer, partition_id) = self
+        let Some((polling_consumer, partition_id)) = self
             .resolve_consumer_with_partition_id(&consumer, client_id, partition_id, false)
             .await
-            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer ID: {}, client ID: {}, partition ID: {:?}", consumer.id, client_id, partition_id))?;
+            .with_error_context(|_| format!("{COMPONENT} - failed to resolve consumer with partition id, consumer ID: {}, client ID: {}, partition ID: {:?}", consumer.id, client_id, partition_id))? else {
+            return Err(IggyError::ConsumerOffsetNotFound(client_id));
+        };
+
         let partition = self.get_partition(partition_id).with_error_context(|_| {
             format!("{COMPONENT} - failed to get partition with id: {partition_id}")
         })?;


### PR DESCRIPTION
This fixes #1478 by returning no messages and none partition ID internally, if there's more consumer group members than the available partitions to be assigned.