### PR TITLE
fix(docs): update README for running iggy-server with defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ One can use default root credentials with optional `--with-default-root-credenti
 This flag is equivalent to setting `IGGY_ROOT_USERNAME=iggy` and `IGGY_ROOT_PASSWORD=iggy`, plus
 it should only be used for development and testing.
 
-`cargo run --bin iggy-server --with-default-root-credentials`
+`cargo run --bin iggy-server -- --with-default-root-credentials`
 
 For configuration options and detailed help:
 


### PR DESCRIPTION

Running `iggy-server` as per the current README.md leads to following error while passing `with-default-root-credentials`. 
```
cargo run --bin iggy-server --with-default-root-credentials
error: unexpected argument '--with-default-root-credentials' found

  tip: a similar argument exists: '--no-default-features'
  tip: to pass '--with-default-root-credentials' as a value, use '-- --with-default-root-credentials'

Usage: cargo run --bin [<NAME>] --no-default-features [ARGS]...

For more information, try '--help'.
```
<img width="951" height="123" alt="Screenshot 2025-10-17 at 8 55 45 AM" src="https://github.com/user-attachments/assets/8e9d0cd8-4887-40e5-ba27-48c40fafe9bd" />

This PR fixes the command in README.md 

