### PR TITLE
fix(cli): disable keyring on musl targets

### DIFF
--- a/core/binary_protocol/Cargo.toml
+++ b/core/binary_protocol/Cargo.toml
@@ -37,10 +37,12 @@ chrono = { workspace = true }
 comfy-table = { workspace = true, optional = false }
 dirs = { workspace = true }
 iggy_common = { workspace = true }
-keyring = { workspace = true, optional = false }
 passterm = { workspace = true, optional = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
+
+[target.'cfg(not(target_env = "musl"))'.dependencies]
+keyring = { workspace = true }

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -41,8 +41,10 @@ humantime = { workspace = true }
 iggy = { workspace = true }
 iggy_binary_protocol = { workspace = true }
 iggy_common = { workspace = true }
-keyring = { workspace = true }
 lazy_static = { workspace = true }
+
+[target.'cfg(not(target_env = "musl"))'.dependencies]
+keyring = { workspace = true }
 libc = "0.2.178"
 log = { workspace = true }
 predicates = { workspace = true }


### PR DESCRIPTION
Musl builds (containers/static binaries) don't have D-Bus or
secret service available. Use conditional compilation to
disable keyring functionality and provide clear error
messages when session storage is attempted.
