### PR TITLE
Fix polling when batch size is greater than messages_required_to_save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,7 +4481,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.150"
+version = "0.4.151"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.150"
+version = "0.4.151"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
The messages_required_to_save config was incorrectly used as batch size limit,
causing messages to be split into smaller batches than requested. This fixes
polling issues where consumers couldn't retrieve their expected batch sizes.
