### PR TITLE
fix(server): correct batch materialization logic in BatchAccumulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.206"
+version = "0.4.207"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.206"
+version = "0.4.207"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/segments/indexes/index.rs
+++ b/server/src/streaming/segments/indexes/index.rs
@@ -12,6 +12,8 @@ pub struct Index {
 impl PartialEq<Self> for Index {
     fn eq(&self, other: &Self) -> bool {
         self.offset == other.offset
+            && self.position == other.position
+            && self.timestamp == other.timestamp
     }
 }
 

--- a/server/src/streaming/segments/reading_messages.rs
+++ b/server/src/streaming/segments/reading_messages.rs
@@ -299,7 +299,7 @@ impl Segment {
             start_offset,
             end_offset
         );
-        let messages_count = (start_offset + end_offset) as usize;
+        let messages_count = (start_offset + end_offset + 1) as usize;
         let messages = self
             .load_batches_by_range(index_range)
             .await

--- a/server/src/streaming/segments/writing_messages.rs
+++ b/server/src/streaming/segments/writing_messages.rs
@@ -101,9 +101,9 @@ impl Segment {
             self.partition_id
         );
 
-        let (has_remainder, batch) = batch_accumulator.materialize_batch_and_maybe_update_state();
+        let batch = batch_accumulator.materialize_batch_and_update_state();
         let batch_size = batch.get_size_bytes();
-        if has_remainder {
+        if batch_size > 0 {
             self.unsaved_messages = Some(batch_accumulator);
         }
         let confirmation = match confirmation {


### PR DESCRIPTION
This commit refactors the `BatchAccumulator` by removing the
`capacity` field and simplifying the logic for materializing
batches. The `materialize_batch_and_maybe_update_state` method
is renamed to `materialize_batch_and_update_state`, and the
logic for handling message offsets and timestamps is streamlined.

The changes improve the clarity and efficiency of the batch processing
logic, addressing issues with the previous handling of `has_remainder`.
Additionally, the logic in `writing_messages.rs` is updated to reflect
these changes, ensuring that unsaved messages are correctly managed
based on batch size.

Now, instead of having hard-limit of `messages_required_to_save` we
will trigger it once when capacity if exceeded and save all messages
on disk, instead of handling remainder.
