### PR TITLE
feat(server): add file_enabled option to logging config

### DIFF
--- a/core/configs/server.toml
+++ b/core/configs/server.toml
@@ -346,6 +346,10 @@ path = "logs"
 # Note: RUST_LOG environment variable always takes precedence over this setting.
 level = "info"
 
+# Whether to write logs to file. When false, logs are only written to stdout.
+# When enabled, logs are stored in {system.path}/{system.logging.path} (default: local_data/logs).
+file_enabled = true
+
 # Maximum size of the log files before rotation.
 max_size = "512 MB"
 

--- a/core/server/src/configs/defaults.rs
+++ b/core/server/src/configs/defaults.rs
@@ -399,6 +399,7 @@ impl Default for LoggingConfig {
         LoggingConfig {
             path: SERVER_CONFIG.system.logging.path.parse().unwrap(),
             level: SERVER_CONFIG.system.logging.level.parse().unwrap(),
+            file_enabled: SERVER_CONFIG.system.logging.file_enabled,
             max_size: SERVER_CONFIG.system.logging.max_size.parse().unwrap(),
             retention: SERVER_CONFIG.system.logging.retention.parse().unwrap(),
             sysinfo_print_interval: SERVER_CONFIG

--- a/core/server/src/configs/displays.rs
+++ b/core/server/src/configs/displays.rs
@@ -248,9 +248,10 @@ impl Display for LoggingConfig {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{{ path: {}, level: {}, max_size: {}, retention: {} }}",
+            "{{ path: {}, level: {}, file_enabled: {}, max_size: {}, retention: {} }}",
             self.path,
             self.level,
+            self.file_enabled,
             self.max_size.as_human_string_with_zero_as_unlimited(),
             self.retention
         )

--- a/core/server/src/configs/system.rs
+++ b/core/server/src/configs/system.rs
@@ -86,6 +86,7 @@ pub struct CompressionConfig {
 pub struct LoggingConfig {
     pub path: String,
     pub level: String,
+    pub file_enabled: bool,
     pub max_size: IggyByteSize,
     #[serde_as(as = "DisplayFromStr")]
     pub retention: IggyDuration,


### PR DESCRIPTION
Allow disabling file logging via system.logging.file_enabled setting.
When false, logs are only written to stdout.
