### PR TITLE
chore(repo): add hk git hook manager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,10 @@ coming onto our [Discussions](https://github.com/apache/Iggy/discussions) and di
 This way we can talk through the solution and discuss if a change that large is even needed!
 This will produce a quicker response to the change and likely produce code that aligns better with our process.
 
+### Hooks
+
+Iggy uses [hk](hk.jdx.dev) for managing git hooks, these should be installed to make sure formatting is done, build works and tests passes before a pull request is opened. The hooks run conditionally depending on the changed files and will trigger tasks for any changed project. Tasks launched by hooks require tools to be installed and setup for each project they run for, i.e. virtualenv has to be setup and activated for `foreign/python`.
+
 ### CI
 
 Currently, Iggy uses GitHub Actions to run tests. The workflows are defined in `.github/workflows`.

--- a/hk.pkl
+++ b/hk.pkl
@@ -1,0 +1,71 @@
+amends "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.2.0/hk@1.2.0#/Builtins.pkl"
+
+local rust_steps = new Mapping<String, Step> {
+    ["cargo-fmt"] {
+        workspace_indicator = "Cargo.toml"
+        glob = "*.rs"
+        check = "cargo fmt --check --manifest-path {{workspace_indicator}}"
+        fix = "cargo fmt --manifest-path {{workspace_indicator}}"
+    }
+    ["cargo-clippy"] {
+        workspace_indicator = "Cargo.toml"
+        glob = "*.rs"
+        check = "cargo clippy --manifest-path {{workspace_indicator}}"
+        fix = "cargo clippy --fix --manifest-path {{workspace_indicator}}"
+    }
+    ["cargo-check"] {
+        workspace_indicator = "Cargo.toml"
+        glob = "*.rs"
+        check = "cargo check --manifest-path {{workspace_indicator}}"
+    }
+    ["cargo-test"] {
+        workspace_indicator = "Cargo.toml"
+        glob = "*.rs"
+        check = "cargo test --manifest-path {{workspace_indicator}}"
+    }
+}
+
+local python_steps = new Mapping<String, Step> {
+    ["python-maturin-develop"] {
+        glob = "foreign/python/*"
+        dir = "foreign/python"
+        check = "maturin develop"
+        exclusive = true
+    }
+    ["python-cargo-run-stub-gen"] {
+        glob = "foreign/python/*"
+        dir = "foreign/python"
+        check = "cargo run --bin stub_gen"
+        exclusive = true
+    }
+    ["python-pytest"] {
+        glob = "foreign/python/*"
+        dir = "foreign/python"
+        check = "pytest -v"
+        exclusive = true
+    }
+}
+
+local all_steps = new Mapping<String, Step> {
+    ...rust_steps
+    ...python_steps
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = all_steps
+    }
+    ["pre-push"] {
+        steps = all_steps
+    }
+    ["fix"] {
+        fix = true
+        steps = all_steps
+    }
+    ["check"] {
+        steps = all_steps
+    }
+}


### PR DESCRIPTION
This adds [hk](hk.jdx.dev) as a git hook manager and configures it to run for all Rust projects in `core/` as well as `foreign/python`.

This is meant as a proposal for adding a git hook manager in general and I am not married to the idea that it has to be `hk` or done in any specific way.

`hk` was chosen because of monorepo support and its use of `pkl` lang for configuration allowing powerful generation of the config.

Hooks for each foreign SDK besides Python remains to be implemented.

One open question is whether one wants steps for dependents to run on changes? i.e. If `core/common` is changed do we want to run tests for `core/sdk`?

Hopefully others feel this would be a useful addition too.
