### PR TITLE
Implement EndToEndProducingConsumerGroup Benchmark

### DIFF
--- a/bench/report/src/types/benchmark_kind.rs
+++ b/bench/report/src/types/benchmark_kind.rs
@@ -38,7 +38,7 @@ pub enum BenchmarkKind {
     #[display("End To End Producing Consumer")]
     #[serde(rename = "end_to_end_producing_consumer")]
     EndToEndProducingConsumer,
-    // #[display("End To End Producer And Consumer Group")]
-    // #[serde(rename = "end_to_end_producer_and_consumer_group")]
-    // EndToEndProducerAndConsumerGroup,
+    #[display("End To End Producing Consumer Group")]
+    #[serde(rename = "end_to_end_producing_consumer_group")]
+    EndToEndProducingConsumerGroup,
 }

--- a/bench/report/src/types/params.rs
+++ b/bench/report/src/types/params.rs
@@ -42,12 +42,13 @@ impl BenchmarkParams {
             }
             BenchmarkKind::EndToEndProducingConsumer => {
                 format!("{} producing consumers", self.producers)
-            } // BenchmarkKind::EndToEndProducerAndConsumerGroup => {
-              //     format!(
-              //         "{} producers/{} consumers/{} consumer groups",
-              //         self.producers, self.consumers, self.consumer_groups
-              //     )
-              // }
+            }
+            BenchmarkKind::EndToEndProducingConsumerGroup => {
+                format!(
+                    "{} producing consumers/{} consumer groups",
+                    self.producers, self.consumer_groups
+                )
+            }
         }
     }
 }

--- a/bench/src/actors/consumer.rs
+++ b/bench/src/actors/consumer.rs
@@ -313,7 +313,7 @@ impl Consumer {
         Self::log_statistics(
             self.consumer_id,
             total_messages,
-            message_batches as u32,
+            current_iteration as u32,
             messages_per_batch,
             &metrics,
         );

--- a/bench/src/args/defaults.rs
+++ b/bench/src/args/defaults.rs
@@ -2,20 +2,18 @@ use nonzero_lit::u32;
 use std::num::NonZeroU32;
 
 pub const DEFAULT_HTTP_SERVER_ADDRESS: &str = "127.0.0.1:3000";
-pub const DEFAULT_HTTP_START_STREAM_ID: NonZeroU32 = u32!(1000000);
 
 pub const DEFAULT_TCP_SERVER_ADDRESS: &str = "127.0.0.1:8090";
-pub const DEFAULT_TCP_START_STREAM_ID: NonZeroU32 = u32!(3000000);
 
 pub const DEFAULT_QUIC_CLIENT_ADDRESS: &str = "127.0.0.1:0";
 pub const DEFAULT_QUIC_SERVER_ADDRESS: &str = "127.0.0.1:8080";
 pub const DEFAULT_QUIC_SERVER_NAME: &str = "localhost";
 pub const DEFAULT_QUIC_VALIDATE_CERTIFICATE: bool = false;
-pub const DEFAULT_QUIC_START_STREAM_ID: NonZeroU32 = u32!(2000000);
 
 pub const DEFAULT_MESSAGES_PER_BATCH: NonZeroU32 = u32!(1000);
 pub const DEFAULT_MESSAGE_BATCHES: NonZeroU32 = u32!(1000);
 pub const DEFAULT_MESSAGE_SIZE: NonZeroU32 = u32!(1000);
+pub const DEFAULT_START_STREAM_ID: NonZeroU32 = u32!(3000000);
 
 pub const DEFAULT_PINNED_NUMBER_OF_STREAMS: NonZeroU32 = u32!(8);
 pub const DEFAULT_BALANCED_NUMBER_OF_STREAMS: NonZeroU32 = u32!(1);

--- a/bench/src/args/examples.rs
+++ b/bench/src/args/examples.rs
@@ -3,26 +3,27 @@ const EXAMPLES: &str = r#"EXAMPLES:
 1) Pinned Mode Benchmarking:
 
     Run benchmarks with pinned producers and consumers. This mode pins specific producers
-    and consumers to specific streams and partitions:
+    and consumers to specific streams and partitions (one to one):
 
