### PR TITLE
fix(ci): free disk space before build to prevent runner exhaustion

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -30,6 +30,17 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Cleanup disk space
+      run: |
+        echo "Disk space before cleanup:"
+        df -h
+        sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+        # sudo docker image prune --all --force
+        # sudo docker builder prune -a
+        echo "Disk space after cleanup:"
+        df -h
+      shell: bash
+
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache
       with:


### PR DESCRIPTION
Remove unused tools (dotnet, android, ghc, CodeQL) to free ~25GB
on GitHub Actions runners.
