### PR TITLE
fix(ci): simplify server-start action to use address parameters

### DIFF
--- a/.github/actions/csharp-dotnet/pre-merge/action.yml
+++ b/.github/actions/csharp-dotnet/pre-merge/action.yml
@@ -84,13 +84,7 @@ runs:
       id: iggy
       if: inputs.task == 'e2e'
       uses: ./.github/actions/utils/server-start
-      with:
-        mode: cargo
-        cargo-bin: iggy-server
-        port: 8090
-      env:
-        IGGY_ROOT_USERNAME: iggy
-        IGGY_ROOT_PASSWORD: iggy
+      continue-on-error: true
 
     - name: Run integration tests
       if: inputs.task == 'e2e'

--- a/.github/actions/go/pre-merge/action.yml
+++ b/.github/actions/go/pre-merge/action.yml
@@ -78,7 +78,6 @@ runs:
         # Run tests with JSON output for better reporting
         go test -v -json ./... > ../../reports/go-tests.json
 
-
     - name: Lint
       if: inputs.task == 'lint'
       uses: golangci/golangci-lint-action@v6
@@ -115,6 +114,7 @@ runs:
     - name: Setup server for e2e tests
       if: inputs.task == 'e2e'
       uses: ./.github/actions/utils/server-start
+      continue-on-error: true
 
     - name: Run e2e tests
       shell: bash

--- a/.github/actions/java-gradle/pre-merge/action.yml
+++ b/.github/actions/java-gradle/pre-merge/action.yml
@@ -67,9 +67,23 @@ runs:
         # Exit with build exit code
         exit $BUILD_EXIT_CODE
 
+    - name: Setup Rust with cache
+      if: inputs.task == 'test'
+      uses: ./.github/actions/utils/setup-rust-with-cache
+      with:
+        cache-targets: false # Only cache registry and git deps, not target dir (sccache handles that)
+
+    - name: Start Iggy server
+      if: inputs.task == 'test'
+      id: iggy
+      uses: ./.github/actions/utils/server-start
+      continue-on-error: true
+
     - name: Test
       if: inputs.task == 'test'
       shell: bash
+      env:
+        USE_EXTERNAL_SERVER: true
       run: |
         foreign/java/dev-support/checks/build.sh test
 
@@ -84,3 +98,10 @@ runs:
           cd foreign/java
           ./gradlew jacocoTestReport --no-daemon
         fi
+
+    - name: Stop Iggy server
+      if: inputs.task == 'test'
+      uses: ./.github/actions/utils/server-stop
+      with:
+        pid-file: ${{ steps.iggy.outputs.pid_file }}
+        log-file: ${{ steps.iggy.outputs.log_file }}

--- a/.github/actions/node-npm/pre-merge/action.yml
+++ b/.github/actions/node-npm/pre-merge/action.yml
@@ -84,15 +84,7 @@ runs:
       id: iggy
       if: inputs.task == 'e2e'
       uses: ./.github/actions/utils/server-start
-      with:
-        mode: cargo
-        cargo-bin: iggy-server
-        host: 127.0.0.1
-        port: 8090
-        wait-timeout-seconds: 45
-      env:
-        IGGY_ROOT_USERNAME: iggy
-        IGGY_ROOT_PASSWORD: iggy
+      continue-on-error: true
 
     - name: E2E tests
       if: inputs.task == 'e2e'

--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -116,16 +116,7 @@ runs:
       if: inputs.task == 'test'
       id: iggy
       uses: ./.github/actions/utils/server-start
-      with:
-        mode: cargo
-        cargo-bin: iggy-server
-        host: 127.0.0.1
-        port: 8090
-        wait-timeout-seconds: 45
       continue-on-error: true
-      env:
-        IGGY_ROOT_USERNAME: iggy
-        IGGY_ROOT_PASSWORD: iggy
 
     - name: Run Python integration tests
       if: inputs.task == 'test' && steps.iggy.outcome == 'success'

--- a/.github/actions/utils/server-start/action.yml
+++ b/.github/actions/utils/server-start/action.yml
@@ -38,14 +38,14 @@ inputs:
     description: "Working directory for building/running"
     required: false
     default: "."
-  host:
-    description: "Bind host to test readiness against"
+  tcp_address:
+    description: "TCP address (host:port)"
     required: false
