### PR TITLE
fix(ci): add aarch64 builds to pre-merge and fix musl linking

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -122,3 +122,31 @@ runs:
           --pr-ref ${{ github.sha }} \
           --port 8090 --wait-secs 180
       shell: bash
+
+    # aarch64 builds (run on ARM64 runners)
+    - name: Build aarch64-gnu
+      if: inputs.task == 'build-aarch64-gnu'
+      run: cargo build --locked --all-targets
+      shell: bash
+
+    - name: Install musl tools for aarch64-musl
+      if: inputs.task == 'build-aarch64-musl'
+      run: |
+        sudo apt-get update && sudo apt-get install -y musl-tools
+        rustup target add aarch64-unknown-linux-musl
+      shell: bash
+
+    - name: Build aarch64-musl
+      if: inputs.task == 'build-aarch64-musl'
+      run: cargo build --locked --all-targets --target aarch64-unknown-linux-musl
+      shell: bash
+      env:
+        # Disable GCC outline atomics to avoid undefined __aarch64_ldadd4_sync
+        # references when linking dbus-sys (required by keyring crate)
+        CFLAGS: "-mno-outline-atomics"
+
+    # macOS builds
+    - name: Build macOS aarch64
+      if: inputs.task == 'build-macos-aarch64'
+      run: cargo build --locked --all-targets
+      shell: bash

--- a/.github/config/components.yml
+++ b/.github/config/components.yml
@@ -98,6 +98,9 @@ components:
       - "machete"
       - "test"
       - "compat"
+      - "build-aarch64-gnu"
+      - "build-aarch64-musl"
+      - "build-macos-aarch64"
 
   # CLI component
   rust-cli:

--- a/.github/workflows/_build_rust_artifacts.yml
+++ b/.github/workflows/_build_rust_artifacts.yml
@@ -119,6 +119,12 @@ jobs:
             bin_flags+=(--bin "$name")
           done
 
+          # aarch64 musl: disable GCC outline atomics to avoid undefined __aarch64_ldadd4_sync
+          # references when linking dbus-sys (required by keyring crate)
+          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
+            export CFLAGS="-mno-outline-atomics"
+          fi
+
           cargo build --locked --release --target ${{ matrix.target }} "${bin_flags[@]}"
 
       - name: Package binaries

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -34,7 +34,12 @@ permissions:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    # Select runner based on build target
+    runs-on: ${{
+      (inputs.task == 'build-aarch64-gnu' || inputs.task == 'build-aarch64-musl') && 'ubuntu-24.04-arm' ||
+      inputs.task == 'build-macos-aarch64' && 'macos-14' ||
+      'ubuntu-latest'
+      }}
     timeout-minutes: 60
     env:
       IGGY_CI_BUILD: true

--- a/core/binary_protocol/Cargo.toml
+++ b/core/binary_protocol/Cargo.toml
@@ -37,12 +37,10 @@ chrono = { workspace = true }
 comfy-table = { workspace = true, optional = false }
 dirs = { workspace = true }
 iggy_common = { workspace = true }
+keyring = { workspace = true, optional = false }
 passterm = { workspace = true, optional = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 tracing = { workspace = true }
-
-[target.'cfg(not(target_env = "musl"))'.dependencies]
-keyring = { workspace = true }

--- a/core/binary_protocol/src/cli/binary_personal_access_tokens/create_personal_access_token.rs
+++ b/core/binary_protocol/src/cli/binary_personal_access_tokens/create_personal_access_token.rs
@@ -22,7 +22,6 @@ use anyhow::Context;
 use async_trait::async_trait;
 use iggy_common::PersonalAccessTokenExpiry;
 use iggy_common::create_personal_access_token::CreatePersonalAccessToken;
-#[cfg(not(target_env = "musl"))]
 use keyring::Entry;
 use tracing::{Level, event};
 
@@ -83,20 +82,11 @@ impl CliCommand for CreatePersonalAccessTokenCmd {
             })?;
 
         if self.store_token {
-            #[cfg(not(target_env = "musl"))]
-            {
-                let server_address = format!("iggy:{}", self.server_address);
-                let entry = Entry::new(&server_address, &self.create_token.name)?;
-                entry.set_password(&token.token)?;
-                event!(target: PRINT_TARGET, Level::DEBUG,"Stored token under service: {} and name: {}", server_address,
-                        self.create_token.name);
-            }
-            #[cfg(target_env = "musl")]
-            {
-                anyhow::bail!(
-                    "Token storage is not available on musl targets. Use --quiet to print the token instead."
-                );
-            }
+            let server_address = format!("iggy:{}", self.server_address);
+            let entry = Entry::new(&server_address, &self.create_token.name)?;
+            entry.set_password(&token.token)?;
+            event!(target: PRINT_TARGET, Level::DEBUG,"Stored token under service: {} and name: {}", server_address,
+                    self.create_token.name);
             event!(target: PRINT_TARGET, Level::INFO,
                 "Personal access token with name: {} and {} created",
                 self.create_token.name,

--- a/core/binary_protocol/src/cli/binary_personal_access_tokens/delete_personal_access_tokens.rs
+++ b/core/binary_protocol/src/cli/binary_personal_access_tokens/delete_personal_access_tokens.rs
@@ -21,7 +21,6 @@ use crate::cli::cli_command::{CliCommand, PRINT_TARGET};
 use anyhow::Context;
 use async_trait::async_trait;
 use iggy_common::delete_personal_access_token::DeletePersonalAccessToken;
-#[cfg(not(target_env = "musl"))]
 use keyring::Entry;
 use tracing::{Level, event};
 
@@ -59,16 +58,13 @@ impl CliCommand for DeletePersonalAccessTokenCmd {
                 )
             })?;
 
