### PR TITLE
refactor(server): Utilize "usize" for stream ID and topic ID

### DIFF
--- a/core/ai/mcp/src/service/requests.rs
+++ b/core/ai/mcp/src/service/requests.rs
@@ -411,7 +411,7 @@ pub struct Permissions {
     pub global: Option<GlobalPermissions>,
 
     #[schemars(description = "stream permissions (optional)")]
-    pub streams: Option<HashMap<u32, StreamPermissions>>,
+    pub streams: Option<HashMap<usize, StreamPermissions>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -468,7 +468,7 @@ pub struct StreamPermissions {
     pub send_messages: Option<bool>,
 
     #[schemars(description = "topics permissions (optional)")]
-    pub topics: Option<HashMap<u32, TopicPermissions>>,
+    pub topics: Option<HashMap<usize, TopicPermissions>>,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]

--- a/core/cli/src/args/permissions/mod.rs
+++ b/core/cli/src/args/permissions/mod.rs
@@ -49,7 +49,7 @@ impl From<PermissionsArgs> for Option<Permissions> {
             .stream
             .into_iter()
             .map(|s| (s.stream_id, s.into()))
-            .collect::<AHashMap<u32, StreamPermissions>>();
+            .collect::<AHashMap<usize, StreamPermissions>>();
 
         match (value.global, stream_permissions.is_empty()) {
             (Some(global), true) => Some(Permissions {

--- a/core/cli/src/args/permissions/stream.rs
+++ b/core/cli/src/args/permissions/stream.rs
@@ -58,7 +58,7 @@ impl FromStr for StreamPermission {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct StreamPermissionsArg {
-    pub(crate) stream_id: u32,
+    pub(crate) stream_id: usize,
     pub(crate) permissions: StreamPermissions,
 }
 
@@ -70,7 +70,7 @@ impl From<StreamPermissionsArg> for StreamPermissions {
 
 impl StreamPermissionsArg {
     pub(super) fn new(
-        stream_id: u32,
+        stream_id: usize,
         stream_permissions: Vec<StreamPermission>,
         topic_permissions: Vec<TopicPermissionsArg>,
     ) -> Self {

--- a/core/cli/src/args/permissions/topic.rs
+++ b/core/cli/src/args/permissions/topic.rs
@@ -52,7 +52,7 @@ impl FromStr for TopicPermission {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct TopicPermissionsArg {
-    pub(crate) topic_id: u32,
+    pub(crate) topic_id: usize,
     pub(crate) permissions: TopicPermissions,
 }
 
@@ -63,7 +63,7 @@ impl From<TopicPermissionsArg> for TopicPermissions {
 }
 
 impl TopicPermissionsArg {
-    fn new(topic_id: u32, topic_permissions: Vec<TopicPermission>) -> Self {
+    fn new(topic_id: usize, topic_permissions: Vec<TopicPermission>) -> Self {
         let mut result = Self {
             topic_id,
             permissions: TopicPermissions::default(),

--- a/core/common/src/types/permissions/permissions_global.rs
+++ b/core/common/src/types/permissions/permissions_global.rs
@@ -35,7 +35,7 @@ pub struct Permissions {
     pub global: GlobalPermissions,
 
     /// Stream permissions are applied to a specific stream.
-    pub streams: Option<AHashMap<u32, StreamPermissions>>,
+    pub streams: Option<AHashMap<usize, StreamPermissions>>,
 }
 
 /// `GlobalPermissions` are applied to all streams without a need to specify them one by one in the `streams` field.
@@ -142,7 +142,7 @@ pub struct StreamPermissions {
     pub send_messages: bool,
 
     /// The `topics` field allows to define the granular permissions for each topic of a stream.
-    pub topics: Option<AHashMap<u32, TopicPermissions>>,
+    pub topics: Option<AHashMap<usize, TopicPermissions>>,
 }
 
 /// `TopicPermissions` are applied to a specific topic of a stream. This is the lowest level of permissions.
@@ -237,7 +237,7 @@ impl BytesSerializable for Permissions {
             let streams_count = streams.len();
             let mut current_stream = 1;
             for (stream_id, stream) in streams {
-                bytes.put_u32_le(*stream_id);
+                bytes.put_u32_le(*stream_id as u32);
                 bytes.put_u8(if stream.manage_stream { 1 } else { 0 });
                 bytes.put_u8(if stream.read_stream { 1 } else { 0 });
                 bytes.put_u8(if stream.manage_topics { 1 } else { 0 });
@@ -249,7 +249,7 @@ impl BytesSerializable for Permissions {
                     let topics_count = topics.len();
                     let mut current_topic = 1;
                     for (topic_id, topic) in topics {
-                        bytes.put_u32_le(*topic_id);
+                        bytes.put_u32_le(*topic_id as u32);
                         bytes.put_u8(if topic.manage_topic { 1 } else { 0 });
                         bytes.put_u8(if topic.read_topic { 1 } else { 0 });
                         bytes.put_u8(if topic.poll_messages { 1 } else { 0 });
@@ -296,7 +296,7 @@ impl BytesSerializable for Permissions {
         if bytes.get_u8() == 1 {
             let mut streams_map = AHashMap::new();
             loop {
-                let stream_id = bytes.get_u32_le();
+                let stream_id = bytes.get_u32_le() as usize;
                 let manage_stream = bytes.get_u8() == 1;
                 let read_stream = bytes.get_u8() == 1;
                 let manage_topics = bytes.get_u8() == 1;
@@ -307,7 +307,7 @@ impl BytesSerializable for Permissions {
                 if bytes.get_u8() == 1 {
                     let mut topics_map = AHashMap::new();
                     loop {
-                        let topic_id = bytes.get_u32_le();
+                        let topic_id = bytes.get_u32_le() as usize;
                         let manage_topic = bytes.get_u8() == 1;
                         let read_topic = bytes.get_u8() == 1;
                         let poll_messages = bytes.get_u8() == 1;

--- a/core/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
+++ b/core/server/src/binary/handlers/consumer_groups/get_consumer_group_handler.rs
@@ -54,8 +54,8 @@ impl ServerCommandHandler for GetConsumerGroup {
             .with_stream_by_id(&self.stream_id, streams::helpers::get_stream_id());
         shard.permissioner.borrow().get_consumer_group(
             session.get_user_id(),
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
+            numeric_stream_id,
+            numeric_topic_id,
         )?;
 
         let consumer_group = shard.streams2.with_consumer_group_by_id(

--- a/core/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
+++ b/core/server/src/binary/handlers/consumer_groups/get_consumer_groups_handler.rs
@@ -55,8 +55,8 @@ impl ServerCommandHandler for GetConsumerGroups {
             .with_stream_by_id(&self.stream_id, streams::helpers::get_stream_id());
         shard.permissioner.borrow().get_consumer_groups(
             session.get_user_id(),
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
+            numeric_stream_id,
+            numeric_topic_id,
         )?;
 
         let consumer_groups =

--- a/core/server/src/binary/handlers/streams/get_stream_handler.rs
+++ b/core/server/src/binary/handlers/streams/get_stream_handler.rs
@@ -52,7 +52,7 @@ impl ServerCommandHandler for GetStream {
         shard
             .permissioner
             .borrow()
-            .get_stream(session.get_user_id(), stream_id as u32)
+            .get_stream(session.get_user_id(), stream_id)
             .with_error_context(|_| {
                 format!(
                     "permission denied to get stream with ID: {} for user with ID: {}",

--- a/core/server/src/binary/handlers/topics/get_topic_handler.rs
+++ b/core/server/src/binary/handlers/topics/get_topic_handler.rs
@@ -49,8 +49,12 @@ impl ServerCommandHandler for GetTopic {
             .with_stream_by_id(&self.stream_id, streams::helpers::get_stream_id());
         shard.permissioner.borrow().get_topic(
             session.get_user_id(),
-            numeric_stream_id as u32,
-            self.topic_id.get_u32_value().unwrap_or(0),
+            numeric_stream_id,
+            self.topic_id
+                .get_u32_value()
+                .unwrap_or(0)
+                .try_into()
+                .unwrap(),
         )?;
 
         let response =

--- a/core/server/src/binary/handlers/topics/get_topics_handler.rs
+++ b/core/server/src/binary/handlers/topics/get_topics_handler.rs
@@ -51,7 +51,7 @@ impl ServerCommandHandler for GetTopics {
         shard
             .permissioner
             .borrow()
-            .get_topics(session.get_user_id(), numeric_stream_id as u32)?;
+            .get_topics(session.get_user_id(), numeric_stream_id)?;
 
         let response = shard.streams2.with_topics(&self.stream_id, |topics| {
             topics.with_components(|topics| {

--- a/core/server/src/http/consumer_groups.rs
+++ b/core/server/src/http/consumer_groups.rs
@@ -87,11 +87,7 @@ async fn get_consumer_group(
         .shard()
         .permissioner
         .borrow()
-        .get_consumer_group(
-            session.get_user_id(),
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
-        )?;
+        .get_consumer_group(session.get_user_id(), numeric_stream_id, numeric_topic_id)?;
 
     let consumer_group = state.shard.shard().streams2.with_consumer_group_by_id(
         &identifier_stream_id,
@@ -135,11 +131,7 @@ async fn get_consumer_groups(
         .shard()
         .permissioner
         .borrow()
-        .get_consumer_groups(
-            session.get_user_id(),
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
-        )?;
+        .get_consumer_groups(session.get_user_id(), numeric_stream_id, numeric_topic_id)?;
 
     let consumer_groups = state.shard.shard().streams2.with_consumer_groups(
         &identifier_stream_id,

--- a/core/server/src/http/topics.rs
+++ b/core/server/src/http/topics.rs
@@ -94,7 +94,7 @@ async fn get_topic(
     state.shard.shard()
         .permissioner
         .borrow()
-        .get_topic(session.get_user_id(), numeric_stream_id as u32, numeric_topic_id as u32)
+        .get_topic(session.get_user_id(), numeric_stream_id, numeric_topic_id)
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - permission denied to get topic with ID: {topic_id} in stream with ID: {stream_id} for user with ID: {}",
@@ -134,7 +134,7 @@ async fn get_topics(
     state.shard.shard()
         .permissioner
         .borrow()
-        .get_topics(session.get_user_id(), numeric_stream_id as u32)
+        .get_topics(session.get_user_id(), numeric_stream_id)
         .with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - permission denied to get topics in stream with ID: {stream_id} for user with ID: {}",

--- a/core/server/src/shard/system/consumer_groups.rs
+++ b/core/server/src/shard/system/consumer_groups.rs
@@ -54,8 +54,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().create_consumer_group(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32,
+                stream_id,
+                topic_id,
             ).with_error_context(|error| format!("{COMPONENT} (error: {error}) - permission denied to create consumer group for user {} on stream ID: {}, topic ID: {}", session.get_user_id(), stream_id, topic_id))?;
         }
         let cg = self.create_and_insert_consumer_group_mem(stream_id, topic_id, name);
@@ -117,8 +117,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().delete_consumer_group(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32,
+                stream_id,
+                topic_id,
             ).with_error_context(|error| format!("{COMPONENT} (error: {error}) - permission denied to delete consumer group for user {} on stream ID: {}, topic ID: {}", session.get_user_id(), stream_id, topic_id))?;
         }
         let cg = self.delete_consumer_group_base2(stream_id, topic_id, group_id);
@@ -190,8 +190,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().join_consumer_group(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32,
+                stream_id,
+                topic_id,
             ).with_error_context(|error| format!("{COMPONENT} (error: {error}) - permission denied to join consumer group for user {} on stream ID: {}, topic ID: {}", session.get_user_id(), stream_id, topic_id))?;
         }
         let client_id = session.client_id;
@@ -250,8 +250,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().leave_consumer_group(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32,
+                stream_id,
+                topic_id,
             ).with_error_context(|error| format!("{COMPONENT} (error: {error}) - permission denied to leave consumer group for user {} on stream ID: {}, topic ID: {}", session.get_user_id(), stream_id, topic_id))?;
         }
         self.streams2.with_consumer_group_by_id_mut(

--- a/core/server/src/shard/system/consumer_offsets.rs
+++ b/core/server/src/shard/system/consumer_offsets.rs
@@ -48,8 +48,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().store_consumer_offset(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32
+                stream_id,
+                topic_id
             ).with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to store consumer offset for user with ID: {}, consumer: {consumer} in topic with ID: {topic_id} and stream with ID: {stream_id}",
@@ -101,8 +101,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().get_consumer_offset(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32
+                stream_id,
+                topic_id
             ).with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to get consumer offset for user with ID: {}, consumer: {consumer} in topic with ID: {topic_id} and stream with ID: {stream_id}",
@@ -159,8 +159,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().delete_consumer_offset(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32
+                stream_id,
+                topic_id
             ).with_error_context(|error| {
             format!(
                 "{COMPONENT} (error: {error}) - permission denied to delete consumer offset for user with ID: {}, consumer: {consumer} in topic with ID: {topic_id} and stream with ID: {stream_id}",

--- a/core/server/src/shard/system/messages.rs
+++ b/core/server/src/shard/system/messages.rs
@@ -80,8 +80,8 @@ impl IggyShard {
             .borrow()
             .append_messages(
                 user_id,
-                numeric_stream_id as u32,
-                numeric_topic_id as u32,
+                numeric_stream_id,
+                numeric_topic_id,
             )
             .with_error_context(|error| {
                 format!("{COMPONENT} (error: {error}) - permission denied to append messages for user {} on stream ID: {}, topic ID: {}", user_id, numeric_stream_id as u32, numeric_topic_id as u32)
@@ -187,7 +187,7 @@ impl IggyShard {
 
         self.permissioner
             .borrow()
-            .poll_messages(user_id, numeric_stream_id as u32, numeric_topic_id as u32)
+            .poll_messages(user_id, numeric_stream_id, numeric_topic_id)
             .with_error_context(|error| format!(
                 "{COMPONENT} (error: {error}) - permission denied to poll messages for user {} on stream ID: {}, topic ID: {}",
                 user_id,
@@ -380,8 +380,8 @@ impl IggyShard {
             .borrow()
             .append_messages(
                 session.get_user_id(),
-                numeric_stream_id as u32,
-                numeric_topic_id as u32,
+                numeric_stream_id,
+                numeric_topic_id,
             )
             .with_error_context(|error| {
                 format!("{COMPONENT} (error: {error}) - permission denied to append messages for user {} on stream ID: {}, topic ID: {}", session.get_user_id(), numeric_stream_id as u32, numeric_topic_id as u32)

--- a/core/server/src/shard/system/partitions.rs
+++ b/core/server/src/shard/system/partitions.rs
@@ -41,8 +41,8 @@ impl IggyShard {
     fn validate_partition_permissions(
         &self,
         session: &Session,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
         operation: &str,
     ) -> Result<(), IggyError> {
         let permissioner = self.permissioner.borrow();
@@ -81,8 +81,8 @@ impl IggyShard {
         // Claude garbage, rework this.
         self.validate_partition_permissions(
             session,
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
+            numeric_stream_id,
+            numeric_topic_id,
             "create",
         )?;
         let parent_stats =
@@ -244,8 +244,8 @@ impl IggyShard {
 
         self.validate_partition_permissions(
             session,
-            numeric_stream_id as u32,
-            numeric_topic_id as u32,
+            numeric_stream_id,
+            numeric_topic_id,
             "delete",
         )?;
 

--- a/core/server/src/shard/system/streams.rs
+++ b/core/server/src/shard/system/streams.rs
@@ -73,7 +73,7 @@ impl IggyShard {
 
         self.permissioner
             .borrow()
-            .update_stream(session.get_user_id(), id as u32)
+            .update_stream(session.get_user_id(), id)
             .with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - failed to update stream, user ID: {}, stream ID: {}",
@@ -138,7 +138,7 @@ impl IggyShard {
             .with_stream_by_id(id, streams::helpers::get_stream_id());
         self.permissioner
             .borrow()
-            .delete_stream(session.get_user_id(), stream_id as u32)
+            .delete_stream(session.get_user_id(), stream_id)
             .with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to delete stream for user {}, stream ID: {}",
@@ -168,7 +168,7 @@ impl IggyShard {
             let stream_id = self.streams2.with_stream_by_id(stream_id, get_stream_id);
             self.permissioner
                 .borrow()
-                .purge_stream(session.get_user_id(), stream_id as u32)
+                .purge_stream(session.get_user_id(), stream_id)
                 .with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to purge stream for user {}, stream ID: {}",

--- a/core/server/src/shard/system/topics.rs
+++ b/core/server/src/shard/system/topics.rs
@@ -46,7 +46,7 @@ impl IggyShard {
         {
             self.permissioner
             .borrow()
-                .create_topic(session.get_user_id(), numeric_stream_id as u32)
+                .create_topic(session.get_user_id(), numeric_stream_id)
                 .with_error_context(|error| {
                     format!(
                         "{COMPONENT} (error: {error}) - permission denied to create topic with name: {name} in stream with ID: {stream_id} for user with ID: {}",
@@ -120,8 +120,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().update_topic(
                 session.get_user_id(),
-                stream_id_val as u32,
-                topic_id_val as u32
+                stream_id_val,
+                topic_id_val
             ).with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to update topic for user with id: {}, stream ID: {}, topic ID: {}",
@@ -210,7 +210,7 @@ impl IggyShard {
             .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
         self.permissioner
             .borrow()
-                .delete_topic(session.get_user_id(), numeric_stream_id as u32, numeric_topic_id as u32)
+                .delete_topic(session.get_user_id(), numeric_stream_id, numeric_topic_id)
                 .with_error_context(|error| {
                     format!(
                         "{COMPONENT} (error: {error}) - permission denied to delete topic with ID: {topic_id} in stream with ID: {stream_id} for user with ID: {}",
@@ -269,8 +269,8 @@ impl IggyShard {
                 .with_stream_by_id(stream_id, streams::helpers::get_stream_id());
             self.permissioner.borrow().purge_topic(
                 session.get_user_id(),
-                stream_id as u32,
-                topic_id as u32
+                stream_id,
+                topic_id
             ).with_error_context(|error| {
                 format!(
                     "{COMPONENT} (error: {error}) - permission denied to purge topic with ID: {topic_id} in stream with ID: {stream_id} for user with ID: {}",

--- a/core/server/src/streaming/users/permissioner.rs
+++ b/core/server/src/streaming/users/permissioner.rs
@@ -24,11 +24,11 @@ use iggy_common::{GlobalPermissions, Permissions, StreamPermissions};
 #[derive(Debug, Default)]
 pub struct Permissioner {
     pub(super) users_permissions: AHashMap<UserId, GlobalPermissions>,
-    pub(super) users_streams_permissions: AHashMap<(UserId, u32), StreamPermissions>,
+    pub(super) users_streams_permissions: AHashMap<(UserId, usize), StreamPermissions>,
     pub(super) users_that_can_poll_messages_from_all_streams: AHashSet<UserId>,
     pub(super) users_that_can_send_messages_to_all_streams: AHashSet<UserId>,
-    pub(super) users_that_can_poll_messages_from_specific_streams: AHashSet<(UserId, u32)>,
-    pub(super) users_that_can_send_messages_to_specific_streams: AHashSet<(UserId, u32)>,
+    pub(super) users_that_can_poll_messages_from_specific_streams: AHashSet<(UserId, usize)>,
+    pub(super) users_that_can_send_messages_to_specific_streams: AHashSet<(UserId, usize)>,
 }
 
 impl Permissioner {

--- a/core/server/src/streaming/users/permissioner_rules/consumer_groups.rs
+++ b/core/server/src/streaming/users/permissioner_rules/consumer_groups.rs
@@ -23,8 +23,8 @@ impl Permissioner {
     pub fn create_consumer_group(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }
@@ -32,8 +32,8 @@ impl Permissioner {
     pub fn delete_consumer_group(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }
@@ -41,8 +41,8 @@ impl Permissioner {
     pub fn get_consumer_group(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }
@@ -50,8 +50,8 @@ impl Permissioner {
     pub fn get_consumer_groups(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }
@@ -59,8 +59,8 @@ impl Permissioner {
     pub fn join_consumer_group(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }
@@ -68,8 +68,8 @@ impl Permissioner {
     pub fn leave_consumer_group(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.get_topic(user_id, stream_id, topic_id)
     }

--- a/core/server/src/streaming/users/permissioner_rules/consumer_offsets.rs
+++ b/core/server/src/streaming/users/permissioner_rules/consumer_offsets.rs
@@ -23,8 +23,8 @@ impl Permissioner {
     pub fn get_consumer_offset(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.poll_messages(user_id, stream_id, topic_id)
     }
@@ -32,8 +32,8 @@ impl Permissioner {
     pub fn store_consumer_offset(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.poll_messages(user_id, stream_id, topic_id)
     }
@@ -41,8 +41,8 @@ impl Permissioner {
     pub fn delete_consumer_offset(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.poll_messages(user_id, stream_id, topic_id)
     }

--- a/core/server/src/streaming/users/permissioner_rules/messages.rs
+++ b/core/server/src/streaming/users/permissioner_rules/messages.rs
@@ -23,8 +23,8 @@ impl Permissioner {
     pub fn poll_messages(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         if self
             .users_that_can_poll_messages_from_all_streams
@@ -83,8 +83,8 @@ impl Permissioner {
     pub fn append_messages(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         if self
             .users_that_can_send_messages_to_all_streams

--- a/core/server/src/streaming/users/permissioner_rules/partitions.rs
+++ b/core/server/src/streaming/users/permissioner_rules/partitions.rs
@@ -23,8 +23,8 @@ impl Permissioner {
     pub fn create_partitions(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.update_topic(user_id, stream_id, topic_id)
     }
@@ -32,8 +32,8 @@ impl Permissioner {
     pub fn delete_partitions(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.update_topic(user_id, stream_id, topic_id)
     }

--- a/core/server/src/streaming/users/permissioner_rules/segments.rs
+++ b/core/server/src/streaming/users/permissioner_rules/segments.rs
@@ -22,8 +22,8 @@ impl Permissioner {
     pub fn delete_segments(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.update_topic(user_id, stream_id, topic_id)
     }

--- a/core/server/src/streaming/users/permissioner_rules/streams.rs
+++ b/core/server/src/streaming/users/permissioner_rules/streams.rs
@@ -20,7 +20,7 @@ use crate::streaming::users::permissioner::Permissioner;
 use iggy_common::IggyError;
 
 impl Permissioner {
-    pub fn get_stream(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn get_stream(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.manage_streams || global_permissions.read_streams)
         {
@@ -56,19 +56,19 @@ impl Permissioner {
         Err(IggyError::Unauthorized)
     }
 
-    pub fn update_stream(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn update_stream(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         self.manage_stream(user_id, stream_id)
     }
 
-    pub fn delete_stream(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn delete_stream(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         self.manage_stream(user_id, stream_id)
     }
 
-    pub fn purge_stream(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn purge_stream(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         self.manage_stream(user_id, stream_id)
     }
 
-    fn manage_stream(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    fn manage_stream(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && global_permissions.manage_streams
         {

--- a/core/server/src/streaming/users/permissioner_rules/topics.rs
+++ b/core/server/src/streaming/users/permissioner_rules/topics.rs
@@ -20,7 +20,12 @@ use crate::streaming::users::permissioner::Permissioner;
 use iggy_common::IggyError;
 
 impl Permissioner {
-    pub fn get_topic(&self, user_id: u32, stream_id: u32, topic_id: u32) -> Result<(), IggyError> {
+    pub fn get_topic(
+        &self,
+        user_id: u32,
+        stream_id: usize,
+        topic_id: usize,
+    ) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.read_streams
                 || global_permissions.manage_streams
@@ -47,7 +52,7 @@ impl Permissioner {
         Err(IggyError::Unauthorized)
     }
 
-    pub fn get_topics(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn get_topics(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.read_streams
                 || global_permissions.manage_streams
@@ -74,7 +79,7 @@ impl Permissioner {
         Err(IggyError::Unauthorized)
     }
 
-    pub fn create_topic(&self, user_id: u32, stream_id: u32) -> Result<(), IggyError> {
+    pub fn create_topic(&self, user_id: u32, stream_id: usize) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.manage_streams || global_permissions.manage_topics)
         {
@@ -93,8 +98,8 @@ impl Permissioner {
     pub fn update_topic(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.manage_topic(user_id, stream_id, topic_id)
     }
@@ -102,8 +107,8 @@ impl Permissioner {
     pub fn delete_topic(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.manage_topic(user_id, stream_id, topic_id)
     }
@@ -111,13 +116,18 @@ impl Permissioner {
     pub fn purge_topic(
         &self,
         user_id: u32,
-        stream_id: u32,
-        topic_id: u32,
+        stream_id: usize,
+        topic_id: usize,
     ) -> Result<(), IggyError> {
         self.manage_topic(user_id, stream_id, topic_id)
     }
 
-    fn manage_topic(&self, user_id: u32, stream_id: u32, topic_id: u32) -> Result<(), IggyError> {
+    fn manage_topic(
+        &self,
+        user_id: u32,
+        stream_id: usize,
+        topic_id: usize,
+    ) -> Result<(), IggyError> {
         if let Some(global_permissions) = self.users_permissions.get(&user_id)
             && (global_permissions.manage_streams || global_permissions.manage_topics)
         {


### PR DESCRIPTION
## Summary

According to #2198, align ID types of stream and topic with the target pointer size "usize" to avoid churny casts and platform-specific inconsistencies.

Some parts outside the scope of server needs to be changed due to the depency for structs under iggy common.