-    default: "127.0.0.1"
-  port:
-    description: "TCP port to check readiness"
+    default: "127.0.0.1:8090"
+  http_address:
+    description: "HTTP address (host:port)"
     required: false
-    default: "8090"
+    default: "127.0.0.1:3000"
   wait-timeout-seconds:
     description: "Max seconds to wait until the server is ready"
     required: false
@@ -72,9 +72,12 @@ outputs:
   log_file:
     description: "Path to log file"
     value: ${{ steps.out.outputs.log_file }}
-  address:
-    description: "Host:port used for checks"
-    value: ${{ steps.out.outputs.address }}
+  tcp_address:
+    description: "TCP address used"
+    value: ${{ inputs.tcp_address }}
+  http_address:
+    description: "HTTP address used"
+    value: ${{ inputs.http_address }}
 runs:
   using: "composite"
   steps:
@@ -120,8 +123,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        HOST="${{ inputs.host }}"
-        PORT="${{ inputs.port }}"
+        TCP_ADDRESS="${{ inputs.tcp_address }}"
+        HOST="${TCP_ADDRESS%:*}"
+        PORT="${TCP_ADDRESS##*:}"
         # true if socket is already open
         if command -v nc >/dev/null 2>&1; then
           if nc -z "$HOST" "$PORT" 2>/dev/null; then busy=1; else busy=0; fi
@@ -133,7 +137,7 @@ runs:
     - if: env.BUSY == '1' && inputs.fail-if-busy == 'true'
       shell: bash
       run: |
-        echo "Port ${{ inputs.host }}:${{ inputs.port }} is already in use." >&2
+        echo "Port ${{ inputs.tcp_address }} is already in use." >&2
         exit 1
 
     - name: Start server
@@ -141,16 +145,22 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         set -euo pipefail
+        export IGGY_TCP_ADDRESS="${{ inputs.tcp_address }}"
+        export IGGY_HTTP_ADDRESS="${{ inputs.http_address }}"
+        export IGGY_ROOT_USERNAME="iggy"
+        export IGGY_ROOT_PASSWORD="iggy"
         nohup "${{ steps.resolve-bin.outputs.bin }}" >"$LOG_FILE" 2>&1 &
         echo $! > "$PID_FILE"
         echo "Started server PID $(cat "$PID_FILE") → logs: $LOG_FILE"
+        echo "Server configured with TCP=$IGGY_TCP_ADDRESS, HTTP=$IGGY_HTTP_ADDRESS"
 
     - name: Wait for readiness
       shell: bash
       run: |
         set -euo pipefail
-        HOST="${{ inputs.host }}"
-        PORT="${{ inputs.port }}"
+        TCP_ADDRESS="${{ inputs.tcp_address }}"
+        HOST="${TCP_ADDRESS%:*}"
+        PORT="${TCP_ADDRESS##*:}"
         DEADLINE=$(( $(date +%s) + ${{ inputs.wait-timeout-seconds }} ))
         until (( $(date +%s) > DEADLINE )); do
           if command -v nc >/dev/null 2>&1; then
@@ -159,7 +169,7 @@ runs:
             timeout 1 bash -lc ":</dev/tcp/$HOST/$PORT" 2>/dev/null && ready=1 || ready=0
           fi
           if [[ "$ready" == "1" ]]; then
-            echo "Server is ready on $HOST:$PORT"
+            echo "Server is ready on $TCP_ADDRESS"
             break
           fi
           sleep 1
@@ -178,4 +188,3 @@ runs:
         echo "pid=$(cat "$PID_FILE")" >> "$GITHUB_OUTPUT"
         echo "pid_file=$PID_FILE" >> "$GITHUB_OUTPUT"
         echo "log_file=$LOG_FILE" >> "$GITHUB_OUTPUT"
-        echo "address=${{ inputs.host }}:${{ inputs.port }}" >> "$GITHUB_OUTPUT"

--- a/core/server/src/args.rs
+++ b/core/server/src/args.rs
@@ -25,7 +25,7 @@ use clap::Parser;
     about = "Apache Iggy: Hyper-Efficient Message Streaming at Laser Speed",
     long_about = r#"Apache Iggy (Incubating) - A persistent message streaming platform written in Rust
 
