### PR TITLE
Update benchmark naming and expected message count

### DIFF
--- a/.github/workflows/backwards_compatibility.yml
+++ b/.github/workflows/backwards_compatibility.yml
@@ -104,11 +104,11 @@ jobs:
           log-output-if: timeout
           tail: true
 
-      - name: Run send bench (origin/master)
+      - name: Run producer bench (origin/master)
         timeout-minutes: 1
         run: target/debug/iggy-bench --verbose --message-batches 50 --messages-per-batch 100 pinned-producer tcp
 
-      - name: Run poll bench (origin/master)
+      - name: Run consumer bench (origin/master)
         timeout-minutes: 1
         run: target/debug/iggy-bench --verbose --message-batches 50 --messages-per-batch 100 pinned-consumer tcp
 
@@ -150,7 +150,7 @@ jobs:
           log-output-if: timeout
           tail: true
 
-      - name: Run poll bench (PR)
+      - name: Run consumer bench (PR)
         timeout-minutes: 1
         run: target/debug/iggy-bench --verbose --message-batches 50 --messages-per-batch 100 pinned-consumer tcp
 

--- a/.github/workflows/post_release.yml
+++ b/.github/workflows/post_release.yml
@@ -37,17 +37,17 @@ jobs:
           sleep 1
           ss -tuln | grep :8090
 
-      - name: Test Benchmark - Send
+      - name: Test Benchmark - Producer
         timeout-minutes: 1
         run: |
           ./target/debug/iggy-bench --skip-server-start --message-batches 100 --messages-per-batch 100 pinned-producer tcp --server-address 127.0.0.1:8090
 
-      - name: Test Benchmark - Poll
+      - name: Test Benchmark - Consumer
         timeout-minutes: 1
         run: |
           ./target/debug/iggy-bench --skip-server-start --message-batches 100 --messages-per-batch 100 pinned-consumer tcp --server-address 127.0.0.1:8090
 
-      - name: Test Benchmark - Send and Poll
+      - name: Test Benchmark - Producer and Consumer
         timeout-minutes: 1
         run: |
           ./target/debug/iggy-bench --skip-server-start --message-batches 100 --messages-per-batch 100 pinned-producer-and-consumer tcp --server-address 127.0.0.1:8090
@@ -58,7 +58,7 @@ jobs:
           STATS=$(./target/debug/iggy -u iggy -p iggy stats)
           echo "$STATS"
           MESSAGE_COUNT=$(./target/debug/iggy -u iggy -p iggy -q stats -o json | jq '.messages_count')
-          readonly EXPECTED_MESSAGE_COUNT=200000
+          readonly EXPECTED_MESSAGE_COUNT=160000
           if [ "$MESSAGE_COUNT" -ne "$EXPECTED_MESSAGE_COUNT" ]; then
             echo "Expected message count to be $EXPECTED_MESSAGE_COUNT, but got $MESSAGE_COUNT"
             exit 1


### PR DESCRIPTION
This commit updates the naming conventions in the GitHub workflows for
benchmarking tasks to use "Producer" and "Consumer" instead of "Send" and
"Poll". Additionally, the expected message count in the post-release
workflow has been adjusted from 200,000 to 160,000 to reflect the updated
benchmarking parameters.

This closes #1483.
