### PR TITLE
fix(server): corrent current offset when index cache is disabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.207"
+version = "0.4.208"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.207"
+version = "0.4.208"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
This commit addresses an issue with the calculation of the current
offset in the segment when the index cache is disabled. Previously,
the logic incorrectly handled the absence of cached indexes,
potentially leading to incorrect offset values.

The updated logic ensures that the current offset is accurately
calculated regardless of the cache setting, improving the reliability
of segment handling.
