### PR TITLE
chore(ci,cli): fix github cli release

### DIFF
--- a/.github/workflows/release_cli.yml
+++ b/.github/workflows/release_cli.yml
@@ -67,7 +67,7 @@ jobs:
           command: "build"
           target: ${{ matrix.platform.target }}
           toolchain: stable
-          args: "--verbose --release -p iggy"
+          args: "--verbose --release --bin iggy"
 
       - name: Collect ${{ matrix.platform.target }} executable
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cli"
-version = "0.8.11"
+version = "0.8.12"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"


### PR DESCRIPTION
Correct build command to make sure iggy binary is build.

This fix #1564 #1565