-    $ cargo r --bin iggy-bench pinned-producer --streams 10 --producers 10 tcp
-    $ cargo r --bin iggy-bench pinned-consumer --streams 10 --consumers 10 tcp
-    $ cargo r --bin iggy-bench pinned-producer-and-consumer --streams 10 --producers 10 --consumers 10 tcp
+    $ cargo r -r --bin iggy-bench -- pinned-producer --streams 10 --producers 10 tcp
+    $ cargo r -r --bin iggy-bench -- pinned-consumer --streams 10 --consumers 10 tcp
+    $ cargo r -r --bin iggy-bench -- pinned-producer-and-consumer --streams 10 --producers 10 --consumers 10 tcp
 
 2) Balanced Mode Benchmarking:
 
     Run benchmarks with balanced distribution of producers and consumers. This mode
     automatically balances the load across streams and consumer groups:
 
-    $ cargo r --bin iggy-bench balanced-producer --partitions 10 --producers 5 tcp
-    $ cargo r --bin iggy-bench balanced-consumer-group --consumers 5 tcp
-    $ cargo r --bin iggy-bench balanced-producer-and-consumer-group --partitions 2 --producers 5 --consumers 5 tcp
+    $ cargo r -r --bin iggy-bench -- balanced-producer --partitions 24 --producers 6 tcp
+    $ cargo r -r --bin iggy-bench -- balanced-consumer-group --consumers 6 tcp
+    $ cargo r -r --bin iggy-bench -- balanced-producer-and-consumer-group --partitions 24 --producers 6 --consumers 6 tcp
 
 3) End-to-End Benchmarking:
 
     Run end-to-end benchmarks that measure performance for a producer that is also a consumer:
 
-    $ cargo r --bin iggy-bench end-to-end-producing-consumer --producers 5 --consumers 5 tcp
+    $ cargo r -r --bin iggy-bench -- end-to-end-producing-consumer --producers 12 --streams 12 tcp
+    $ cargo r -r --bin iggy-bench -- end-to-end-producing-consumer-group --partitions 24 --producers 6 tcp
 
 4) Advanced Configuration:
 
@@ -32,12 +33,13 @@ const EXAMPLES: &str = r#"EXAMPLES:
     --messages-per-batch (-p): Number of messages per batch [default: 1000]
     --message-batches (-b): Total number of batches [default: 1000]
     --message-size (-m): Message size in bytes [default: 1000]
+    --start-stream-id (-S): Start stream ID [default: 1]
     --rate-limit (-r): Optional throughput limit per producer (e.g., "50KB/s", "10MB/s")
     --warmup-time (-w): Warmup duration [default: 0s]
     --sampling-time (-t): Metrics sampling interval [default: 10ms]
     --moving-average-window (-W): Window size for moving average [default: 20]
     --cleanup: Remove server data after benchmark
-    --verbose (-v): Show server output
+    --verbose (-v): Show server output (only applicable for local server)
 
     Benchmark-specific options (after the benchmark command):
     --streams (-s): Number of streams
@@ -65,26 +67,58 @@ const EXAMPLES: &str = r#"EXAMPLES:
 
     To benchmark a remote server, specify the server address in the transport subcommand:
 
-    $ cargo r --bin iggy-bench pinned-producer \
+    $ cargo r -r --bin iggy-bench -- pinned-producer \
         --streams 5 --producers 5 \
         tcp --server-address 192.168.1.100:8090
 
-6) Help and Documentation:
+6) Output Data and Results:
+
+    The benchmark tool can store detailed results for analysis and comparison:
+
+    # Basic result storage:
+    $ cargo r -r --bin iggy-bench -- pinned-producer --streams 10 --producers 10 tcp \
+        output --output-dir ./results
+
+    # Organized benchmarking with metadata:
+    $ cargo r -r --bin iggy-bench -- balanced-producer --partitions 24 --producers 6 tcp \
+        output \
+        --output-dir performance_results \
+        --identifier "prod-test-$(date +%Y%m%d)" \
+        --remark "production-config" \
+        --gitref "$(git rev-parse --short HEAD)" \
+        --gitref-date "$(git show -s --format=%cI HEAD)"
+
+    # Quick result visualization:
+    $ cargo r -r --bin iggy-bench -- end-to-end-producing-consumer --producers 12 --streams 12 tcp \
+        output \
+        --output-dir performance_results \
+        --open-charts
+
+    Output configuration options:
+    --output-dir (-o)  : Directory for storing results (required for output)
+    --identifier       : Benchmark run ID (defaults to hostname)
+    --remark           : Additional context (e.g., "production-config")
+    --extra-info       : Custom metadata for future analysis
+    --gitref           : Git reference for version tracking
+    --gitref-date      : Git reference date (merge/commit date)
+    --open-charts      : Auto-open result charts in browser
+
+7) Help and Documentation:
 
     For more details on available options:
 
     # General help
