### PR TITLE
fix(server): don't panic during segment deletion, improve max topic size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.201"
+version = "0.4.202"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/configs/server.toml
+++ b/configs/server.toml
@@ -422,9 +422,10 @@ path = "topics"
 # the oldest segment will be deleted upon reaching 10 GB.
 # Example: `max_topic_size = "10 GB"` means oldest messages in topics will be deleted when they reach 10 GB.
 # Note: this setting can be overwritten with CreateTopic and UpdateTopic requests.
-max_size = "10 GB"
+max_size = "unlimited"
 
 # Configures whether the oldest segments are deleted when a topic reaches its maximum size (boolean).
+# Note: segments are removed in intervals defined by `system.message_cleaner.interval`.
 delete_oldest_segments = false
 
 # Partition configuration

--- a/integration/tests/cli/topic/test_topic_create_command.rs
+++ b/integration/tests/cli/topic/test_topic_create_command.rs
@@ -7,10 +7,12 @@ use async_trait::async_trait;
 use humantime::Duration as HumanDuration;
 use iggy::client::Client;
 use iggy::compression::compression_algorithm::CompressionAlgorithm;
+use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::expiry::IggyExpiry;
 use iggy::utils::topic_size::MaxTopicSize;
 use predicates::str::diff;
 use serial_test::parallel;
+use std::str::FromStr;
 use std::time::Duration;
 
 struct TestTopicCreateCmd {
@@ -71,6 +73,8 @@ impl TestTopicCreateCmd {
         args.push(format!("{}", self.partitions_count));
         args.push(format!("{}", self.compression_algorithm));
         args.extend(self.message_expiry.clone().unwrap_or_default());
+        args.push("--max-topic-size".to_string());
+        args.push(format!("{}", self.max_topic_size));
 
         args
     }
@@ -185,7 +189,7 @@ pub async fn should_be_successful() {
             1,
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Numeric,
         ))
@@ -199,7 +203,7 @@ pub async fn should_be_successful() {
             5,
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Named,
         ))
@@ -213,7 +217,7 @@ pub async fn should_be_successful() {
             1,
             Default::default(),
             Some(vec![String::from("3days"), String::from("5s")]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Named,
         ))
@@ -232,7 +236,7 @@ pub async fn should_be_successful() {
                 String::from("1m"),
                 String::from("1s"),
             ]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Custom(IggyByteSize::from_str("1GB").unwrap()),
             1,
             TestStreamId::Numeric,
         ))

--- a/integration/tests/cli/topic/test_topic_get_command.rs
+++ b/integration/tests/cli/topic/test_topic_get_command.rs
@@ -110,7 +110,7 @@ impl IggyCmdTestCase for TestTopicGetCmd {
             )))
             .stdout(contains("Topic size          | 0"))
             .stdout(contains("Message expiry      | unlimited"))
-            .stdout(contains("Max topic size      | 10.00 GB"))
+            .stdout(contains("Max topic size      | unlimited"))
             .stdout(contains("Topic message count | 0"))
             .stdout(contains("Partitions count    | 1"));
     }

--- a/integration/tests/cli/topic/test_topic_update_command.rs
+++ b/integration/tests/cli/topic/test_topic_update_command.rs
@@ -7,10 +7,12 @@ use async_trait::async_trait;
 use humantime::Duration as HumanDuration;
 use iggy::client::Client;
 use iggy::compression::compression_algorithm::CompressionAlgorithm;
+use iggy::utils::byte_size::IggyByteSize;
 use iggy::utils::expiry::IggyExpiry;
 use iggy::utils::topic_size::MaxTopicSize;
 use predicates::str::diff;
 use serial_test::parallel;
