### PR TITLE
refactor(server): improve cache size calculation and memory tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.200"
+version = "0.4.201"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.200"
+version = "0.4.201"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/local_sizeable.rs
+++ b/server/src/streaming/local_sizeable.rs
@@ -5,3 +5,9 @@ use iggy::utils::byte_size::IggyByteSize;
 pub trait LocalSizeable {
     fn get_size_bytes(&self) -> IggyByteSize;
 }
+
+/// Trait for calculating the real memory size of a type, including all its fields
+/// and any additional overhead from containers like Arc, Vec, etc.
+pub trait RealSize {
+    fn real_size(&self) -> IggyByteSize;
+}


### PR DESCRIPTION
This commit refactors the cache size calculation by replacing the
`LocalSizeable` trait with a new `RealSize` trait. The `RealSize`
trait provides a more accurate calculation of the memory size of
types, including overhead from containers like `Arc` and `Vec`.