-    $ cargo r --bin iggy-bench --help
+    $ cargo r -r --bin iggy-bench -- --help
 
     # Help for specific benchmark mode
-    $ cargo r --bin iggy-bench pinned-producer --help
-    $ cargo r --bin iggy-bench balanced-consumer-group --help
-    $ cargo r --bin iggy-bench end-to-end-producing-consumer --help
+    $ cargo r -r --bin iggy-bench -- pinned-producer --help
+    $ cargo r -r --bin iggy-bench -- balanced-consumer-group --help
+    $ cargo r -r --bin iggy-bench -- end-to-end-producing-consumer --help
 
     # Help for transport options
-    $ cargo r --bin iggy-bench pinned-producer tcp --help
-    $ cargo r --bin iggy-bench balanced-producer http --help
-    $ cargo r --bin iggy-bench end-to-end-producing-consumer quic --help
+    $ cargo r -r --bin iggy-bench -- pinned-producer tcp --help
+    $ cargo r -r --bin iggy-bench -- balanced-producer http --help
+    $ cargo r -r --bin iggy-bench -- end-to-end-producing-consumer quic --help
 
 "#;
 

--- a/bench/src/args/kind.rs
+++ b/bench/src/args/kind.rs
@@ -1,7 +1,8 @@
 use super::examples::print_examples;
 use super::kinds::balanced::producer::BalancedProducerArgs;
 use super::kinds::balanced::producer_and_consumer_group::BalancedProducerAndConsumerGroupArgs;
-use super::kinds::end_to_end::producer_and_consumer::EndToEndProducingConsumerArgs;
+use super::kinds::end_to_end::producing_consumer::EndToEndProducingConsumerArgs;
+use super::kinds::end_to_end::producing_consumer_group::EndToEndProducingConsumerGroupArgs;
 use super::props::BenchmarkKindProps;
 use super::transport::BenchmarkTransportCommand;
 use crate::args::kinds::balanced::consumer_group::BalancedConsumerGroupArgs;
@@ -66,8 +67,15 @@ pub enum BenchmarkKindCommand {
         verbatim_doc_comment
     )]
     EndToEndProducingConsumer(EndToEndProducingConsumerArgs),
-    // EndToEndProducerAndConsumerGroup(EndToEndProducerAndConsumerGroupArgs),
-    /// Prints examples
+
+    #[command(
+        about = "N producing consumers assigned to M consumer groups sending and polling to/from K streams",
+        visible_alias = "e2ecg",
+        verbatim_doc_comment
+    )]
+    EndToEndProducingConsumerGroup(EndToEndProducingConsumerGroupArgs),
+
+    #[command(about = "Print examples", visible_alias = "e", verbatim_doc_comment)]
     Examples,
 }
 
