### PR TITLE
chore(ci, cli): add to cli configuration support for binstall

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2513,7 +2513,7 @@ dependencies = [
 
 [[package]]
 name = "iggy-cli"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy-cli"
-version = "0.8.12"
+version = "0.8.13"
 edition = "2021"
 authors = ["bartosz.ciesla@gmail.com"]
 repository = "https://github.com/iggy-rs/iggy"
@@ -38,3 +38,7 @@ tracing-subscriber = { version = "0.3.19", default-features = false, features = 
 [[bin]]
 name = "iggy"
 path = "src/main.rs"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/{ name }-{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"


### PR DESCRIPTION
Add binstall section to iggy-cli Cargo.toml to allow users to
use cargo binstall or cargo install-update and fetch binary
artefacts from iggy official ci release. Bump cli version
for testing purposes.
