### PR TITLE
Add identifier to benchmark script in CI workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Run predefined benchmarks
         timeout-minutes: 60
-        run: ./scripts/performance/run-standard-performance-suite.sh
+        run: ./scripts/performance/run-standard-performance-suite.sh --identifier iggy-ci
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This change updates the GitHub Actions workflow to include an identifier
`iggy-ci` when running the standard performance suite script. This helps
in distinguishing benchmark results generated by CI from other runs,
facilitating better tracking and analysis of performance data.
