### PR TITLE
fix(server): change log level from warn to trace for empty file checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.204"
+version = "0.4.205"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.204"
+version = "0.4.205"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/segments/indexes/index_reader.rs
+++ b/server/src/streaming/segments/indexes/index_reader.rs
@@ -55,7 +55,7 @@ impl SegmentIndexReader {
     pub async fn load_all_indexes_impl(&self) -> Result<Vec<Index>, IggyError> {
         let file_size = self.file_size();
         if file_size == 0 {
-            warn!("Index {} file is empty.", self.file_path);
+            trace!("Index file {} is empty.", self.file_path);
             return Ok(Vec::new());
         }
 
@@ -97,15 +97,17 @@ impl SegmentIndexReader {
         segment_start_offset: u64,
     ) -> Result<Option<IndexRange>, IggyError> {
         if index_start_offset > index_end_offset {
-            warn!(
+            trace!(
                 "Index start offset {} is greater than index end offset {} for file {}.",
-                index_start_offset, index_end_offset, self.file_path
+                index_start_offset,
+                index_end_offset,
+                self.file_path
             );
             return Ok(None);
         }
         let file_size = self.file_size();
         if file_size == 0 {
-            warn!("Index {} file is empty.", self.file_path);
+            trace!("Index file {} is empty.", self.file_path);
             return Ok(None);
         }
         trace!("Index file length: {} bytes.", file_size);

--- a/server/src/streaming/segments/logs/log_reader.rs
+++ b/server/src/streaming/segments/logs/log_reader.rs
@@ -76,7 +76,7 @@ impl SegmentLogReader {
     ) -> Result<Vec<RetainedMessageBatch>, IggyError> {
         let mut file_size = self.file_size();
         if file_size == 0 {
-            warn!("Log file {} is empty.", self.file_path);
+            trace!("Log file {} is empty.", self.file_path);
             return Ok(Vec::new());
         }
 
@@ -111,7 +111,7 @@ impl SegmentLogReader {
     pub async fn load_message_ids_impl(&self) -> Result<Vec<u128>, IggyError> {
         let mut file_size = self.file_size();
         if file_size == 0 {
-            warn!("Log file {} is empty.", self.file_path);
+            trace!("Log file {} is empty.", self.file_path);
             return Ok(Vec::new());
         }
 
@@ -149,7 +149,7 @@ impl SegmentLogReader {
     {
         let mut file_size = self.file_size();
         if file_size == 0 {
-            warn!("Log file {} is empty.", self.file_path);
+            trace!("Log file {} is empty.", self.file_path);
             return Ok(());
         }
 
@@ -186,7 +186,7 @@ impl SegmentLogReader {
     ) -> Result<(), IggyError> {
         let mut file_size = self.file_size();
         if file_size == 0 {
-            warn!("Log file {} is empty.", self.file_path);
+            trace!("Log file {} is empty.", self.file_path);
             return Ok(());
         }
 


### PR DESCRIPTION
This commit updates the log level from `warn` to `trace` for messages
indicating that index or log files are empty. This change is made to
reduce the verbosity of warnings in the logs when encountering empty
files, which may be a normal condition in some scenarios.
