### PR TITLE
fix(io_uring): resolve clippy lints and add WebSocket to benchmark tool

### DIFF
--- a/core/bench/src/args/common.rs
+++ b/core/bench/src/args/common.rs
@@ -360,6 +360,7 @@ impl IggyBenchArgs {
             BenchmarkTransportCommand::Tcp(_) => "tcp",
             BenchmarkTransportCommand::Quic(_) => "quic",
             BenchmarkTransportCommand::Http(_) => "http",
+            BenchmarkTransportCommand::WebSocket(_) => "ws",
         };
 
         let actors = match &self.benchmark_kind {

--- a/core/bench/src/args/defaults.rs
+++ b/core/bench/src/args/defaults.rs
@@ -29,6 +29,8 @@ pub const DEFAULT_QUIC_SERVER_ADDRESS: &str = "127.0.0.1:8080";
 pub const DEFAULT_QUIC_SERVER_NAME: &str = "localhost";
 pub const DEFAULT_QUIC_VALIDATE_CERTIFICATE: bool = false;
 
+pub const DEFAULT_WEBSOCKET_SERVER_ADDRESS: &str = "127.0.0.1:8092";
+
 pub const DEFAULT_MESSAGES_PER_BATCH: NonZeroU32 = u32!(1000);
 pub const DEFAULT_MESSAGE_BATCHES: NonZeroU32 = u32!(1000);
 pub const DEFAULT_MESSAGE_SIZE: NonZeroU32 = u32!(1000);

--- a/core/common/src/types/args/mod.rs
+++ b/core/common/src/types/args/mod.rs
@@ -201,7 +201,7 @@ pub struct ArgsOptional {
 
     /// The optional server address for the WebSocket transport
     ///
-    /// [default: 127.0.0.1:8095]
+    /// [default: 127.0.0.1:8092]
     #[arg(long)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub websocket_server_address: Option<String>,
@@ -403,7 +403,7 @@ impl Default for Args {
             quic_max_idle_timeout: 10000,
             quic_validate_certificate: false,
             quic_heartbeat_interval: "5s".to_string(),
-            websocket_server_address: "127.0.0.1:8095".to_string(),
+            websocket_server_address: "127.0.0.1:8092".to_string(),
             websocket_reconnection_enabled: true,
             websocket_reconnection_max_retries: None,
             websocket_reconnection_interval: "1s".to_string(),

--- a/core/integration/tests/cli/general/test_help_command.rs
+++ b/core/integration/tests/cli/general/test_help_command.rs
@@ -177,7 +177,7 @@ Options:
       --websocket-server-address <WEBSOCKET_SERVER_ADDRESS>
           The optional server address for the WebSocket transport
 {CLAP_INDENT}
-          [default: 127.0.0.1:8095]
+          [default: 127.0.0.1:8092]
 
       --websocket-reconnection-max-retries <WEBSOCKET_RECONNECTION_MAX_RETRIES>
           The optional number of max reconnect retries for the WebSocket transport

--- a/core/server/src/configs/websocket.rs
+++ b/core/server/src/configs/websocket.rs
@@ -53,34 +53,34 @@ impl WebSocketConfig {
 
         let mut config = TungsteniteConfig::default();
 
-        if let Some(read_buf_size_str) = &self.read_buffer_size {
-            if let Ok(byte_size) = read_buf_size_str.parse::<IggyByteSize>() {
-                config = config.read_buffer_size(byte_size.as_bytes_u64() as usize);
-            }
+        if let Some(read_buf_size_str) = &self.read_buffer_size
+            && let Ok(byte_size) = read_buf_size_str.parse::<IggyByteSize>()
+        {
+            config = config.read_buffer_size(byte_size.as_bytes_u64() as usize);
         }
 
-        if let Some(write_buf_size_str) = &self.write_buffer_size {
-            if let Ok(byte_size) = write_buf_size_str.parse::<IggyByteSize>() {
-                config = config.write_buffer_size(byte_size.as_bytes_u64() as usize);
-            }
+        if let Some(write_buf_size_str) = &self.write_buffer_size
+            && let Ok(byte_size) = write_buf_size_str.parse::<IggyByteSize>()
+        {
+            config = config.write_buffer_size(byte_size.as_bytes_u64() as usize);
         }
 
-        if let Some(max_write_buf_size_str) = &self.max_write_buffer_size {
-            if let Ok(byte_size) = max_write_buf_size_str.parse::<IggyByteSize>() {
-                config = config.max_write_buffer_size(byte_size.as_bytes_u64() as usize);
-            }
+        if let Some(max_write_buf_size_str) = &self.max_write_buffer_size
+            && let Ok(byte_size) = max_write_buf_size_str.parse::<IggyByteSize>()
+        {
+            config = config.max_write_buffer_size(byte_size.as_bytes_u64() as usize);
         }
 
-        if let Some(msg_size_str) = &self.max_message_size {
-            if let Ok(byte_size) = msg_size_str.parse::<IggyByteSize>() {
-                config = config.max_message_size(Some(byte_size.as_bytes_u64() as usize));
-            }
+        if let Some(msg_size_str) = &self.max_message_size
+            && let Ok(byte_size) = msg_size_str.parse::<IggyByteSize>()
+        {
+            config = config.max_message_size(Some(byte_size.as_bytes_u64() as usize));
         }
 
-        if let Some(frame_size_str) = &self.max_frame_size {
-            if let Ok(byte_size) = frame_size_str.parse::<IggyByteSize>() {
-                config = config.max_frame_size(Some(byte_size.as_bytes_u64() as usize));
-            }
+        if let Some(frame_size_str) = &self.max_frame_size
+            && let Ok(byte_size) = frame_size_str.parse::<IggyByteSize>()
+        {
+            config = config.max_frame_size(Some(byte_size.as_bytes_u64() as usize));
         }
 
         config = config.accept_unmasked_frames(self.accept_unmasked_frames);

--- a/core/server/src/websocket/connection_handler.rs
+++ b/core/server/src/websocket/connection_handler.rs
@@ -69,14 +69,14 @@ pub(crate) async fn handle_connection(
         let length =
             u32::from_le_bytes(initial_buffer[0..INITIAL_BYTES_LENGTH].try_into().unwrap());
         let (res, mut code_buffer_out) = sender.read(code_buffer).await;
-        let _ = res?;
+        res?;
         let code: u32 =
             u32::from_le_bytes(code_buffer_out[0..INITIAL_BYTES_LENGTH].try_into().unwrap());
 
         initial_buffer.clear();
         code_buffer_out.clear();
-        length_buffer = BytesMut::from(initial_buffer);
-        code_buffer = BytesMut::from(code_buffer_out);
+        length_buffer = initial_buffer;
+        code_buffer = code_buffer_out;
 
         debug!("Received a WebSocket request, length: {length}, code: {code}");
         let command = ServerCommand::from_code_and_reader(code, sender, length - 4).await?;

--- a/core/server/src/websocket/websocket_listener.rs
+++ b/core/server/src/websocket/websocket_listener.rs
@@ -92,7 +92,6 @@ async fn accept_loop(
 ) -> Result<(), IggyError> {
     loop {
         let shard = shard.clone();
-        let ws_config = ws_config.clone();
         let accept_future = listener.accept();
 
         futures::select! {
@@ -110,7 +109,7 @@ async fn accept_loop(
                         shard_info!(shard.id, "Accepted new WebSocket connection from: {}", remote_addr);
 
                         let shard_clone = shard.clone();
-                        let ws_config_clone = ws_config.clone();
+                        let ws_config_clone = ws_config;
                         let registry = shard.task_registry.clone();
                         let registry_clone = registry.clone();
 


### PR DESCRIPTION
- Fix clippy warnings in websocket server code
- Add WebSocket transport support to iggy-bench (alias: ws)
- Update default WebSocket address to 8092
