### PR TITLE
Use case-sensitive names for resources such as streams, topics, users etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.93"
+version = "0.6.100"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -2395,10 +2395,8 @@ dependencies = [
  "futures-util",
  "humantime",
  "keyring",
- "lazy_static",
  "passterm",
  "quinn",
- "regex",
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
@@ -4482,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.140"
+version = "0.4.150"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.93"
+version = "0.6.100"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"
@@ -41,10 +41,8 @@ keyring = { version = "3.6.1", optional = true, features = [
     "sync-secret-service",
     "vendored",
 ] }
-lazy_static = "1.5.0"
 passterm = { version = "2.0.1", optional = true }
 quinn = { version = "0.11.6" }
-regex = "1.11.1"
 reqwest = { version = "0.12.12", default-features = false, features = [
     "json",
     "rustls-tls",

--- a/sdk/src/consumer_groups/create_consumer_group.rs
+++ b/sdk/src/consumer_groups/create_consumer_group.rs
@@ -4,7 +4,6 @@ use crate::consumer_groups::MAX_NAME_LENGTH;
 use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::utils::sizeable::Sizeable;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -16,7 +15,7 @@ use std::str::from_utf8;
 /// - `stream_id` - unique stream ID (numeric or name).
 /// - `topic_id` - unique topic ID (numeric or name).
 /// - `group_id` - unique consumer group ID.
-/// - `name` - unique consumer group name, max length is 255 characters. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
+/// - `name` - unique consumer group name, max length is 255 characters.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreateConsumerGroup {
     /// Unique stream ID (numeric or name).
@@ -57,10 +56,6 @@ impl Validatable<IggyError> for CreateConsumerGroup {
         }
 
         if self.name.is_empty() || self.name.len() > MAX_NAME_LENGTH {
-            return Err(IggyError::InvalidConsumerGroupName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidConsumerGroupName);
         }
 

--- a/sdk/src/identifier.rs
+++ b/sdk/src/identifier.rs
@@ -2,7 +2,6 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::error::IggyError;
 use crate::utils::byte_size::IggyByteSize;
 use crate::utils::sizeable::Sizeable;
-use crate::utils::text::to_lowercase_non_whitespace;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -151,14 +150,13 @@ impl Identifier {
         })
     }
 
-    /// Creates a new identifier from the given string value. The name will always be converted to lowercase and all whitespaces will be replaced with dots.
+    /// Creates a new identifier from the given string value.
     pub fn named(value: &str) -> Result<Self, IggyError> {
         let length = value.len();
         if length == 0 || length > 255 {
             return Err(IggyError::InvalidIdentifier);
         }
 
-        let value = to_lowercase_non_whitespace(value);
         Ok(Self {
             kind: IdKind::String,
             #[allow(clippy::cast_possible_truncation)]

--- a/sdk/src/models/topic.rs
+++ b/sdk/src/models/topic.rs
@@ -12,8 +12,8 @@ use serde::{Deserialize, Serialize};
 /// - `created_at`: the timestamp when the topic was created.
 /// - `name`: the unique name of the topic.
 /// - `size`: the total size of the topic in bytes.
-/// - `message_expiry`: the optional expiry of the messages in the topic in seconds.
-/// - `max_topic_size`: the optional maximum size of the topic in bytes.
+/// - `message_expiry`: the expiry of the messages in the topic.
+/// - `max_topic_size`: the maximum size of the topic.
 /// - `replication_factor`: replication factor for the topic.
 /// - `messages_count`: the total number of messages in the topic.
 /// - `partitions_count`: the total number of partitions in the topic.
@@ -48,8 +48,8 @@ pub struct Topic {
 /// - `created_at`: the timestamp when the topic was created.
 /// - `name`: the unique name of the topic.
 /// - `size`: the total size of the topic.
-/// - `message_expiry`: the optional expiry of the messages in the topic in seconds.
-/// - `max_topic_size`: the optional maximum size of the topic.
+/// - `message_expiry`: the expiry of the messages in the topic.
+/// - `max_topic_size`: the maximum size of the topic.
 /// - `replication_factor`: replication factor for the topic.
 /// - `messages_count`: the total number of messages in the topic.
 /// - `partitions_count`: the total number of partitions in the topic.

--- a/sdk/src/personal_access_tokens/create_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/create_personal_access_token.rs
@@ -3,7 +3,6 @@ use crate::command::{Command, CREATE_PERSONAL_ACCESS_TOKEN_CODE};
 use crate::error::IggyError;
 use crate::users::defaults::*;
 use crate::utils::expiry::IggyExpiry;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -12,13 +11,13 @@ use std::str::from_utf8;
 
 /// `CreatePersonalAccessToken` command is used to create a new personal access token for the authenticated user.
 /// It has additional payload:
-/// - `name` - unique name of the token, must be between 3 and 30 characters long. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
-/// - `expiry` - expiry in seconds (optional), if provided, must be between 1 and 4294967295. Otherwise, the token will never expire.
+/// - `name` - unique name of the token, must be between 3 and 30 characters long.
+/// - `expiry` - expiry of the token.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreatePersonalAccessToken {
     /// Unique name of the token, must be between 3 and 30 characters long.
     pub name: String,
-    /// Expiry in seconds (optional), if provided, must be between 1 and 4294967295. Otherwise, the token will never expire.
+    /// Expiry of the token.
     pub expiry: IggyExpiry,
 }
 
@@ -43,10 +42,6 @@ impl Validatable<IggyError> for CreatePersonalAccessToken {
             || self.name.len() > MAX_PERSONAL_ACCESS_TOKEN_NAME_LENGTH
             || self.name.len() < MIN_PERSONAL_ACCESS_TOKEN_NAME_LENGTH
         {
-            return Err(IggyError::InvalidPersonalAccessTokenName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidPersonalAccessTokenName);
         }
 

--- a/sdk/src/personal_access_tokens/delete_personal_access_token.rs
+++ b/sdk/src/personal_access_tokens/delete_personal_access_token.rs
@@ -2,7 +2,6 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::{Command, DELETE_PERSONAL_ACCESS_TOKEN_CODE};
 use crate::error::IggyError;
 use crate::users::defaults::*;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -11,7 +10,7 @@ use std::str::from_utf8;
 
 /// `DeletePersonalAccessToken` command is used to delete a personal access token for the authenticated user.
 /// It has additional payload:
-/// - `name` - unique name of the token, must be between 3 and 30 characters long. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
+/// - `name` - unique name of the token, must be between 3 and 30 characters long.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct DeletePersonalAccessToken {
     /// Unique name of the token, must be between 3 and 30 characters long.
@@ -38,10 +37,6 @@ impl Validatable<IggyError> for DeletePersonalAccessToken {
             || self.name.len() > MAX_PERSONAL_ACCESS_TOKEN_NAME_LENGTH
             || self.name.len() < MIN_PERSONAL_ACCESS_TOKEN_NAME_LENGTH
         {
-            return Err(IggyError::InvalidPersonalAccessTokenName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidPersonalAccessTokenName);
         }
 

--- a/sdk/src/streams/create_stream.rs
+++ b/sdk/src/streams/create_stream.rs
@@ -2,7 +2,6 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::{Command, CREATE_STREAM_CODE};
 use crate::error::IggyError;
 use crate::streams::MAX_NAME_LENGTH;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -12,7 +11,7 @@ use std::str::from_utf8;
 /// `CreateStream` command is used to create a new stream.
 /// It has additional payload:
 /// - `stream_id` - unique stream ID (numeric)
-/// - `name` - unique stream name (string), max length is 255 characters. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
+/// - `name` - unique stream name (string), max length is 255 characters.
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct CreateStream {
     /// Unique stream ID (numeric), if None is provided then the server will automatically assign it.
@@ -45,10 +44,6 @@ impl Validatable<IggyError> for CreateStream {
         }
 
         if self.name.is_empty() || self.name.len() > MAX_NAME_LENGTH {
-            return Err(IggyError::InvalidStreamName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidStreamName);
         }
 

--- a/sdk/src/streams/update_stream.rs
+++ b/sdk/src/streams/update_stream.rs
@@ -4,7 +4,6 @@ use crate::error::IggyError;
 use crate::identifier::Identifier;
 use crate::streams::MAX_NAME_LENGTH;
 use crate::utils::sizeable::Sizeable;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -42,10 +41,6 @@ impl Default for UpdateStream {
 impl Validatable<IggyError> for UpdateStream {
     fn validate(&self) -> Result<(), IggyError> {
         if self.name.is_empty() || self.name.len() > MAX_NAME_LENGTH {
-            return Err(IggyError::InvalidStreamName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidStreamName);
         }
 

--- a/sdk/src/topics/update_topic.rs
+++ b/sdk/src/topics/update_topic.rs
@@ -6,7 +6,6 @@ use crate::identifier::Identifier;
 use crate::topics::MAX_NAME_LENGTH;
 use crate::utils::expiry::IggyExpiry;
 use crate::utils::sizeable::Sizeable;
-use crate::utils::text;
 use crate::utils::topic_size::MaxTopicSize;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
@@ -18,8 +17,8 @@ use std::str::from_utf8;
 /// It has additional payload:
 /// - `stream_id` - unique stream ID (numeric or name).
 /// - `topic_id` - unique topic ID (numeric or name).
-/// - `message_expiry` - optional message expiry in seconds, if `None` then messages will never expire.
-/// - `max_topic_size` - optional maximum size of the topic in bytes, if `None` then topic size is unlimited.
+/// - `message_expiry` - message expiry, if `NeverExpire` then messages will never expire.
+/// - `max_topic_size` - maximum size of the topic in bytes, if `Unlimited` then topic size is unlimited.
 ///                      Can't be lower than segment size in the config.
 /// - `replication_factor` - replication factor for the topic.
 /// - `name` - unique topic name, max length is 255 characters.
@@ -33,9 +32,9 @@ pub struct UpdateTopic {
     pub topic_id: Identifier,
     /// Compression algorithm for the topic.
     pub compression_algorithm: CompressionAlgorithm,
-    /// Optional message expiry in seconds, if `None` then messages will never expire.
+    /// Message expiry, if `NeverExpire` then messages will never expire.
     pub message_expiry: IggyExpiry,
-    /// Optional max topic size, if `None` then topic size is unlimited.
+    /// Max topic size, if `Unlimited` then topic size is unlimited.
     /// Can't be lower than segment size in the config.
     pub max_topic_size: MaxTopicSize,
     /// Replication factor for the topic.
@@ -67,10 +66,6 @@ impl Default for UpdateTopic {
 impl Validatable<IggyError> for UpdateTopic {
     fn validate(&self) -> Result<(), IggyError> {
         if self.name.is_empty() || self.name.len() > MAX_NAME_LENGTH {
-            return Err(IggyError::InvalidTopicName);
-        }
-
-        if !text::is_resource_name_valid(&self.name) {
             return Err(IggyError::InvalidTopicName);
         }
 

--- a/sdk/src/users/create_user.rs
+++ b/sdk/src/users/create_user.rs
@@ -4,7 +4,6 @@ use crate::error::IggyError;
 use crate::models::permissions::Permissions;
 use crate::models::user_status::UserStatus;
 use crate::users::defaults::*;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -13,7 +12,7 @@ use std::str::from_utf8;
 
 /// `CreateUser` command is used to create a new user.
 /// It has additional payload:
-/// - `username` - unique name of the user, must be between 3 and 50 characters long. The name will be always converted to lowercase and all whitespaces will be replaced with dots.
+/// - `username` - unique name of the user, must be between 3 and 50 characters long.
 /// - `password` - password of the user, must be between 3 and 100 characters long.
 /// - `status` - status of the user, can be either `active` or `inactive`.
 /// - `permissions` - optional permissions of the user. If not provided, user will have no permissions.
@@ -52,10 +51,6 @@ impl Validatable<IggyError> for CreateUser {
             || self.username.len() > MAX_USERNAME_LENGTH
             || self.username.len() < MIN_USERNAME_LENGTH
         {
-            return Err(IggyError::InvalidUsername);
-        }
-
-        if !text::is_resource_name_valid(&self.username) {
             return Err(IggyError::InvalidUsername);
         }
 

--- a/sdk/src/users/login_user.rs
+++ b/sdk/src/users/login_user.rs
@@ -2,7 +2,6 @@ use crate::bytes_serializable::BytesSerializable;
 use crate::command::{Command, LOGIN_USER_CODE};
 use crate::error::IggyError;
 use crate::users::defaults::*;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -48,10 +47,6 @@ impl Validatable<IggyError> for LoginUser {
             || self.username.len() > MAX_USERNAME_LENGTH
             || self.username.len() < MIN_USERNAME_LENGTH
         {
-            return Err(IggyError::InvalidUsername);
-        }
-
-        if !text::is_resource_name_valid(&self.username) {
             return Err(IggyError::InvalidUsername);
         }
 

--- a/sdk/src/users/update_user.rs
+++ b/sdk/src/users/update_user.rs
@@ -5,7 +5,6 @@ use crate::identifier::Identifier;
 use crate::models::user_status::UserStatus;
 use crate::users::defaults::*;
 use crate::utils::sizeable::Sizeable;
-use crate::utils::text;
 use crate::validatable::Validatable;
 use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
@@ -42,10 +41,6 @@ impl Validatable<IggyError> for UpdateUser {
             || username.len() > MAX_USERNAME_LENGTH
             || username.len() < MIN_USERNAME_LENGTH
         {
-            return Err(IggyError::InvalidUsername);
-        }
-
-        if !text::is_resource_name_valid(username) {
             return Err(IggyError::InvalidUsername);
         }
 

--- a/sdk/src/utils/text.rs
+++ b/sdk/src/utils/text.rs
@@ -1,24 +1,6 @@
 use crate::error::IggyError;
 use base64::engine::general_purpose;
 use base64::Engine;
-use lazy_static::lazy_static;
-use regex::Regex;
-
-lazy_static! {
-    static ref RESOURCE_NAME_REGEX: Regex = Regex::new(r"^[\w\.\-\s]+$").unwrap();
-}
-
-pub fn to_lowercase_non_whitespace(value: &str) -> String {
-    value
-        .to_lowercase()
-        .split_whitespace()
-        .collect::<Vec<&str>>()
-        .join(".")
-}
-
-pub fn is_resource_name_valid(value: &str) -> bool {
-    RESOURCE_NAME_REGEX.is_match(value)
-}
 
 pub fn from_base64_as_bytes(value: &str) -> Result<Vec<u8>, IggyError> {
     let result = general_purpose::STANDARD.decode(value);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.140"
+version = "0.4.150"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/topics/consumer_groups.rs
+++ b/server/src/streaming/topics/consumer_groups.rs
@@ -5,7 +5,6 @@ use error_set::ErrContext;
 use iggy::error::IggyError;
 use iggy::identifier::{IdKind, Identifier};
 use iggy::locking::IggySharedMutFn;
-use iggy::utils::text;
 use std::sync::atomic::Ordering;
 use tokio::sync::RwLock;
 use tracing::info;
@@ -70,10 +69,9 @@ impl Topic {
         group_id: Option<u32>,
         name: &str,
     ) -> Result<&RwLock<ConsumerGroup>, IggyError> {
-        let name = text::to_lowercase_non_whitespace(name);
-        if self.consumer_groups_ids.contains_key(&name) {
+        if self.consumer_groups_ids.contains_key(name) {
             return Err(IggyError::ConsumerGroupNameAlreadyExists(
-                name,
+                name.to_owned(),
                 self.topic_id,
             ));
         }
@@ -104,9 +102,9 @@ impl Topic {
         }
 
         let consumer_group =
-            ConsumerGroup::new(self.topic_id, id, &name, self.partitions.len() as u32);
+            ConsumerGroup::new(self.topic_id, id, name, self.partitions.len() as u32);
         self.consumer_groups.insert(id, RwLock::new(consumer_group));
-        self.consumer_groups_ids.insert(name, id);
+        self.consumer_groups_ids.insert(name.to_owned(), id);
         info!(
             "Created consumer group with ID: {} for topic with ID: {} and stream with ID: {}.",
             id, self.topic_id, self.stream_id


### PR DESCRIPTION
Remove the existing convention which would rename the received resource name to lowercase, replace whitespace characters with dots etc. - let the user decide and be responsible for naming the things.