-        #[cfg(not(target_env = "musl"))]
-        {
-            let server_address = format!("iggy:{}", self.server_address);
-            let entry = Entry::new(&server_address, &self.delete_token.name)?;
-            event!(target: PRINT_TARGET, Level::DEBUG,"Checking token presence under service: {} and name: {}",
-                    server_address, self.delete_token.name);
-            if let Err(e) = entry.delete_credential() {
-                event!(target: PRINT_TARGET, Level::DEBUG, "{}", e);
-            };
-        }
+        let server_address = format!("iggy:{}", self.server_address);
+        let entry = Entry::new(&server_address, &self.delete_token.name)?;
+        event!(target: PRINT_TARGET, Level::DEBUG,"Checking token presence under service: {} and name: {}",
+                server_address, self.delete_token.name);
+        if let Err(e) = entry.delete_credential() {
+            event!(target: PRINT_TARGET, Level::DEBUG, "{}", e);
+        };
 
         event!(target: PRINT_TARGET, Level::INFO,
             "Personal access token with name: {} deleted", self.delete_token.name

--- a/core/binary_protocol/src/cli/binary_system/session.rs
+++ b/core/binary_protocol/src/cli/binary_system/session.rs
@@ -16,11 +16,9 @@
  * under the License.
  */
 
-#[cfg(not(target_env = "musl"))]
 use keyring::{Entry, Result};
 
 const SESSION_TOKEN_NAME: &str = "iggy-cli-session";
-#[cfg(not(target_env = "musl"))]
 const SESSION_KEYRING_SERVICE_NAME: &str = "iggy-cli-session";
 
 pub struct ServerSession {
@@ -36,7 +34,6 @@ impl ServerSession {
         &self.server_address
     }
 
-    #[cfg(not(target_env = "musl"))]
     fn get_service_name(&self) -> String {
         format!("{SESSION_KEYRING_SERVICE_NAME}:{}", self.server_address)
     }
@@ -45,7 +42,6 @@ impl ServerSession {
         String::from(SESSION_TOKEN_NAME)
     }
 
-    #[cfg(not(target_env = "musl"))]
     pub fn is_active(&self) -> bool {
         if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name()) {
             return entry.get_password().is_ok();
@@ -54,26 +50,12 @@ impl ServerSession {
         false
     }
 
-    #[cfg(target_env = "musl")]
-    pub fn is_active(&self) -> bool {
-        false
-    }
-
-    #[cfg(not(target_env = "musl"))]
     pub fn store(&self, token: &str) -> Result<()> {
         let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
         entry.set_password(token)?;
         Ok(())
     }
 
-    #[cfg(target_env = "musl")]
-    pub fn store(&self, _token: &str) -> anyhow::Result<()> {
-        anyhow::bail!(
-            "Session storage is not available on musl targets. Use explicit credentials instead."
-        )
-    }
-
-    #[cfg(not(target_env = "musl"))]
     pub fn get_token(&self) -> Option<String> {
         if let Ok(entry) = Entry::new(&self.get_service_name(), &self.get_token_name())
             && let Ok(token) = entry.get_password()
@@ -84,19 +66,8 @@ impl ServerSession {
         None
     }
 
-    #[cfg(target_env = "musl")]
-    pub fn get_token(&self) -> Option<String> {
-        None
-    }
-
-    #[cfg(not(target_env = "musl"))]
     pub fn delete(&self) -> Result<()> {
         let entry = Entry::new(&self.get_service_name(), &self.get_token_name())?;
         entry.delete_credential()
-    }
-
-    #[cfg(target_env = "musl")]
-    pub fn delete(&self) -> anyhow::Result<()> {
-        Ok(())
     }
 }

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -41,6 +41,7 @@ humantime = { workspace = true }
 iggy = { workspace = true }
 iggy_binary_protocol = { workspace = true }
 iggy_common = { workspace = true }
+keyring = { workspace = true }
 lazy_static = { workspace = true }
 libc = "0.2.178"
 log = { workspace = true }
@@ -65,6 +66,3 @@ tokio = { workspace = true }
 twox-hash = { workspace = true }
 uuid = { workspace = true }
 zip = { workspace = true }
-
-[target.'cfg(not(target_env = "musl"))'.dependencies]
-keyring = { workspace = true }


### PR DESCRIPTION
- Revert PR #2478 cfg guards in favor of CFLAGS approach
- Add CFLAGS=-mno-outline-atomics for aarch64-musl builds
- Add build-aarch64-gnu and build-aarch64-musl tasks to pre-merge
- Use ubuntu-24.04-arm runner for ARM64 builds
