### PR TITLE
fix(server): refactor system write and read operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.211"
+version = "0.4.212"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.211"
+version = "0.4.212"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/binary/handlers/consumer_groups/delete_consumer_group_handler.rs
+++ b/server/src/binary/handlers/consumer_groups/delete_consumer_group_handler.rs
@@ -16,9 +16,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .delete_consumer_group(
                 session,
                 &command.stream_id,
@@ -29,9 +29,8 @@ pub async fn handle(
                 "{COMPONENT} (error: {error}) - failed to delete consumer group with ID: {} for topic with ID: {} in stream with ID: {} for session: {}",
                 command.group_id, command.topic_id, command.stream_id, session
             ))?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     let stream_id = command.stream_id.clone();
     let topic_id = command.topic_id.clone();
     let group_id = command.group_id.clone();

--- a/server/src/binary/handlers/partitions/create_partitions_handler.rs
+++ b/server/src/binary/handlers/partitions/create_partitions_handler.rs
@@ -16,9 +16,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .create_partitions(
                 session,
                 &command.stream_id,
@@ -32,9 +32,8 @@ pub async fn handle(
                     command.stream_id, command.topic_id, session
                 )
             })?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     let stream_id = command.stream_id.clone();
     let topic_id = command.topic_id.clone();
 

