### PR TITLE
chore(sdk): update SendMessages Display, update deps

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -116,6 +116,9 @@ jobs:
       - name: Build binary
         run: cargo build --verbose --target aarch64-apple-darwin
 
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
       - name: Run tests
         run: cargo test --verbose --target aarch64-apple-darwin
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,9 +977,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acebd8ad879283633b343856142139f2da2317c96b05b4dd6181c61e2480184"
+checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.29"
+version = "4.5.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba32cbda51c7e1dfd49acc1457ba1a7dec5b64fe360e828acb13ca8dc9c2f9"
+checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
 dependencies = [
  "anstream",
  "anstyle",
@@ -999,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.44"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+checksum = "1e3040c8291884ddf39445dc033c70abc2bc44a42f0a3a00571a0f483a83f0cd"
 dependencies = [
  "clap",
 ]
@@ -1285,9 +1285,18 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952d7c24b2615675db90c2201742b49c314dea9fa56c6688cbf8c4dee2b2553f"
+checksum = "035a5c3c87da8be7a0e5ebd6fbabcccd8651a59c27197096d1dfd74f312aaee5"
+dependencies = [
+ "ctor-proc-macro",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107adb396b2d8e7766e79151083ce1cc624b51dfd1c23e0429c50226bba693eb"
 
 [[package]]
 name = "ctr"
@@ -3207,9 +3216,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
 dependencies = [
  "bitflags 2.8.0",
  "cfg-if",
@@ -3248,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
@@ -4819,18 +4828,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4936,9 +4945,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
 dependencies = [
  "cfg-if",
  "fastrand",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -12,7 +12,7 @@ atomic-time = "0.1.5"
 bytes = "1.10.0"
 charming = "0.4.0"
 chrono = "0.4.39"
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 figlet-rs = "0.1.5"
 futures = "0.3.31"
 hostname = "0.4.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -17,8 +17,8 @@ login-session = ["dep:keyring"]
 [dependencies]
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.95"
-clap = { version = "4.5.29", features = ["derive"] }
-clap_complete = "4.5.44"
+clap = { version = "4.5.30", features = ["derive"] }
+clap_complete = "4.5.45"
 figlet-rs = "0.1.5"
 iggy = { path = "../sdk", features = ["iggy-cli"], version = "0.6.90" }
 keyring = { version = "3.6.1", features = [

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -76,7 +76,7 @@ path = "src/stream-builder/stream-producer-config/main.rs"
 ahash = { version = "0.8.11", features = ["serde"] }
 anyhow = "1.0.95"
 bytes = "1.10.0"
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 futures-util = "0.3.31"
 iggy = { path = "../sdk" }
 rand = "0.9.0"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -10,7 +10,7 @@ assert_cmd = "2.0.16"
 async-trait = "0.1.86"
 bytes = "1.10.0"
 chrono = "0.4.39"
-ctor = "0.3.3"
+ctor = "0.3.4"
 derive_more = "2.0.1"
 env_logger = "0.11.6"
 futures = "0.3.31"
@@ -24,7 +24,7 @@ predicates = "3.1.3"
 regex = "1.11.1"
 serial_test = "3.2.0"
 server = { path = "../server" }
-tempfile = "3.16.0"
+tempfile = "3.17.1"
 tokio = { version = "1.43.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.19", features = ["fmt", "env-filter"] }
 twox-hash = { version = "2.1.0", features = ["xxhash32"] }

--- a/integration/tests/cli/common/command.rs
+++ b/integration/tests/cli/common/command.rs
@@ -76,6 +76,7 @@ impl IggyCmdCommand {
         self.env.clone()
     }
 
+    #[cfg(not(target_os = "macos"))]
     pub(crate) fn disable_backtrace(self) -> Self {
         self.env("RUST_BACKTRACE", "0")
     }

--- a/integration/tests/cli/common/mod.rs
+++ b/integration/tests/cli/common/mod.rs
@@ -215,6 +215,7 @@ impl IggyCmdTest {
         test_case.verify_command(assert);
     }
 
+    #[cfg(not(target_os = "macos"))]
     pub(crate) fn get_tcp_server_address(&self) -> Option<String> {
         self.server.get_raw_tcp_addr()
     }

--- a/integration/tests/cli/system/mod.rs
+++ b/integration/tests/cli/system/mod.rs
@@ -1,10 +1,12 @@
 // Disable tests due to missing keyring on macOS until #794 is implemented
 #[cfg(not(target_os = "macos"))]
 mod test_cli_session_scenario;
+#[cfg(not(target_os = "macos"))]
 mod test_login_cmd;
 mod test_login_command;
 mod test_logout_cmd;
 mod test_logout_command;
+#[cfg(not(target_os = "macos"))]
 mod test_me_command;
 mod test_ping_command;
 mod test_snapshot_cmd;

--- a/integration/tests/cli/system/mod.rs
+++ b/integration/tests/cli/system/mod.rs
@@ -4,6 +4,7 @@ mod test_cli_session_scenario;
 #[cfg(not(target_os = "macos"))]
 mod test_login_cmd;
 mod test_login_command;
+#[cfg(not(target_os = "macos"))]
 mod test_logout_cmd;
 mod test_logout_command;
 #[cfg(not(target_os = "macos"))]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -27,7 +27,7 @@ byte-unit = { version = "5.1.6", default-features = false, features = [
 ] }
 bytes = "1.10.0"
 chrono = { version = "0.4.39" }
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 comfy-table = { version = "7.1.4", optional = true }
 crc32fast = "1.4.2"
 dashmap = "6.1.0"
@@ -54,7 +54,7 @@ rustls = { version = "0.23.23", features = ["ring"] }
 serde = { version = "1.0.217", features = ["derive", "rc"] }
 serde_json = "1.0.138"
 serde_with = { version = "3.12.0", features = ["base64"] }
-strum = { version = "0.27.0", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-rustls = { version = "0.26.1" }

--- a/sdk/src/messages/send_messages.rs
+++ b/sdk/src/messages/send_messages.rs
@@ -521,15 +521,15 @@ impl Display for SendMessages {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}|{}|{}|{}",
+            "{}|{}|{}|batch_len:{}|batch_size:{}",
             self.stream_id,
             self.topic_id,
             self.partitioning,
+            self.messages.len(),
             self.messages
                 .iter()
-                .map(std::string::ToString::to_string)
-                .collect::<Vec<String>>()
-                .join("|")
+                .map(Message::get_size_bytes)
+                .sum::<IggyByteSize>(),
         )
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -30,7 +30,7 @@ bincode = "1.3.3"
 blake3 = "1.5.5"
 bytes = "1.10.0"
 chrono = "0.4.39"
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 console-subscriber = { version = "0.4.1", optional = true }
 dashmap = "6.1.0"
 derive_more = "2.0.1"
@@ -46,7 +46,7 @@ jsonwebtoken = "9.3.1"
 mimalloc = { version = "0.1", optional = true }
 moka = { version = "0.12.10", features = ["future"] }
 nix = { version = "0.29", features = ["fs"] }
-openssl = { version = "0.10.70", features = ["vendored"] }
+openssl = { version = "0.10.71", features = ["vendored"] }
 opentelemetry = { version = "0.28.0", features = ["trace", "logs"] }
 opentelemetry-appender-tracing = { version = "0.28.1", features = ["log"] }
 opentelemetry-otlp = { version = "0.28.0", features = [
@@ -80,9 +80,9 @@ serde = { version = "1.0.217", features = ["derive", "rc"] }
 serde_json = "1.0.138"
 serde_with = { version = "3.12.0", features = ["base64", "macros"] }
 static-toml = "1.3.0"
-strum = { version = "0.27.0", features = ["derive"] }
+strum = { version = "0.27.1", features = ["derive"] }
 sysinfo = "0.33.1"
-tempfile = "3.16"
+tempfile = "3.17"
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-native-tls = "0.3.1"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/data-seeder/main.rs"
 
 [dependencies]
 anyhow = "1.0.95"
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.30", features = ["derive"] }
 iggy = { path = "../sdk" }
 rand = "0.9.0"
 tokio = { version = "1.43.0", features = ["full"] }


### PR DESCRIPTION
This commit modifies the `Display` implementation for the
`SendMessages` struct to include batch length and batch size
in the output instead of raw payload data of message, so
stdout isn't overflown with useless data.
