### PR TITLE
Add mimalloc allocator and adjust message save threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4511,7 +4511,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.152"
+version = "0.4.153"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -3,6 +3,8 @@ name = "bench"
 version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
+# Due to dependency to integration, which has a dependency to server, setting
+# mimalloc on server is also setting it on bench.
 
 [dependencies]
 async-trait = "0.1.86"

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -446,7 +446,7 @@ validate_checksum = false
 # The threshold of buffered messages before triggering a save to disk (integer).
 # Specifies how many messages accumulate before persisting to storage.
 # Adjusting this can balance between write performance and data durability.
-messages_required_to_save = 5000
+messages_required_to_save = 1000
 
 # Segment configuration
 [system.segment]

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -292,7 +292,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     assert_eq!(topic.name, TOPIC_NAME);
     assert_eq!(topic.partitions_count, PARTITIONS_COUNT);
     assert_eq!(topic.partitions.len(), PARTITIONS_COUNT as usize);
-    assert_eq!(topic.size, 55890);
+    assert_eq!(topic.size, 55914);
     assert_eq!(topic.messages_count, MESSAGES_COUNT as u64);
     let topic_partition = topic.partitions.get((PARTITION_ID - 1) as usize).unwrap();
     assert_eq!(topic_partition.id, PARTITION_ID);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "server"
-version = "0.4.152"
+version = "0.4.153"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"
 
 [features]
 default = []
-mimalloc = ["dep:mimalloc"]
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
 [dependencies]
@@ -35,6 +34,7 @@ futures = "0.3.31"
 human-repr = "1.1.0"
 iggy = { path = "../sdk" }
 jsonwebtoken = "9.3.1"
+mimalloc = "0.1"
 moka = { version = "0.12.10", features = ["future"] }
 openssl = { version = "0.10.70", features = ["vendored"] }
 opentelemetry = { version = "0.27.1", features = ["trace", "logs"] }
@@ -93,12 +93,6 @@ zip = "2.2.2"
 
 [dev-dependencies]
 mockall = "0.13.1"
-
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-mimalloc = { version = "0.1", optional = true }
-
-[target.'cfg(target_env = "musl")'.dependencies]
-mimalloc = { version = "0.1", features = ["override"] }
 
 [build-dependencies]
 figment = { version = "0.10.19", features = ["json", "toml", "env"] }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,7 +1,5 @@
-#[cfg(any(feature = "mimalloc", target_env = "musl"))]
 use mimalloc::MiMalloc;
 
-#[cfg(any(feature = "mimalloc", target_env = "musl"))]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 


### PR DESCRIPTION
This commit integrates the mimalloc allocator as the default feature for
both the bench and server packages, aiming to improve memory allocation
performance. The `messages_required_to_save` configuration in
`server.toml` is reduced from 5000 to 1000 to enhance performance. by
Additionally, the server version is bumped from 0.4.151 to 0.4.152 to
reflect these changes.