-Apache Iggy is a high-performance message streaming platform that supports QUIC, TCP, and HTTP 
+Apache Iggy is a high-performance message streaming platform that supports QUIC, TCP, and HTTP
 transport protocols, capable of processing millions of messages per second with low latency.
 
 WEBSITE:
@@ -38,7 +38,7 @@ DOCUMENTATION:
     https://iggy.apache.org/docs
 
 CONFIGURATION:
-    The server uses a TOML configuration file. By default, it looks for 'configs/server.toml' 
+    The server uses a TOML configuration file. By default, it looks for 'configs/server.toml'
     in the current working directory. You can override this with the IGGY_CONFIG_PATH environment
     variable or use the --config-provider flag.
 
@@ -89,4 +89,20 @@ pub struct Args {
     ///   iggy-server -f                               # Short form
     #[arg(short, long, default_value_t = false, verbatim_doc_comment)]
     pub fresh: bool,
+
+    /// Use default root credentials (INSECURE - FOR DEVELOPMENT ONLY!)
+    ///
+    /// When this flag is set, the root user will be created with username 'iggy'
+    /// and password 'iggy' if it doesn't exist. If the root user already exists,
+    /// this flag has no effect and a warning will be printed.
+    ///
+    /// This flag is equivalent to setting IGGY_ROOT_USERNAME=iggy and IGGY_ROOT_PASSWORD=iggy,
+    /// but environment variables take precedence over this flag.
+    ///
+    /// WARNING: This is insecure and should only be used for development and testing!
+    ///
+    /// Examples:
+    ///   iggy-server --with-default-root-credentials     # Use 'iggy/iggy' as root credentials
+    #[arg(long, default_value_t = false, verbatim_doc_comment)]
+    pub with_default_root_credentials: bool,
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/IntegrationTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/IntegrationTest.java
@@ -20,12 +20,18 @@
 package org.apache.iggy.client.blocking;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 import org.apache.iggy.topic.CompressionAlgorithm;
 import java.math.BigInteger;
+import java.util.List;
+import java.util.ArrayList;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
 
@@ -35,21 +41,88 @@ public abstract class IntegrationTest {
     public static final int HTTP_PORT = 3000;
     public static final int TCP_PORT = 8090;
 
-    @Container
-    protected final GenericContainer<?> iggyServer = new GenericContainer<>(DockerImageName.parse("apache/iggy:edge"))
-            .withExposedPorts(HTTP_PORT, TCP_PORT);
+    private static final boolean USE_EXTERNAL_SERVER = System.getenv("USE_EXTERNAL_SERVER") != null;
+
+    protected static GenericContainer<?> iggyServer;
+
+    // Track created resources for cleanup
+    protected List<Long> createdStreamIds = new ArrayList<>();
+    protected List<Long> createdUserIds = new ArrayList<>();
+
+    @BeforeAll
+    static void setupContainer() {
+        if (!USE_EXTERNAL_SERVER) {
+            iggyServer = new GenericContainer<>(DockerImageName.parse("apache/iggy:edge"))
+                .withExposedPorts(HTTP_PORT, TCP_PORT)
+                .withEnv("IGGY_ROOT_USERNAME", "iggy")
+                .withEnv("IGGY_ROOT_PASSWORD", "iggy")
+                .withEnv("IGGY_TCP_ADDRESS", "0.0.0.0:8090")
+                .withEnv("IGGY_HTTP_ADDRESS", "0.0.0.0:3000")
+                .withLogConsumer(frame -> System.out.print(frame.getUtf8String()));
+            iggyServer.start();
+        }
+    }
+
+    @AfterAll
+    static void stopContainer() {
+        if (iggyServer != null && iggyServer.isRunning()) {
+            // Print last logs before stopping
+            System.out.println("=== Iggy Server Container Logs ===");
+            System.out.println(iggyServer.getLogs());
+            System.out.println("=================================");
+            iggyServer.stop();
+        }
+    }
 
     protected IggyBaseClient client;
 
     @BeforeEach
     void beforeEachIntegrationTest() {
         client = getClient();
+        // Clear tracking lists for new test
+        createdStreamIds.clear();
+        createdUserIds.clear();
+    }
+
+    @AfterEach
+    void cleanupTestResources() {
+        if (client == null) {
+            return;
+        }
+
+        // Login as root to ensure we have permissions for cleanup
+        try {
+            login();
+        } catch (Exception e) {
+            // Already logged in or login failed - continue with cleanup anyway
+        }
+
+        // Delete all created streams (which also deletes topics within them)
+        for (Long streamId : createdStreamIds) {
+            try {
+                client.streams().deleteStream(streamId);
+            } catch (Exception e) {
+                // Stream might already be deleted or doesn't exist - ignore
+            }
+        }
+
+        // Delete all created non-root users
+        for (Long userId : createdUserIds) {
+            try {
+                if (userId != 1) { // Don't try to delete root user
+                    client.users().deleteUser(userId);
+                }
+            } catch (Exception e) {
+                // User might already be deleted or doesn't exist - ignore
+            }
+        }
     }
 
     abstract protected IggyBaseClient getClient();
 
     protected void setUpStream() {
         client.streams().createStream(of(42L), "test-stream");
+        createdStreamIds.add(42L);
     }
 
     protected void setUpStreamAndTopic() {
@@ -67,6 +140,20 @@ public abstract class IntegrationTest {
 
     protected void login() {
         client.users().login("iggy", "iggy");
+    }
+
+    // Helper method for tests that need to track streams created directly
+    protected void trackStream(Long streamId) {
+        if (!createdStreamIds.contains(streamId)) {
+            createdStreamIds.add(streamId);
+        }
+    }
+
+    // Helper method for tests that need to track users created
+    protected void trackUser(Long userId) {
+        if (!createdUserIds.contains(userId)) {
+            createdUserIds.add(userId);
+        }
     }
 
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/PersonalAccessTokensBaseTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/PersonalAccessTokensBaseTest.java
@@ -34,6 +34,16 @@ public abstract class PersonalAccessTokensBaseTest extends IntegrationTest {
         personalAccessTokensClient = client.personalAccessTokens();
 
         login();
+
+        // Clean up any existing tokens before test
+        var existingTokens = personalAccessTokensClient.getPersonalAccessTokens();
+        for (var token : existingTokens) {
+            try {
+                personalAccessTokensClient.deletePersonalAccessToken(token.name());
+            } catch (Exception e) {
+                // Ignore if already deleted
+            }
+        }
     }
 
     @Test
@@ -78,6 +88,9 @@ public abstract class PersonalAccessTokensBaseTest extends IntegrationTest {
 
         // then
         assertThat(user).isPresent();
+
+        // cleanup
+        personalAccessTokensClient.deletePersonalAccessToken("new-token");
     }
 
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/StreamClientBaseTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/StreamClientBaseTest.java
@@ -39,6 +39,7 @@ public abstract class StreamClientBaseTest extends IntegrationTest {
     void shouldCreateAndDeleteStream() {
         // when
         streamsClient.createStream(Optional.of(42L), "test-stream");
+        trackStream(42L);
         var streamOptional = streamsClient.getStream(42L);
 
         // then
@@ -55,6 +56,7 @@ public abstract class StreamClientBaseTest extends IntegrationTest {
 
         // when
         streamsClient.deleteStream(42L);
+        createdStreamIds.remove(42L); // Remove from tracking since we deleted it
         streams = streamsClient.getStreams();
 
         // then
@@ -65,6 +67,7 @@ public abstract class StreamClientBaseTest extends IntegrationTest {
     void shouldUpdateStream() {
         // given
         streamsClient.createStream(Optional.of(42L), "test-stream");
+        trackStream(42L);
 
         // when
         streamsClient.updateStream(42L, "test-stream-new");

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/UsersClientBaseTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/UsersClientBaseTest.java
@@ -74,6 +74,7 @@ public abstract class UsersClientBaseTest extends IntegrationTest {
                 "test",
                 UserStatus.Active,
                 Optional.of(new Permissions(createGlobalPermissions(true), Collections.emptyMap())));
+        trackUser(createdUser.id());
 
         // then
         assertThat(createdUser).isNotNull();
@@ -100,6 +101,7 @@ public abstract class UsersClientBaseTest extends IntegrationTest {
         // given
         login();
         UserInfoDetails user = usersClient.createUser("test", "test", UserStatus.Active, Optional.empty());
+        trackUser(user.id());
 
         // when
         usersClient.updateUser(user.id(), Optional.empty(), Optional.of(UserStatus.Inactive));
@@ -115,6 +117,7 @@ public abstract class UsersClientBaseTest extends IntegrationTest {
         var permissions = new Permissions(createGlobalPermissions(true), Collections.emptyMap());
         login();
         UserInfoDetails user = usersClient.createUser("test", "test", UserStatus.Active, Optional.of(permissions));
+        trackUser(user.id());
 
         // when
         usersClient.updatePermissions(user.id(), Optional.of(new Permissions(createGlobalPermissions(false), Collections.emptyMap())));
@@ -141,6 +144,9 @@ public abstract class UsersClientBaseTest extends IntegrationTest {
 
         // then
         assertThat(newLogin).isNotNull();
+
+        // restore original password for other tests
+        usersClient.changePassword(identity.userId(), "new-pass", "iggy");
     }
 
     @Test

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/http/HttpClientFactory.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/http/HttpClientFactory.java
@@ -25,6 +25,10 @@ import static org.apache.iggy.client.blocking.IntegrationTest.HTTP_PORT;
 class HttpClientFactory {
 
     static IggyHttpClient create(GenericContainer<?> iggyServer) {
+        if (iggyServer == null) {
+            // Server is running externally
+            return new IggyHttpClient("http://127.0.0.1:" + HTTP_PORT);
+        }
         String address = iggyServer.getHost();
         Integer port = iggyServer.getMappedPort(HTTP_PORT);
         return new IggyHttpClient("http://" + address + ":" + port);

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/SystemTcpClientTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/SystemTcpClientTest.java
@@ -56,6 +56,6 @@ class SystemTcpClientTest extends SystemClientBaseTest {
 
         // then
         assertThat(clients).isNotNull();
-        assertThat(clients.size()).isEqualTo(1);
+        assertThat(clients.size()).isGreaterThanOrEqualTo(1); // At least our connection
     }
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/TcpClientFactory.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/TcpClientFactory.java
@@ -25,6 +25,10 @@ import static org.apache.iggy.client.blocking.IntegrationTest.TCP_PORT;
 class TcpClientFactory {
 
     static IggyTcpClient create(GenericContainer<?> iggyServer) {
+        if (iggyServer == null) {
+            // Server is running externally
+            return new IggyTcpClient("127.0.0.1", TCP_PORT);
+        }
         String address = iggyServer.getHost();
         Integer port = iggyServer.getMappedPort(TCP_PORT);
         return new IggyTcpClient(address, port);

--- a/scripts/check-backwards-compat.sh
+++ b/scripts/check-backwards-compat.sh
@@ -157,7 +157,7 @@ ok "built baseline"
 
 info "Starting iggy-server (baseline)"
 set +e
-( nohup target/debug/iggy-server >"$MASTER_LOG" 2>&1 & echo $! > "$TMP_ROOT/master.pid" )
+( IGGY_ROOT_USERNAME=iggy IGGY_ROOT_PASSWORD=iggy nohup target/debug/iggy-server >"$MASTER_LOG" 2>&1 & echo $! > "$TMP_ROOT/master.pid" )
 set -e
 MASTER_PID="$(cat "$TMP_ROOT/master.pid")"
 ok "iggy-server started (pid $MASTER_PID), logs: $MASTER_LOG"
@@ -222,7 +222,7 @@ ok "restored local_data/"
 # -----------------------------
 info "Starting iggy-server (PR)"
 set +e
-( nohup target/debug/iggy-server >"$PR_LOG" 2>&1 & echo $! > "$TMP_ROOT/pr.pid" )
+( IGGY_ROOT_USERNAME=iggy IGGY_ROOT_PASSWORD=iggy nohup target/debug/iggy-server >"$PR_LOG" 2>&1 & echo $! > "$TMP_ROOT/pr.pid" )
 set -e
 PR_PID="$(cat "$TMP_ROOT/pr.pid")"
 ok "iggy-server (PR) started (pid $PR_PID), logs: $PR_LOG"


### PR DESCRIPTION
- Replace host/port with tcp_address and http_address parameters
- Set IGGY_TCP_ADDRESS and IGGY_HTTP_ADDRESS env vars for server
- Hardcode IGGY_ROOT_USERNAME=iggy and IGGY_ROOT_PASSWORD=iggy
- Remove redundant default values from all workflow files
- Fix Java tests to use external server instead of Docker image