### PR TITLE
chore(ci): rename release workflow and add new release_server

### DIFF
--- a/.github/workflows/post_publish_server.yml
+++ b/.github/workflows/post_publish_server.yml
@@ -1,13 +1,13 @@
-name: post_release
+name: post_publish_server
 on:
   workflow_dispatch:
   workflow_run:
-    workflows: [ "release" ]
+    workflows: [ "publish_server" ]
     types:
       - completed
 
 jobs:
-  post_release:
+  post_publish_server:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch'}}
     steps:
@@ -67,9 +67,9 @@ jobs:
       - name: Clean up
         run: docker rm -f iggy_container
 
-  finalize_post_release:
+  finalize_post_publish_server:
     runs-on: ubuntu-latest
-    needs: [ post_release ]
+    needs: [ post_publish_server ]
     if: always()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish_server.yml
+++ b/.github/workflows/publish_server.yml
@@ -1,4 +1,4 @@
-name: release
+name: publish_server
 on:
   push:
     branches:
@@ -234,92 +234,11 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.DOCKERHUB_REGISTRY_NAME }}:latest
 
-  create_github_release:
-    runs-on: ubuntu-latest
-    if: ${{ needs.tag.outputs.tag_created == 'true' }}
-    needs:
-      - tag
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Cache cargo & target directories
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: "v2"
-
-      - name: Install musl-tools on Linux
-        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
-
-      - name: Build iggy-server release binary for Linux-x86_64
-        uses: houseabsolute/actions-rust-cross@v0
-        with:
-          command: "build"
-          target: x86_64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --bin iggy-server"
-
-      - name: Build iggy-cli release binary for Linux-x86_64
-        uses: houseabsolute/actions-rust-cross@v0
-        with:
-          command: "build"
-          target: x86_64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --no-default-features --bin iggy"
-
-      - name: Prepare Linux-x86_64 artifacts
-        run: |
-          mkdir -p all_artifacts/Linux-x86_64
-          cp target/x86_64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-x86_64/
-          cp target/x86_64-unknown-linux-musl/release/iggy all_artifacts/Linux-x86_64/
-
-      - name: Build iggy-server release binary for Linux-aarch64
-        uses: houseabsolute/actions-rust-cross@v0
-        with:
-          command: "build"
-          target: aarch64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --bin iggy-server"
-
-      - name: Build iggy-cli release binary for Linux-aarch64
-        uses: houseabsolute/actions-rust-cross@v0
-        with:
-          command: "build"
-          target: aarch64-unknown-linux-musl
-          toolchain: stable
-          args: "--verbose --release --no-default-features --bin iggy"
-
-      - name: Prepare Linux-aarch64 artifacts
-        run: |
-          mkdir -p all_artifacts/Linux-aarch64
-          cp target/aarch64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-aarch64/
-          cp target/aarch64-unknown-linux-musl/release/iggy all_artifacts/Linux-aarch64/
-
-      - name: Zip artifacts for each platform
-        run: |
-          mkdir zipped_artifacts
-          for dir in all_artifacts/*; do
-            if [ -d "$dir" ]; then
-              zip -r "zipped_artifacts/$(basename $dir).zip" "$dir"
-            fi
-          done
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: zipped_artifacts/*
-          tag_name: server-${{ needs.tag.outputs.server_version }}
-          draft: false
-          prerelease: false
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  finalize_release:
+  finalize_publish_server:
     runs-on: ubuntu-latest
     needs:
       - release_and_publish
       - merge_docker_manifest
-      - create_github_release
     if: always()
     steps:
       - name: Checkout code

--- a/.github/workflows/release_server.yml
+++ b/.github/workflows/release_server.yml
@@ -1,0 +1,122 @@
+name: release_server
+
+on:
+  push:
+    tags:
+      - 'server-*'
+
+env:
+  GITHUB_TOKEN: ${{ github.token }}
+  RUST_BACKTRACE: 1
+  CARGO_TERM_COLOR: always
+  IGGY_CI_BUILD: true
+
+jobs:
+  check_release_trigger:
+    name: Check if trigger was server tag creation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if trigger was a tag creation
+        id: trigger
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/tags/server-* ]];
+          then
+            echo "This push was a tag creation."
+            echo "release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "This push was not a tag creation."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+          fi
+    outputs:
+      release: ${{ steps.trigger.outputs.release == 'true' }}
+
+  release_server:
+    name: Build and release server binary
+    needs: check_release_trigger
+    if: ${{ needs.check_release_trigger.outputs.release == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install musl-tools on Linux
+        run: sudo apt-get update --yes && sudo apt-get install --yes musl-tools
+
+      - name: Build iggy-server release binary for Linux-x86_64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: x86_64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --bin iggy-server"
+
+      - name: Build iggy-cli release binary for Linux-x86_64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: x86_64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --no-default-features --bin iggy"
+
+      - name: Prepare Linux-x86_64 artifacts
+        run: |
+          mkdir -p all_artifacts/Linux-x86_64
+          cp target/x86_64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-x86_64/
+          cp target/x86_64-unknown-linux-musl/release/iggy all_artifacts/Linux-x86_64/
+
+      - name: Build iggy-server release binary for Linux-aarch64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: aarch64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --bin iggy-server"
+
+      - name: Build iggy-cli release binary for Linux-aarch64
+        uses: houseabsolute/actions-rust-cross@v0
+        with:
+          command: "build"
+          target: aarch64-unknown-linux-musl
+          toolchain: stable
+          args: "--verbose --release --no-default-features --bin iggy"
+
+      - name: Prepare Linux-aarch64 artifacts
+        run: |
+          mkdir -p all_artifacts/Linux-aarch64
+          cp target/aarch64-unknown-linux-musl/release/iggy-server all_artifacts/Linux-aarch64/
+          cp target/aarch64-unknown-linux-musl/release/iggy all_artifacts/Linux-aarch64/
+
+      - name: Zip artifacts for each platform
+        run: |
+          mkdir zipped_artifacts
+          for dir in all_artifacts/*; do
+            if [ -d "$dir" ]; then
+              zip -r "zipped_artifacts/$(basename $dir).zip" "$dir"
+            fi
+          done
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: zipped_artifacts/*
+          tag_name: ${GITHUB_REF#refs/tags/}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  finalize_release:
+    name: Finalize release
+    runs-on: ubuntu-latest
+    needs:
+      - check_release_trigger
+      - release_server
+    if: always()
+    steps:
+      - name: Everything is fine
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+
+      - name: Some checks failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
Rename release CI workflow to publish_server and extract from that
flow step for GitHub release creation to release_server workflow
file which is triggered when server tag is created.

This fix #1517
