### PR TITLE
Change messages required to save back to 5000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4567,7 +4567,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.154"
+version = "0.4.155"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -446,7 +446,7 @@ validate_checksum = false
 # The threshold of buffered messages before triggering a save to disk (integer).
 # Specifies how many messages accumulate before persisting to storage.
 # Adjusting this can balance between write performance and data durability.
-messages_required_to_save = 1000
+messages_required_to_save = 5000
 
 # Segment configuration
 [system.segment]

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -292,7 +292,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     assert_eq!(topic.name, TOPIC_NAME);
     assert_eq!(topic.partitions_count, PARTITIONS_COUNT);
     assert_eq!(topic.partitions.len(), PARTITIONS_COUNT as usize);
-    assert_eq!(topic.size, 55914);
+    assert_eq!(topic.size, 55890);
     assert_eq!(topic.messages_count, MESSAGES_COUNT as u64);
     let topic_partition = topic.partitions.get((PARTITION_ID - 1) as usize).unwrap();
     assert_eq!(topic_partition.id, PARTITION_ID);

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.154"
+version = "0.4.155"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
There is unknown (yet) bug in server which makes it work unpredictably bad when mentioned value is set to 1000.
