### PR TITLE
fix(server): correct getting messages by timestamp from unsaved_buffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2447,7 +2447,7 @@ dependencies = [
 
 [[package]]
 name = "iggy"
-version = "0.6.202"
+version = "0.6.203"
 dependencies = [
  "aes-gcm",
  "ahash 0.8.11",
@@ -4623,7 +4623,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.212"
+version = "0.4.213"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",

--- a/integration/tests/streaming/get_by_offset.rs
+++ b/integration/tests/streaming/get_by_offset.rs
@@ -50,7 +50,7 @@ fn index_cache_disabled() -> bool {
 
 #[test_matrix(
     [msg_size(50), msg_size(1000), msg_size(20000)],
-    [msgs_req_to_save(10), msgs_req_to_save(24)],
+    [msgs_req_to_save(10), msgs_req_to_save(24), msgs_req_to_save(1000)],
     [segment_size(500), segment_size(2000), segment_size(100000)],
     [msg_cache_size(0), msg_cache_size(5000), msg_cache_size(50000), msg_cache_size(2000000)],
     [index_cache_disabled(), index_cache_enabled()])]

--- a/integration/tests/streaming/get_by_timestamp.rs
+++ b/integration/tests/streaming/get_by_timestamp.rs
@@ -50,7 +50,7 @@ fn index_cache_disabled() -> bool {
 
 #[test_matrix(
     [msg_size(50), msg_size(1000), msg_size(20000)],
-    [msgs_req_to_save(3), msgs_req_to_save(10)],
+    [msgs_req_to_save(3), msgs_req_to_save(10),  msgs_req_to_save(1000)],
     [segment_size(500), segment_size(2000), segment_size(100000)],
     [msg_cache_size(0), msg_cache_size(5000), msg_cache_size(50000), msg_cache_size(2000000)],
     [index_cache_disabled(), index_cache_enabled()])]
@@ -262,7 +262,7 @@ async fn test_get_messages_by_timestamp(
             "Message timestamp {} at position {} is less than initial timestamp {}",
             loaded_message.timestamp,
             i,
-            initial_timestamp.as_micros()
+            initial_timestamp
         );
     }
 
@@ -285,7 +285,7 @@ async fn test_get_messages_by_timestamp(
             msg.timestamp >= span_timestamp.as_micros(),
             "Message timestamp {} should be >= span timestamp {}",
             msg.timestamp,
-            span_timestamp.as_micros()
+            span_timestamp
         );
     }
 }

--- a/integration/tests/streaming/messages.rs
+++ b/integration/tests/streaming/messages.rs
@@ -159,7 +159,7 @@ async fn should_persist_messages_and_then_load_them_by_timestamp() {
             "Message timestamp {} at position {} is less than test timestamp {}",
             loaded_message.timestamp,
             i,
-            test_timestamp.as_micros()
+            test_timestamp
         );
         assert_eq!(
             loaded_message

--- a/integration/tests/streaming/segment.rs
+++ b/integration/tests/streaming/segment.rs
@@ -102,7 +102,7 @@ async fn should_load_existing_segment_from_disk() {
             Arc::new(AtomicU64::new(0)),
         );
         loaded_segment.load_from_disk().await.unwrap();
-        let loaded_messages = loaded_segment.get_messages(0, 10).await.unwrap();
+        let loaded_messages = loaded_segment.get_messages_by_offset(0, 10).await.unwrap();
 
         assert_eq!(loaded_segment.partition_id, segment.partition_id);
         assert_eq!(loaded_segment.start_offset, segment.start_offset);
@@ -189,7 +189,7 @@ async fn should_persist_and_load_segment_with_messages() {
     );
     loaded_segment.load_from_disk().await.unwrap();
     let messages = loaded_segment
-        .get_messages(0, messages_count as u32)
+        .get_messages_by_offset(0, messages_count as u32)
         .await
         .unwrap();
     assert_eq!(messages.len(), messages_count as usize);
@@ -279,7 +279,7 @@ async fn should_persist_and_load_segment_with_messages_with_nowait_confirmation(
     );
     loaded_segment.load_from_disk().await.unwrap();
     let messages = loaded_segment
-        .get_messages(0, messages_count as u32)
+        .get_messages_by_offset(0, messages_count as u32)
         .await
         .unwrap();
     assert_eq!(messages.len(), messages_count as usize);

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iggy"
-version = "0.6.202"
+version = "0.6.203"
 description = "Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 edition = "2021"
 license = "Apache-2.0"

--- a/sdk/src/utils/timestamp.rs
+++ b/sdk/src/utils/timestamp.rs
@@ -65,6 +65,12 @@ impl From<IggyTimestamp> for u64 {
     }
 }
 
