### PR TITLE
fix(ci): improve process management in performance scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ dependencies = [
 
 [[package]]
 name = "bench"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-trait",
  "atomic-time",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bench"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "Apache-2.0"
 # Due to dependency to integration, which has a dependency to server, setting

--- a/bench/report/src/prints.rs
+++ b/bench/report/src/prints.rs
@@ -91,12 +91,16 @@ impl BenchmarkGroupMetrics {
         let p9999 = format!("{:.2}", self.summary.average_p9999_latency_ms);
         let avg = format!("{:.2}", self.summary.average_latency_ms);
         let median = format!("{:.2}", self.summary.average_median_latency_ms);
+        let total_test_time = format!(
+            "{:.2}",
+            self.avg_throughput_mb_ts.points.last().unwrap().time_s
+        );
 
         format!(
             "{}: Total throughput: {} MB/s, {} messages/s, average throughput per {}: {} MB/s, \
             p50 latency: {} ms, p90 latency: {} ms, p95 latency: {} ms, \
             p99 latency: {} ms, p999 latency: {} ms, p9999 latency: {} ms, average latency: {} ms, \
-            median latency: {} ms",
+            median latency: {} ms, total time: {} s",
             prefix,
             total_mb,
             total_msg,
@@ -110,6 +114,7 @@ impl BenchmarkGroupMetrics {
             p9999,
             avg,
             median,
+            total_test_time
         )
         .color(color)
     }

--- a/bench/src/args/common.rs
+++ b/bench/src/args/common.rs
@@ -297,12 +297,25 @@ impl IggyBenchArgs {
             BenchmarkTransportCommand::Http(_) => "http",
         };
 
+        let actors = match &self.benchmark_kind {
+            BenchmarkKindCommand::PinnedProducer(_) => self.producers(),
+            BenchmarkKindCommand::PinnedConsumer(_) => self.consumers(),
+            BenchmarkKindCommand::PinnedProducerAndConsumer(_) => {
+                self.producers() + self.consumers()
+            }
+            BenchmarkKindCommand::BalancedProducer(_) => self.producers(),
+            BenchmarkKindCommand::BalancedConsumerGroup(_) => self.consumers(),
+            BenchmarkKindCommand::BalancedProducerAndConsumerGroup(_) => {
+                self.producers() + self.consumers()
+            }
+            BenchmarkKindCommand::EndToEndProducingConsumer(_) => self.producers(),
+            BenchmarkKindCommand::EndToEndProducingConsumerGroup(_) => self.producers(),
+            BenchmarkKindCommand::Examples => unreachable!(),
+        };
+
         let mut parts = vec![
             benchmark_kind.to_string(),
-            match benchmark_kind {
-                "send" => self.producers().to_string(),
-                _ => self.consumers().to_string(),
-            },
+            actors.to_string(),
             self.message_size().to_string(),
             self.messages_per_batch().to_string(),
             self.message_batches().to_string(),

--- a/bench/src/args/kind.rs
+++ b/bench/src/args/kind.rs
@@ -56,7 +56,7 @@ pub enum BenchmarkKindCommand {
 
     #[command(
         about = "N producers sending to M partitions in K streams, L consumers polling from P consumer groups",
-        visible_alias = "bpc",
+        visible_alias = "bpcg",
         verbatim_doc_comment
     )]
     BalancedProducerAndConsumerGroup(BalancedProducerAndConsumerGroupArgs),

--- a/scripts/performance/utils.sh
+++ b/scripts/performance/utils.sh
@@ -8,12 +8,12 @@ function get_git_iggy_server_tag_or_sha1() {
     local dir="$1"
 
     if [ -d "$dir" ]; then
-        pushd "$dir" > /dev/null || {
+        pushd "$dir" >/dev/null || {
             echo "Error: Failed to enter directory '$dir'." >&2
             exit 1
         }
 
-        if git rev-parse --git-dir > /dev/null 2>&1; then
+        if git rev-parse --git-dir >/dev/null 2>&1; then
             # Get the short commit hash
             local commit_hash
             commit_hash=$(git rev-parse --short HEAD)
@@ -22,7 +22,7 @@ function get_git_iggy_server_tag_or_sha1() {
             local matching_tags
             matching_tags=$(git tag --points-at HEAD | grep -i "server" || true)
 
-            popd > /dev/null || {
+            popd >/dev/null || {
                 echo "Error: Failed to return from directory '$dir'." >&2
                 exit 1
             }
@@ -39,7 +39,7 @@ function get_git_iggy_server_tag_or_sha1() {
             fi
         else
             echo "Error: Directory '$dir' is not a git repository." >&2
-            popd > /dev/null || exit 1
+            popd >/dev/null || exit 1
             return 1
         fi
     else
@@ -53,17 +53,17 @@ function get_git_commit_date() {
     local dir="$1"
 
     if [ -d "$dir" ]; then
-        pushd "$dir" > /dev/null || {
+        pushd "$dir" >/dev/null || {
             echo "Error: Failed to enter directory '$dir'." >&2
             exit 1
         }
 
-        if git rev-parse --git-dir > /dev/null 2>&1; then
+        if git rev-parse --git-dir >/dev/null 2>&1; then
             # Get the committer date (last modified) in ISO 8601 format
             local commit_date
             commit_date=$(git show -s --format=%cI HEAD 2>/dev/null || echo "")
 
-            popd > /dev/null || {
+            popd >/dev/null || {
                 echo "Error: Failed to return from directory '$dir'." >&2
                 exit 1
             }
@@ -76,7 +76,7 @@ function get_git_commit_date() {
             fi
         else
             echo "Error: Directory '$dir' is not a git repository." >&2
-            popd > /dev/null || exit 1
+            popd >/dev/null || exit 1
             return 1
         fi
     else
@@ -87,55 +87,61 @@ function get_git_commit_date() {
 
 # Function to construct a bench command
 function construct_bench_command() {
-    local bench_command=$1
-    local benchmark_mode=$2
-    local streams=$3
-    local actors=$4
-    local message_size=$5
-    local messages_per_batch=$6
-    local message_batches=$7
-    local protocol=$8
-    local remark=${9:-""}
-    local identifier=${10:-$(hostname)}
-    local rate_limit=${11:-""}
+    readonly bench_command=$1
+    readonly benchmark_mode=$2
+    readonly streams=$3
+    readonly actors=$4
+    readonly message_size=$5
+    readonly messages_per_batch=$6
+    readonly message_batches=$7
+    readonly protocol=$8
+    readonly remark=${9:-""}
+    readonly identifier=${10:-$(hostname)}
+    readonly rate_limit=${11:-""}
 
     # Set variables based on benchmark mode
     local actor_args=""
     case "$benchmark_mode" in
-        "pinned-producer")
-            actor_args="--producers ${actors}"
-            ;;
-        "pinned-consumer")
-            actor_args="--consumers ${actors}"
-            ;;
-        "pinned-producer-and-consumer")
-            actor_args="--producers ${actors} --consumers ${actors}"
-            ;;
-        "balanced-producer")
-            actor_args="--producers ${actors}"
-            ;;
-        "balanced-consumer-group")
-            actor_args="--consumers ${actors}"
-            ;;
-        "balanced-producer-and-consumer-group")
-            actor_args="--producers ${actors} --consumers ${actors}"
-            ;;
-        "end-to-end-producing-consumer")
-            actor_args="--producers ${actors}"
-            ;;
-        "end-to-end-producing-consumer-group")
-            actor_args="--producers ${actors}"
-            ;;
-        *)
-            echo "Error: Invalid benchmark mode '$benchmark_mode'." >&2
-            return 1
-            ;;
+    "pinned-producer")
+        actor_args="--producers ${actors}"
+        ;;
+    "pinned-consumer")
+        actor_args="--consumers ${actors}"
+        ;;
+    "pinned-producer-and-consumer")
+        actor_args="--producers ${actors} --consumers ${actors}"
+        ;;
+    "balanced-producer")
+        actor_args="--producers ${actors}"
+        ;;
+    "balanced-consumer-group")
+        actor_args="--consumers ${actors}"
+        ;;
+    "balanced-producer-and-consumer-group")
+        actor_args="--producers ${actors} --consumers ${actors}"
+        ;;
+    "end-to-end-producing-consumer")
+        actor_args="--producers ${actors}"
+        ;;
+    "end-to-end-producing-consumer-group")
+        actor_args="--producers ${actors}"
+        ;;
+    *)
+        echo "Error: Invalid benchmark mode '$benchmark_mode'." >&2
+        return 1
+        ;;
     esac
 
     local commit_hash
-    commit_hash=$(get_git_iggy_server_tag_or_sha1 .) || { echo "Failed to get git commit or tag."; exit 1; }
+    commit_hash=$(get_git_iggy_server_tag_or_sha1 .) || {
+        echo "Failed to get git commit or tag."
+        exit 1
+    }
     local commit_date
-    commit_date=$(get_git_commit_date .) || { echo "Failed to get git commit date."; exit 1; }
+    commit_date=$(get_git_commit_date .) || {
+        echo "Failed to get git commit date."
+        exit 1
+    }
 
     echo "$bench_command ${rate_limit:+ --rate-limit ${rate_limit}} \
 --message-size ${message_size} \


### PR DESCRIPTION
This commit enhances the performance scripts by:
- Using `pgrep -x` for exact process name matching to avoid
  unintended matches.
- Introducing `wait_for_process_pid` to wait for a specific
  PID to exit.
- Modifying the server start and stop logic to use the
  correct PID.
- Adding informative messages for process status checks.
- Ensuring graceful termination of processes with specific
  'PIDs.
- Improving the robustness of the script by handling
  potential race conditions.
- Adding new benchmark for single producer/consumer with
  enabled fsync and rate-limiter.

Besides that, improved print at the end of benchmark by adding
total time.
