### PR TITLE
feat(cli): Implement error handling for cli encryptor parsing

### DIFF
--- a/core/cli/src/error.rs
+++ b/core/cli/src/error.rs
@@ -22,6 +22,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub(crate) enum CmdToolError {
     MissingCredentials,
+    InvalidEncryptionKey,
     #[cfg(feature = "login-session")]
     MissingServerAddress,
 }
@@ -31,6 +32,9 @@ impl Display for CmdToolError {
         match self {
             Self::MissingCredentials => {
                 write!(f, "Missing iggy server credentials")
+            }
+            Self::InvalidEncryptionKey => {
+                write!(f, "Invalid encryption key provided")
             }
             #[cfg(feature = "login-session")]
             Self::MissingServerAddress => {


### PR DESCRIPTION
## Summary
In the main loop of iggy-cli, putting invalid value for encryptor will generate a panic from client side, however, a panic should refer to a programmer bug rather than invalid user input.

Implement error handling when facing invalid user input of encryptor for iggy-cli, which will output an error message, e.g.
```
Error: CommandError(Iggy command line tool error

Caused by:
    Invalid encryption key provided)
```

## Testing
Before the change, when using some invalid encryption string which isn't base64
```
$ iggy --username <user_name> --password <password> --encryption-key rururu me

thread 'main' panicked at core/cli/src/main.rs:372:76:
called `Result::unwrap()` on an `Err` value: InvalidEncryptionKey
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After the change, error message will be print
```
$ iggy --username <user_name> --password <password> --encryption-key rururu me
Error: CommandError(Iggy command line tool error

Caused by:
    Invalid encryption key provided)
```