+impl From<SystemTime> for IggyTimestamp {
+    fn from(timestamp: SystemTime) -> Self {
+        IggyTimestamp(timestamp)
+    }
+}
+
 impl Add<SystemTime> for IggyTimestamp {
     type Output = IggyTimestamp;
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.212"
+version = "0.4.213"
 edition = "2021"
 build = "src/build.rs"
 license = "Apache-2.0"

--- a/server/src/streaming/batching/batch_accumulator.rs
+++ b/server/src/streaming/batching/batch_accumulator.rs
@@ -47,6 +47,18 @@ impl BatchAccumulator {
         self.messages[start_idx..end_idx].to_vec()
     }
 
+    pub fn get_messages_by_timestamp(
+        &self,
+        start_timestamp: u64,
+        count: usize,
+    ) -> Vec<Arc<RetainedMessage>> {
+        let start_idx = self
+            .messages
+            .partition_point(|msg| msg.timestamp < start_timestamp);
+        let end_idx = std::cmp::min(start_idx + count, self.messages.len());
+        self.messages[start_idx..end_idx].to_vec()
+    }
+
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }

--- a/server/src/streaming/segments/segment.rs
+++ b/server/src/streaming/segments/segment.rs
@@ -19,7 +19,9 @@ pub struct Segment {
     pub topic_id: u32,
     pub partition_id: u32,
     pub start_offset: u64,
+    pub start_timestamp: u64, // first message timestamp
     pub end_offset: u64,
+    pub end_timestamp: u64, // last message timestamp
     pub current_offset: u64,
     pub index_path: String,
     pub log_path: String,
@@ -78,7 +80,9 @@ impl Segment {
             topic_id,
             partition_id,
             start_offset,
+            start_timestamp: IggyTimestamp::now().as_micros(),
             end_offset: 0,
+            end_timestamp: IggyTimestamp::now().as_micros(),
             current_offset: start_offset,
             log_path,
             index_path,
@@ -253,7 +257,7 @@ impl Segment {
             IggyExpiry::NeverExpire => false,
             IggyExpiry::ServerDefault => false,
             IggyExpiry::ExpireDuration(expiry) => {
-                let last_messages = self.get_messages(self.current_offset, 1).await;
+                let last_messages = self.get_messages_by_offset(self.current_offset, 1).await;
                 if last_messages.is_err() {
                     return false;
                 }

--- a/server/src/streaming/segments/writing_messages.rs
+++ b/server/src/streaming/segments/writing_messages.rs
@@ -29,11 +29,15 @@ impl Segment {
             self.config.partition.messages_required_to_save as usize,
             batch.len(),
         );
+        if self.current_offset == 0 {
+            self.start_timestamp = batch.first().unwrap().timestamp;
+        }
         let batch_base_offset = batch.first().unwrap().offset;
         let batch_accumulator = self
             .unsaved_messages
             .get_or_insert_with(|| BatchAccumulator::new(batch_base_offset, messages_cap));
         batch_accumulator.append(batch_size, batch);
+        self.end_timestamp = batch_accumulator.batch_max_timestamp();
         let curr_offset = batch_accumulator.batch_max_offset();
 
         self.current_offset = curr_offset;


### PR DESCRIPTION
This commit fixed functionality to retrieve messages by timestamp
when all messages are stored in the unsaved buffer. The changes include
modifications to the `BatchAccumulator` and `Segment` structs to handle
timestamp-based retrieval efficiently. The `get_messages_by_timestamp`
method has been added to both strcuts, allowing for precise message
retrieval based on timestamps.