--- a/server/src/binary/handlers/partitions/delete_partitions_handler.rs
+++ b/server/src/binary/handlers/partitions/delete_partitions_handler.rs
@@ -19,9 +19,8 @@ pub async fn handle(
     let stream_id = command.stream_id.clone();
     let topic_id = command.topic_id.clone();
 
-    {
-        let mut system = system.write().await;
-        system
+    let mut system = system.write().await;
+    system
             .delete_partitions(
                 session,
                 &command.stream_id,
@@ -34,9 +33,8 @@ pub async fn handle(
                     "{COMPONENT} (error: {error}) - failed to delete partitions for topic with ID: {topic_id} in stream with ID: {stream_id}, session: {session}",
                 )
             })?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
@@ -18,12 +18,10 @@ pub async fn handle(
     session: &Session,
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
-    let bytes;
-    let token_hash;
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        let token = system
+
+    let mut system = system.write().await;
+    let token = system
             .create_personal_access_token(session, &command.name, command.expiry)
             .await
             .with_error_context(|error| {
@@ -32,11 +30,10 @@ pub async fn handle(
                     command.name
                 )
             })?;
-        bytes = mapper::map_raw_pat(&token);
-        token_hash = PersonalAccessToken::hash_token(&token);
-    }
+    let bytes = mapper::map_raw_pat(&token);
+    let token_hash = PersonalAccessToken::hash_token(&token);
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
+++ b/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
@@ -18,17 +18,15 @@ pub async fn handle(
     debug!("session: {session}, command: {command}");
     let token_name = command.name.clone();
 
-    {
-        let mut system = system.write().await;
-        system
+    let mut system = system.write().await;
+    system
             .delete_personal_access_token(session, &command.name)
             .await
             .with_error_context(|error| {format!(
                 "{COMPONENT} (error: {error}) - failed to delete personal access token with name: {token_name}, session: {session}"
             )})?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/streams/delete_stream_handler.rs
+++ b/server/src/binary/handlers/streams/delete_stream_handler.rs
@@ -17,17 +17,16 @@ pub async fn handle(
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
     let stream_id = command.stream_id.clone();
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .delete_stream(session, &command.stream_id)
             .await
             .with_error_context(|error| {
                 format!("{COMPONENT} (error: {error}) - failed to delete stream with ID: {stream_id}, session: {session}")
             })?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(session.get_user_id(), EntryCommand::DeleteStream(command))

--- a/server/src/binary/handlers/streams/update_stream_handler.rs
+++ b/server/src/binary/handlers/streams/update_stream_handler.rs
@@ -18,18 +18,15 @@ pub async fn handle(
     debug!("session: {session}, command: {command}");
     let stream_id = command.stream_id.clone();
 
-    {
-        let mut system = system.write().await;
-        system
+    let mut system = system.write().await;
+    system
             .update_stream(session, &command.stream_id, &command.name)
             .await
             .with_error_context(|error| {
                 format!("{COMPONENT} (error: {error}) - failed to update stream with id: {stream_id}, session: {session}")
             })?;
-    }
 
-    let system = system.read().await;
-
+    let system = system.downgrade();
     system
         .state
         .apply(session.get_user_id(), EntryCommand::UpdateStream(command))

--- a/server/src/binary/handlers/topics/delete_topic_handler.rs
+++ b/server/src/binary/handlers/topics/delete_topic_handler.rs
@@ -19,17 +19,15 @@ pub async fn handle(
     let stream_id = command.stream_id.clone();
     let topic_id = command.topic_id.clone();
 
-    {
-        let mut system = system.write().await;
-        system
+    let mut system = system.write().await;
+    system
             .delete_topic(session, &command.stream_id, &command.topic_id)
             .await
             .with_error_context(|error| format!(
                 "{COMPONENT} (error: {error}) - failed to delete topic with ID: {topic_id} in stream with ID: {stream_id}, session: {session}",
             ))?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(session.get_user_id(), EntryCommand::DeleteTopic(command))

--- a/server/src/binary/handlers/topics/update_topic_handler.rs
+++ b/server/src/binary/handlers/topics/update_topic_handler.rs
@@ -16,10 +16,10 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
 
-        let topic = system
+    let mut system = system.write().await;
+
+    let topic = system
             .update_topic(
                 session,
                 &command.stream_id,
@@ -35,13 +35,12 @@ pub async fn handle(
                 "{COMPONENT} (error: {error}) - failed to update topic with id: {}, stream_id: {}, session: {session}",
                 command.topic_id, command.stream_id
             ))?;
-        command.message_expiry = topic.message_expiry;
-        command.max_topic_size = topic.max_topic_size;
-    }
+    command.message_expiry = topic.message_expiry;
+    command.max_topic_size = topic.max_topic_size;
 
     let topic_id = command.topic_id.clone();
     let stream_id = command.stream_id.clone();
-    let system = system.read().await;
+    let system = system.downgrade();
 
     system
         .state

--- a/server/src/binary/handlers/users/change_password_handler.rs
+++ b/server/src/binary/handlers/users/change_password_handler.rs
@@ -17,9 +17,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .change_password(
                 session,
                 &command.user_id,
@@ -33,10 +33,9 @@ pub async fn handle(
                     command.user_id
                 )
             })?;
-    }
 
     // For the security of the system, we hash the password before storing it in metadata.
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/users/create_user_handler.rs
+++ b/server/src/binary/handlers/users/create_user_handler.rs
@@ -18,10 +18,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    let response;
-    {
-        let mut system = system.write().await;
-        let user = system
+
+    let mut system = system.write().await;
+    let user = system
             .create_user(
                 session,
                 &command.username,
@@ -36,11 +35,10 @@ pub async fn handle(
                     command.username
                 )
             })?;
-        response = mapper::map_user(user);
-    }
+    let response = mapper::map_user(user);
 
     // For the security of the system, we hash the password before storing it in metadata.
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/users/delete_user_handler.rs
+++ b/server/src/binary/handlers/users/delete_user_handler.rs
@@ -16,9 +16,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .delete_user(session, &command.user_id)
             .await
             .with_error_context(|error| {
@@ -27,9 +27,8 @@ pub async fn handle(
                     command.user_id
                 )
             })?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     let user_id = command.user_id.clone();
     system
         .state

--- a/server/src/binary/handlers/users/update_permissions_handler.rs
+++ b/server/src/binary/handlers/users/update_permissions_handler.rs
@@ -16,17 +16,16 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .update_permissions(session, &command.user_id, command.permissions.clone())
             .await
             .with_error_context(|error| format!("{COMPONENT} (error: {error}) - failed to update permissions for user_id: {}, session: {session}",
                 command.user_id
             ))?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(

--- a/server/src/binary/handlers/users/update_user_handler.rs
+++ b/server/src/binary/handlers/users/update_user_handler.rs
@@ -16,9 +16,9 @@ pub async fn handle(
     system: &SharedSystem,
 ) -> Result<(), IggyError> {
     debug!("session: {session}, command: {command}");
-    {
-        let mut system = system.write().await;
-        system
+
+    let mut system = system.write().await;
+    system
             .update_user(
                 session,
                 &command.user_id,
@@ -32,9 +32,8 @@ pub async fn handle(
                     command.user_id
                 )
             })?;
-    }
 
-    let system = system.read().await;
+    let system = system.downgrade();
     let user_id = command.user_id.clone();
 
     system

--- a/server/src/http/partitions.rs
+++ b/server/src/http/partitions.rs
@@ -35,9 +35,9 @@ async fn create_partitions(
     command.stream_id = Identifier::from_str_value(&stream_id)?;
     command.topic_id = Identifier::from_str_value(&topic_id)?;
     command.validate()?;
-    {
-        let mut system = state.system.write().await;
-        system
+
+    let mut system = state.system.write().await;
+    system
             .create_partitions(
                 &Session::stateless(identity.user_id, identity.ip_address),
                 &command.stream_id,
@@ -51,9 +51,8 @@ async fn create_partitions(
                     stream_id, topic_id
                 )
             })?;
-    }
 
-    let system = state.system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(identity.user_id, EntryCommand::CreatePartitions(command))
@@ -77,9 +76,9 @@ async fn delete_partitions(
     query.stream_id = Identifier::from_str_value(&stream_id)?;
     query.topic_id = Identifier::from_str_value(&topic_id)?;
     query.validate()?;
-    {
-        let mut system = state.system.write().await;
-        system
+
+    let mut system = state.system.write().await;
+    system
             .delete_partitions(
                 &Session::stateless(identity.user_id, identity.ip_address),
                 &query.stream_id.clone(),
@@ -93,9 +92,8 @@ async fn delete_partitions(
                     stream_id, topic_id
                 )
             })?;
-    }
 
-    let system = state.system.read().await;
+    let system = system.downgrade();
     system
         .state
         .apply(


### PR DESCRIPTION
This commit refactors the handling of system write and read
operations by removing unnecessary scopes and using `downgrade()`
instead of `read().await`.

This change reduces potential deadlocks.
