### PR TITLE
fix(python): include typing stubs in built sdist

### DIFF
--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -69,6 +69,9 @@ include = [
         "sdist",
         "wheel",
     ] },
+    { path = "apache_iggy.pyi", format = [
+        "sdist",
+    ] },
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Built source distribution currently published on PYPI does not contain the typing stubs. This fixes this by explicitly including it.

This will include it as `apache_iggy.pyi` instead of `__init__.pyi` as is doen by the built wheels but my testing locally seems to indicate that it works either way.