+use std::str::FromStr;
 use std::time::Duration;
 
 struct TestTopicUpdateCmd {
@@ -84,7 +86,7 @@ impl TestTopicUpdateCmd {
         command.push(self.topic_new_compression_algorithm.to_string());
 
         if let MaxTopicSize::Custom(max_size) = &self.topic_new_max_size {
-            command.push(format!("--max-topic-bytes={}", max_size));
+            command.push(format!("--max-topic-size={}", max_size));
         }
 
         if self.topic_new_replication_factor != 1 {
@@ -162,9 +164,9 @@ impl IggyCmdTestCase for TestTopicUpdateCmd {
         })
         .to_string();
 
-        let max_topic_size = self.max_topic_size.to_string();
+        let max_topic_size = self.topic_new_max_size.to_string();
 
-        let replication_factor = self.replication_factor;
+        let replication_factor = self.topic_new_replication_factor;
         let new_topic_name = &self.topic_new_name;
 
         let expected_message = format!("Executing update topic with ID: {topic_id}, name: {new_topic_name}, \
@@ -231,12 +233,12 @@ pub async fn should_be_successful() {
             String::from("sync"),
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("new_name"),
             CompressionAlgorithm::Gzip,
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Custom(IggyByteSize::from_str("1GB").unwrap()),
             1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
@@ -250,12 +252,12 @@ pub async fn should_be_successful() {
             String::from("topic"),
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("testing"),
             CompressionAlgorithm::Gzip,
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Named,
             TestTopicId::Numeric,
@@ -269,12 +271,12 @@ pub async fn should_be_successful() {
             String::from("development"),
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("development"),
             CompressionAlgorithm::Gzip,
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Numeric,
             TestTopicId::Named,
@@ -288,7 +290,7 @@ pub async fn should_be_successful() {
             String::from("probe"),
             Default::default(),
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("development"),
             CompressionAlgorithm::Gzip,
@@ -298,7 +300,7 @@ pub async fn should_be_successful() {
                 String::from("1m"),
                 String::from("1s"),
             ]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
@@ -312,12 +314,12 @@ pub async fn should_be_successful() {
             String::from("testing"),
             Default::default(),
             Some(vec![String::from("1s")]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("testing"),
             CompressionAlgorithm::Gzip,
             Some(vec![String::from("1m 6s")]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Numeric,
             TestTopicId::Numeric,
@@ -335,12 +337,12 @@ pub async fn should_be_successful() {
                 String::from("1m"),
                 String::from("1h"),
             ]),
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             String::from("testing"),
             CompressionAlgorithm::Gzip,
             None,
-            MaxTopicSize::ServerDefault,
+            MaxTopicSize::Unlimited,
             1,
             TestStreamId::Numeric,
             TestTopicId::Named,

--- a/integration/tests/server/scenarios/system_scenario.rs
+++ b/integration/tests/server/scenarios/system_scenario.rs
@@ -131,10 +131,7 @@ pub async fn run(client_factory: &dyn ClientFactory) {
     assert_eq!(topic.size, 0);
     assert_eq!(topic.messages_count, 0);
     assert_eq!(topic.message_expiry, IggyExpiry::NeverExpire);
-    assert_eq!(
-        topic.max_topic_size,
-        MaxTopicSize::from_str("10 GB").unwrap()
-    );
+    assert_eq!(topic.max_topic_size, MaxTopicSize::Unlimited);
     assert_eq!(topic.replication_factor, 1);
 
     // 11. Get topic details by ID

--- a/sdk/src/utils/topic_size.rs
+++ b/sdk/src/utils/topic_size.rs
@@ -87,6 +87,7 @@ impl FromStr for MaxTopicSize {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let result = match s {
+            "unlimited" => MaxTopicSize::Unlimited,
             "0" | "server_default" => MaxTopicSize::ServerDefault,
             value => {
                 let size = value.parse::<IggyByteSize>().map_err(|e| format!("{e}"))?;

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.201"
+version = "0.4.202"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/channels/commands/maintain_messages.rs
+++ b/server/src/channels/commands/maintain_messages.rs
@@ -12,7 +12,7 @@ use iggy::utils::duration::IggyDuration;
 use iggy::utils::timestamp::IggyTimestamp;
 use std::sync::Arc;
 use tokio::time;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, trace};
 
 pub struct MessagesMaintainer {
     cleaner_enabled: bool,
@@ -127,9 +127,10 @@ impl ServerCommand<MaintainMessagesCommand> for MaintainMessagesExecutor {
                 };
 
                 if deleted_segments.segments_count == 0 {
-                    info!(
+                    trace!(
                         "No segments were deleted for stream ID: {}, topic ID: {}",
-                        topic.stream_id, topic.topic_id
+                        topic.stream_id,
+                        topic.topic_id
                     );
                     continue;
                 }

--- a/server/src/streaming/segments/logs/log_writer.rs
+++ b/server/src/streaming/segments/logs/log_writer.rs
@@ -161,15 +161,15 @@ impl SegmentLogWriter {
 
     pub async fn fsync(&self) -> Result<(), IggyError> {
         let mut file = self.file.write().await;
-        let file = file
-            .as_mut()
-            .unwrap_or_else(|| panic!("File {} should be open", self.file_path));
-        file.sync_all()
-            .await
-            .with_error_context(|e| {
-                format!("Failed to fsync log file: {}, error: {e}", self.file_path)
-            })
-            .map_err(|_| IggyError::CannotWriteToFile)?;
+        if let Some(file) = file.as_mut() {
+            file.sync_all()
+                .await
+                .with_error_context(|e| {
+                    format!("Failed to fsync log file: {}, error: {e}", self.file_path)
+                })
+                .map_err(|_| IggyError::CannotWriteToFile)?;
+        }
+
         Ok(())
     }
 

--- a/server/src/streaming/segments/writing_messages.rs
+++ b/server/src/streaming/segments/writing_messages.rs
@@ -151,7 +151,7 @@ impl Segment {
             self.end_offset = self.current_offset;
             self.is_closed = true;
             self.unsaved_messages = None;
-            self.close().await?;
+            self.shutdown_writing().await;
             info!(
                 "Closed segment with start offset: {}, end offset: {} for partition with ID: {}.",
                 self.start_offset, self.end_offset, self.partition_id

--- a/server/src/streaming/topics/messages.rs
+++ b/server/src/streaming/topics/messages.rs
@@ -84,7 +84,9 @@ impl Topic {
             return Err(IggyError::NoPartitions(self.topic_id, self.stream_id));
         }
 
-        if self.is_full() {
+        // Don't return an error if the topic is full and delete_oldest_segments is true.
+        // Oldest segment will be removed eventually by MaintainMessages background job.
+        if self.is_full() && self.config.topic.delete_oldest_segments {
             return Err(IggyError::TopicFull(self.topic_id, self.stream_id));
         }
 


### PR DESCRIPTION
This commit addresses a panic issue that occurred during segment deletion
and closure by ensuring proper shutdown of reading and writing tasks. It
also improves the handling of maximum topic size by allowing unlimited
size and ensuring that the oldest segments are removed by a background
job when necessary. Additionally, the logging level for certain operations
has been adjusted to provide more detailed trace information. These changes
enhance the stability and flexibility of the system in managing topic
segments and their lifecycle.
