### PR TITLE
Add `--fresh` flag to remove system path before starting

### DIFF
--- a/server/src/args.rs
+++ b/server/src/args.rs
@@ -5,4 +5,11 @@ use clap::Parser;
 pub struct Args {
     #[arg(short, long, default_value = "file")]
     pub config_provider: String,
+
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Remove system path (local_data by default) before starting. THIS WILL REMOVE ALL SAVED DATA!"
+    )]
+    pub fresh: bool,
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,7 +46,18 @@ async fn main() -> Result<(), ServerError> {
     let args = Args::parse();
     let config_provider = config_provider::resolve(&args.config_provider)?;
     let config = ServerConfig::load(&config_provider).await?;
-
+    if args.fresh {
+        let system_path = config.system.get_system_path();
+        if tokio::fs::metadata(&system_path).await.is_ok() {
+            println!(
+                "Removing system path at: {} because `--fresh` flag was set",
+                system_path
+            );
+            if let Err(e) = tokio::fs::remove_dir_all(&system_path).await {
+                eprintln!("Failed to remove system path at {}: {}", system_path, e);
+            }
+        }
+    }
     let mut logging = Logging::new(config.telemetry.clone());
     logging.early_init();
 


### PR DESCRIPTION
This commit introduces a new `--fresh` flag to the server's command-line
arguments. When this flag is set, the server will remove the system path
(local_data by default) before starting, effectively clearing all saved
data. This is useful for starting with a clean state.