@@ -87,9 +95,9 @@ impl BenchmarkKindCommand {
             BenchmarkKindCommand::EndToEndProducingConsumer(_) => {
                 BenchmarkKind::EndToEndProducingConsumer
             }
-            // BenchmarkKindCommand::EndToEndProducerAndConsumerGroup(_) => {
-            //     BenchmarkKind::EndToEndProducerAndConsumerGroup
-            // }
+            BenchmarkKindCommand::EndToEndProducingConsumerGroup(_) => {
+                BenchmarkKind::EndToEndProducingConsumerGroup
+            }
             BenchmarkKindCommand::Examples => {
                 print_examples();
                 std::process::exit(0);
@@ -136,7 +144,7 @@ impl BenchmarkKindProps for BenchmarkKindCommand {
             BenchmarkKindCommand::BalancedConsumerGroup(args) => args,
             BenchmarkKindCommand::BalancedProducerAndConsumerGroup(args) => args,
             BenchmarkKindCommand::EndToEndProducingConsumer(args) => args,
-            // BenchmarkKindCommand::EndToEndProducerAndConsumerGroup(args) => args,
+            BenchmarkKindCommand::EndToEndProducingConsumerGroup(args) => args,
             BenchmarkKindCommand::Examples => {
                 print_examples();
                 std::process::exit(0);

--- a/bench/src/args/kinds/balanced/consumer_group.rs
+++ b/bench/src/args/kinds/balanced/consumer_group.rs
@@ -16,10 +16,6 @@ pub struct BalancedConsumerGroupArgs {
     #[arg(long, default_value_t = DEFAULT_BALANCED_NUMBER_OF_STREAMS)]
     pub streams: NonZeroU32,
 
-    /// Number of partitions
-    #[arg(long, default_value_t = DEFAULT_BALANCED_NUMBER_OF_PARTITIONS)]
-    pub partitions: NonZeroU32,
-
     /// Number of consumers
     #[arg(long, default_value_t = DEFAULT_NUMBER_OF_CONSUMERS)]
     pub consumers: NonZeroU32,

--- a/bench/src/args/kinds/end_to_end/mod.rs
+++ b/bench/src/args/kinds/end_to_end/mod.rs
@@ -1,2 +1,2 @@
-pub mod producer_and_consumer;
-pub mod producer_and_consumer_group;
+pub mod producing_consumer;
+pub mod producing_consumer_group;

--- a/bench/src/args/kinds/end_to_end/producer_and_consumer_group.rs
+++ b/bench/src/args/kinds/end_to_end/producer_and_consumer_group.rs
@@ -1,1 +1,0 @@
-// not yet implemented

--- a/bench/src/args/kinds/end_to_end/producing_consumer.rs
+++ b/bench/src/args/kinds/end_to_end/producing_consumer.rs
@@ -7,7 +7,7 @@ use iggy::utils::byte_size::IggyByteSize;
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
-pub struct PinnedProducerArgs {
+pub struct EndToEndProducingConsumerArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
 
@@ -15,8 +15,8 @@ pub struct PinnedProducerArgs {
     #[arg(long, short = 's', default_value_t = DEFAULT_PINNED_NUMBER_OF_STREAMS)]
     pub streams: NonZeroU32,
 
-    /// Number of producers
-    #[arg(long, short = 'c', default_value_t = DEFAULT_NUMBER_OF_PRODUCERS)]
+    /// Number of producing consumers
+    #[arg(long, short = 'p', default_value_t = DEFAULT_NUMBER_OF_PRODUCERS)]
     pub producers: NonZeroU32,
 
     /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GB". If not provided then the server default will be used.
@@ -24,7 +24,7 @@ pub struct PinnedProducerArgs {
     pub max_topic_size: Option<IggyByteSize>,
 }
 
-impl BenchmarkKindProps for PinnedProducerArgs {
+impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
     fn streams(&self) -> u32 {
         self.streams.get()
     }
@@ -34,7 +34,7 @@ impl BenchmarkKindProps for PinnedProducerArgs {
     }
 
     fn consumers(&self) -> u32 {
-        0
+        self.producers.get()
     }
 
     fn producers(&self) -> u32 {
@@ -55,12 +55,12 @@ impl BenchmarkKindProps for PinnedProducerArgs {
 
     fn validate(&self) {
         let mut cmd = IggyBenchArgs::command();
-        let streams = self.streams();
-        let producers = self.producers();
-        if streams != producers {
+        let streams = self.streams.get();
+        let producers = self.producers.get();
+        if streams > producers {
             cmd.error(
                 ErrorKind::ArgumentConflict,
-                format!("For pinned producer, number of streams ({streams}) must be equal to the number of producers ({producers}).",
+                format!("For producing consumer, number of streams ({streams}) must be less than or equal to the number of producers ({producers}).",
             ))
             .exit();
         }

--- a/bench/src/args/kinds/end_to_end/producing_consumer_group.rs
+++ b/bench/src/args/kinds/end_to_end/producing_consumer_group.rs
@@ -7,28 +7,32 @@ use iggy::utils::byte_size::IggyByteSize;
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
-pub struct EndToEndProducingConsumerArgs {
+pub struct EndToEndProducingConsumerGroupArgs {
     #[command(subcommand)]
     pub transport: BenchmarkTransportCommand,
 
     /// Number of streams
-    #[arg(long, short = 's', default_value_t = DEFAULT_PINNED_NUMBER_OF_STREAMS)]
+    #[arg(long, short = 's', default_value_t = DEFAULT_BALANCED_NUMBER_OF_STREAMS)]
     pub streams: NonZeroU32,
 
-    /// Number of partitions
-    #[arg(long, short = 'a',default_value_t = DEFAULT_PINNED_NUMBER_OF_PARTITIONS)]
+    /// Partitions per stream
+    #[arg(long, short = 'a', default_value_t = DEFAULT_BALANCED_NUMBER_OF_PARTITIONS)]
     pub partitions: NonZeroU32,
 
-    /// Number of producers
+    /// Number of consumer groups
+    #[arg(long, short = 'g', default_value_t = DEFAULT_NUMBER_OF_CONSUMER_GROUPS)]
+    pub consumer_groups: NonZeroU32,
+
+    /// Number of producing consumers
     #[arg(long, short = 'p', default_value_t = DEFAULT_NUMBER_OF_PRODUCERS)]
     pub producers: NonZeroU32,
 
-    /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GB". If not provided then the server default will be used.
+    /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GB". If not provided then topic size will be unlimited.
     #[arg(long, short = 't')]
     pub max_topic_size: Option<IggyByteSize>,
 }
 
-impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
+impl BenchmarkKindProps for EndToEndProducingConsumerGroupArgs {
     fn streams(&self) -> u32 {
         self.streams.get()
     }
@@ -38,7 +42,7 @@ impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
     }
 
     fn consumers(&self) -> u32 {
-        0
+        self.producers.get()
     }
 
     fn producers(&self) -> u32 {
@@ -50,7 +54,7 @@ impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
     }
 
     fn number_of_consumer_groups(&self) -> u32 {
-        0
+        self.consumer_groups.get()
     }
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
@@ -58,24 +62,26 @@ impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
     }
 
     fn validate(&self) {
-        let partitions = self.partitions.get();
         let mut cmd = IggyBenchArgs::command();
-
-        if partitions > 1 {
-            cmd.error(
-                ErrorKind::ArgumentConflict,
-                format!("For producing consumer, number of partitions must be 1, got {partitions}"),
-            )
-            .exit();
-        }
-
         let streams = self.streams.get();
         let producers = self.producers.get();
         if streams > producers {
             cmd.error(
                 ErrorKind::ArgumentConflict,
-                format!("For producing consumer, number of streams ({streams}) must be less than or equal to the number of producers ({producers}).",
+                format!("For producing consumer group benchmark, number of streams ({streams}) must be less than or equal to the number of producers ({producers}).",
             ))
+            .exit();
+        }
+
+        let cg_number = self.consumer_groups.get();
+        if cg_number < streams {
+            cmd.error(
+                ErrorKind::ArgumentConflict,
+                format!(
+                    "For producing consumer group benchmark, consumer groups number ({}) must be less than the number of streams ({})",
+                    cg_number, streams
+                ),
+            )
             .exit();
         }
     }

--- a/bench/src/args/output.rs
+++ b/bench/src/args/output.rs
@@ -20,7 +20,7 @@ pub struct BenchmarkOutputArgs {
     #[arg(long)]
     pub remark: Option<String>,
 
-    /// Extra information for future use
+    /// Extra information
     #[arg(long)]
     pub extra_info: Option<String>,
 

--- a/bench/src/args/props.rs
+++ b/bench/src/args/props.rs
@@ -23,7 +23,6 @@ pub trait BenchmarkTransportProps {
     fn transport(&self) -> &Transport;
     fn server_address(&self) -> &str;
     fn client_address(&self) -> &str;
-    fn start_stream_id(&self) -> u32;
     fn validate_certificate(&self) -> bool;
     fn output_command(&self) -> &Option<BenchmarkOutputCommand>;
     fn inner(&self) -> &dyn BenchmarkTransportProps

--- a/bench/src/args/transport.rs
+++ b/bench/src/args/transport.rs
@@ -3,7 +3,6 @@ use super::{output::BenchmarkOutputCommand, props::BenchmarkTransportProps};
 use clap::{Parser, Subcommand};
 use integration::test_server::Transport;
 use serde::{Serialize, Serializer};
-use std::num::NonZeroU32;
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum BenchmarkTransportCommand {
@@ -35,10 +34,6 @@ impl BenchmarkTransportProps for BenchmarkTransportCommand {
         self.inner().server_address()
     }
 
-    fn start_stream_id(&self) -> u32 {
-        self.inner().start_stream_id()
-    }
-
     fn validate_certificate(&self) -> bool {
         self.inner().validate_certificate()
     }
@@ -66,10 +61,6 @@ pub struct HttpArgs {
     #[arg(long, default_value_t = DEFAULT_HTTP_SERVER_ADDRESS.to_owned())]
     pub server_address: String,
 
-    /// Start stream id
-    #[arg(long, default_value_t = DEFAULT_HTTP_START_STREAM_ID)]
-    pub start_stream_id: NonZeroU32,
-
     /// Optional output command, used to output results (charts, raw json data) to a directory
     #[command(subcommand)]
     pub output: Option<BenchmarkOutputCommand>,
@@ -82,10 +73,6 @@ impl BenchmarkTransportProps for HttpArgs {
 
     fn server_address(&self) -> &str {
         &self.server_address
-    }
-
-    fn start_stream_id(&self) -> u32 {
-        self.start_stream_id.get()
     }
 
     fn validate_certificate(&self) -> bool {
@@ -107,10 +94,6 @@ pub struct TcpArgs {
     #[arg(long, default_value_t = DEFAULT_TCP_SERVER_ADDRESS.to_owned())]
     pub server_address: String,
 
-    /// Start stream id
-    #[arg(long, default_value_t = DEFAULT_TCP_START_STREAM_ID)]
-    pub start_stream_id: NonZeroU32,
-
     /// Optional output command, used to output results (charts, raw json data) to a directory
     #[command(subcommand)]
     output: Option<BenchmarkOutputCommand>,
@@ -123,10 +106,6 @@ impl BenchmarkTransportProps for TcpArgs {
 
     fn server_address(&self) -> &str {
         &self.server_address
-    }
-
-    fn start_stream_id(&self) -> u32 {
-        self.start_stream_id.get()
     }
 
     fn validate_certificate(&self) -> bool {
@@ -160,10 +139,6 @@ pub struct QuicArgs {
     #[arg(long, default_value_t = DEFAULT_QUIC_VALIDATE_CERTIFICATE)]
     pub validate_certificate: bool,
 
-    /// Start stream id
-    #[arg(long, default_value_t = DEFAULT_QUIC_START_STREAM_ID)]
-    pub start_stream_id: NonZeroU32,
-
     /// Optional output command, used to output results (charts, raw json data) to a directory
     #[command(subcommand)]
     pub output: Option<BenchmarkOutputCommand>,
@@ -176,10 +151,6 @@ impl BenchmarkTransportProps for QuicArgs {
 
     fn server_address(&self) -> &str {
         &self.server_address
-    }
-
-    fn start_stream_id(&self) -> u32 {
-        self.start_stream_id.get()
     }
 
     fn validate_certificate(&self) -> bool {

--- a/bench/src/benchmarks/benchmark.rs
+++ b/bench/src/benchmarks/benchmark.rs
@@ -20,6 +20,7 @@ use super::producer_and_consumer_benchmark::ProducerAndConsumerBenchmark;
 use super::producer_and_consumer_group_benchmark::ProducerAndConsumerGroupBenchmark;
 use super::producer_benchmark::ProducerBenchmark;
 use super::producing_consumer_benchmark::EndToEndProducingConsumerBenchmark;
+use super::producing_consumer_group_benchmark::EndToEndProducingConsumerGroupBenchmark;
 
 pub type BenchmarkFutures = Result<
     Vec<Pin<Box<dyn Future<Output = Result<BenchmarkIndividualMetrics, IggyError>> + Send>>>,
@@ -52,13 +53,9 @@ impl From<IggyBenchArgs> for Box<dyn Benchmarkable> {
             BenchmarkKindCommand::EndToEndProducingConsumer(_) => Box::new(
                 EndToEndProducingConsumerBenchmark::new(Arc::new(args), client_factory),
             ),
-            // not yet implemented
-            // BenchmarkKindCommand::EndToEndProducerAndConsumerGroup(_) => {
-            //     Box::new(EndToEndProducerAndConsumerGroupBenchmark::new(
-            //         Arc::new(args),
-            //         client_factory,
-            //     ))
-            // }
+            BenchmarkKindCommand::EndToEndProducingConsumerGroup(_) => Box::new(
+                EndToEndProducingConsumerGroupBenchmark::new(Arc::new(args), client_factory),
+            ),
             _ => todo!(),
         }
     }

--- a/bench/src/benchmarks/mod.rs
+++ b/bench/src/benchmarks/mod.rs
@@ -5,6 +5,7 @@ pub mod producer_and_consumer_benchmark;
 pub mod producer_and_consumer_group_benchmark;
 pub mod producer_benchmark;
 pub mod producing_consumer_benchmark;
+pub mod producing_consumer_group_benchmark;
 
 pub const CONSUMER_GROUP_BASE_ID: u32 = 0;
 pub const CONSUMER_GROUP_NAME_PREFIX: &str = "cg";

--- a/bench/src/benchmarks/producing_consumer_group_benchmark.rs
+++ b/bench/src/benchmarks/producing_consumer_group_benchmark.rs
@@ -1,25 +1,25 @@
-use super::benchmark::{BenchmarkFutures, Benchmarkable};
-use crate::{
-    actors::consumer::Consumer,
-    args::common::IggyBenchArgs,
-    benchmarks::{CONSUMER_GROUP_BASE_ID, CONSUMER_GROUP_NAME_PREFIX},
-};
+use crate::actors::producing_consumer::ProducingConsumer;
+use crate::args::common::IggyBenchArgs;
+use crate::benchmarks::benchmark::{BenchmarkFutures, Benchmarkable};
+use crate::benchmarks::{CONSUMER_GROUP_BASE_ID, CONSUMER_GROUP_NAME_PREFIX};
+use crate::rate_limiter::RateLimiter;
 use async_trait::async_trait;
-use iggy::{
-    client::ConsumerGroupClient, clients::client::IggyClient, error::IggyError,
-    messages::poll_messages::PollingKind,
-};
+use iggy::client::ConsumerGroupClient;
+use iggy::clients::client::IggyClient;
+use iggy::error::IggyError;
+use iggy::messages::poll_messages::PollingKind;
 use iggy_bench_report::benchmark_kind::BenchmarkKind;
 use integration::test_server::{login_root, ClientFactory};
-use std::sync::{atomic::AtomicI64, Arc};
+use std::sync::atomic::AtomicI64;
+use std::sync::Arc;
 use tracing::{error, info};
 
-pub struct ConsumerGroupBenchmark {
+pub struct EndToEndProducingConsumerGroupBenchmark {
     args: Arc<IggyBenchArgs>,
     client_factory: Arc<dyn ClientFactory>,
 }
 
-impl ConsumerGroupBenchmark {
+impl EndToEndProducingConsumerGroupBenchmark {
     pub fn new(args: Arc<IggyBenchArgs>, client_factory: Arc<dyn ClientFactory>) -> Self {
         Self {
             args,
@@ -67,57 +67,77 @@ impl ConsumerGroupBenchmark {
 }
 
 #[async_trait]
-impl Benchmarkable for ConsumerGroupBenchmark {
+impl Benchmarkable for EndToEndProducingConsumerGroupBenchmark {
     async fn run(&mut self) -> BenchmarkFutures {
-        self.check_streams().await?;
+        self.init_streams().await.expect("Failed to init streams!");
         let consumer_groups_count = self.args.number_of_consumer_groups();
         self.init_consumer_groups(consumer_groups_count)
             .await
-            .expect("Failed to init consumer group");
+            .expect("Failed to init consumer groups!");
 
-        let start_stream_id = self.args.start_stream_id();
+        let actors_count = self.args.producers();
+        info!(
+            "Creating {actors_count} producing consumer(s) which belong to {consumer_groups_count} consumer groups...",
+        );
         let start_consumer_group_id = CONSUMER_GROUP_BASE_ID;
-        let consumers = self.args.consumers();
+        let start_stream_id = self.args.start_stream_id();
         let messages_per_batch = self.args.messages_per_batch();
-        let warmup_time = self.args.warmup_time();
-        let mut futures: BenchmarkFutures = Ok(Vec::with_capacity((consumers) as usize));
-        let polling_kind = PollingKind::Next;
         let message_batches = self.args.message_batches();
-        let total_message_batches = Arc::new(AtomicI64::new((message_batches * consumers) as i64));
+        let message_size = self.args.message_size();
+        let partitions_count = self.args.number_of_partitions();
+        let warmup_time = self.args.warmup_time();
+        let polling_kind = PollingKind::Next;
+        let mut futures: BenchmarkFutures = Ok(Vec::with_capacity(actors_count as usize));
+        let consumer_groups_count = self.args.number_of_consumer_groups();
+        let total_message_batches =
+            Arc::new(AtomicI64::new((message_batches * actors_count) as i64));
 
-        for consumer_id in 1..=consumers {
+        for actor_id in 1..=actors_count {
+            let args = self.args.clone();
+            let client_factory = self.client_factory.clone();
+            info!(
+                "Executing the benchmark on producing consumer #{}...",
+                actor_id
+            );
+            let stream_id = start_stream_id + 1 + (actor_id % consumer_groups_count);
             let consumer_group_id =
-                start_consumer_group_id + 1 + (consumer_id % consumer_groups_count);
-            let stream_id = start_stream_id + 1 + (consumer_id % consumer_groups_count);
+                start_consumer_group_id + 1 + (actor_id % consumer_groups_count);
 
-            let consumer = Consumer::new(
-                self.client_factory.clone(),
-                self.args.kind(),
-                consumer_id,
+            let actor = ProducingConsumer::new(
+                client_factory,
+                args.kind(),
+                actor_id,
                 Some(consumer_group_id),
                 stream_id,
+                partitions_count,
                 messages_per_batch,
                 message_batches,
-                // In this test all consumers are polling 8000 messages in total, doesn't matter which one is fastest
+                message_size,
                 total_message_batches.clone(),
                 warmup_time,
-                self.args.sampling_time(),
-                self.args.moving_average_window(),
+                args.sampling_time(),
+                args.moving_average_window(),
+                args.rate_limit()
+                    .map(|rl| RateLimiter::new(rl.as_bytes_u64())),
                 polling_kind,
-                false, // TODO: Calculate latency from timestamp in first message, it should be an argument to iggy-bench
+                false,
             );
-            let future = Box::pin(async move { consumer.run().await });
+            let future = Box::pin(async move { actor.run().await });
             futures.as_mut().unwrap().push(future);
         }
-        info!(
-            "Starting consumer group benchmark with {} messages",
-            self.total_messages()
-        );
+        info!("Created {actors_count} producing consumer(s) which would be part of {consumer_groups_count} consumer groups");
         futures
     }
 
     fn kind(&self) -> BenchmarkKind {
         self.args.kind()
+    }
+
+    fn total_messages(&self) -> u64 {
+        let messages_per_batch = self.args.messages_per_batch();
+        let message_batches = self.args.message_batches();
+        let streams = self.args.streams();
+        (messages_per_batch * message_batches * streams) as u64
     }
 
     fn args(&self) -> &IggyBenchArgs {

--- a/bench/src/runner.rs
+++ b/bench/src/runner.rs
@@ -38,7 +38,6 @@ impl BenchmarkRunner {
 
         let mut benchmark: Box<dyn Benchmarkable> = args.into();
         let mut join_handles = benchmark.run().await?;
-        info!("Benchmarking finished");
 
         let mut individual_metrics = Vec::new();
 

--- a/server/src/streaming/partitions/messages.rs
+++ b/server/src/streaming/partitions/messages.rs
@@ -107,7 +107,7 @@ impl Partition {
             .get_messages_by_offset(start_offset, adjusted_count)
             .await
             .with_error_context(|_| format!(
-                "{COMPONENT} - failed to get messages by offset, partititon: {}, timestamp: {}, start offset: {}",
+                "{COMPONENT} - failed to get messages by offset, partition: {}, timestamp: {}, start offset: {}",
                 self, timestamp, start_offset,
             ))?
             .into_iter()


### PR DESCRIPTION
This commit introduces the `EndToEndProducingConsumerGroup` benchmark, which
allows for benchmarking scenarios with producing consumers assigned to multiple
consumer groups. Key changes include:

- Added `EndToEndProducingConsumerGroup` to the `BenchmarkKind` enum.
- Implemented the `ProducingConsumer` actor to handle producing and consuming
  messages within consumer groups.
- Updated command-line arguments to support the new benchmark type.
- Modified existing benchmarks to accommodate the new consumer group logic.
- Improved logging and error handling for better traceability during execution.
