### PR TITLE
feat(ci): use native ARM64 runners and implement better shared Docker cache

### DIFF
--- a/.github/actions/utils/docker-buildx/action.yml
+++ b/.github/actions/utils/docker-buildx/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "Libc to use (glibc/musl)"
     required: false
     default: "musl"
+  platform:
+    description: "Single platform to build (e.g., linux/amd64). If set, builds only this platform without QEMU. Leave empty for multi-arch build."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -112,6 +116,8 @@ runs:
         fi
 
     - name: Set up QEMU
+      # Skip QEMU when building single platform on native runner (no emulation needed)
+      if: inputs.platform == ''
       uses: docker/setup-qemu-action@v3
       with:
         platforms: all
@@ -130,30 +136,56 @@ runs:
         username: ${{ env.DOCKERHUB_USER }}
         password: ${{ env.DOCKERHUB_TOKEN }}
 
+    - name: Compute platform suffix
+      id: suffix
+      shell: bash
+      run: |
+        platform="${{ inputs.platform }}"
+        if [ -n "$platform" ]; then
+          # Extract arch from platform (e.g., linux/amd64 -> amd64)
+          suffix="${platform##*/}"
+          echo "suffix=-${suffix}" >> "$GITHUB_OUTPUT"
+          echo "is_single=true" >> "$GITHUB_OUTPUT"
+          echo "📦 Platform suffix: -${suffix}"
+        else
+          echo "suffix=" >> "$GITHUB_OUTPUT"
+          echo "is_single=false" >> "$GITHUB_OUTPUT"
+          echo "📦 No platform suffix (multi-arch)"
+        fi
+
     - name: Docker meta
       id: meta
       uses: docker/metadata-action@v5
       with:
         images: ${{ steps.config.outputs.image }}
         tags: |
-          type=raw,value=${{ inputs.version }}
-          type=raw,value=latest,enable=${{ steps.config.outputs.should_push == 'true' && inputs.version != 'test' && !contains(inputs.version, 'edge') && !contains(inputs.version, 'rc') && !contains(inputs.version, 'alpha') && !contains(inputs.version, 'beta') }}
+          type=raw,value=${{ inputs.version }}${{ steps.suffix.outputs.suffix }}
+          type=raw,value=latest,enable=${{ steps.suffix.outputs.is_single == 'false' && steps.config.outputs.should_push == 'true' && inputs.version != 'test' && !contains(inputs.version, 'edge') && !contains(inputs.version, 'rc') && !contains(inputs.version, 'alpha') && !contains(inputs.version, 'beta') }}
           type=sha,enable=${{ inputs.version == 'test' }}
 
     - name: Determine platforms
       id: platforms
       shell: bash
       run: |
+        p_input="${{ inputs.platform }}"
         p_cfg="${{ steps.config.outputs.cfg_platforms }}"
-        if [ -n "$p_cfg" ]; then
+
+        # Priority: input platform > config platforms > defaults
+        if [ -n "$p_input" ]; then
+          # Single platform specified - native build on correct runner
+          platforms="$p_input"
+          echo "🚀 Single platform build (native): $platforms"
+        elif [ -n "$p_cfg" ]; then
           platforms="$p_cfg"
+          echo "🖥️ Platforms from config: $platforms"
         elif [ "${{ steps.config.outputs.should_push }}" = "true" ]; then
           platforms="linux/amd64,linux/arm64"
+          echo "🖥️ Multi-arch build: $platforms"
         else
           platforms="linux/amd64"
+          echo "🖥️ Default platform: $platforms"
         fi
         echo "platforms=$platforms" >> "$GITHUB_OUTPUT"
-        echo "🖥️ Platforms: $platforms"
 
     - name: Compose cache config (no registry on dry-run)
       id: cachecfg
@@ -162,36 +194,52 @@ runs:
         set -euo pipefail
         comp="${{ inputs.component }}"
         os="${{ runner.os }}"
+        arch="${{ runner.arch }}"
         img="${{ steps.config.outputs.image }}"
+
+        # Include architecture in cache scope to prevent collisions between
+        # native amd64 and arm64 builds (both have runner.os = "Linux")
+        scope_arch="${comp}-${os}-${arch}"
+        scope_os="${comp}-${os}"
+
+        # Shared deps cache image - apache/iggy has the most deps, others can reuse
+        shared_deps="apache/iggy"
+
         if [ "${{ inputs.dry_run }}" = "true" ]; then
-          # dry-run/forks: avoid Docker Hub completely
+          # dry-run/forks: avoid Docker Hub completely, use shared GHA scope for deps
           CACHE_TO=$(
             printf '%s\n' \
-              "type=gha,scope=buildkit-${comp}-${os},mode=max" \
-              "type=gha,scope=buildkit-${comp},mode=max" \
+              "type=gha,scope=buildkit-deps-${os}-${arch},mode=max" \
+              "type=gha,scope=buildkit-${scope_arch},mode=max" \
               "type=inline"
           )
           CACHE_FROM=$(
             printf '%s\n' \
-              "type=gha,scope=buildkit-${comp}-${os}" \
-              "type=gha,scope=buildkit-${comp}"
+              "type=gha,scope=buildkit-deps-${os}-${arch}" \
+              "type=gha,scope=buildkit-${scope_arch}" \
+              "type=gha,scope=buildkit-${scope_os}"
           )
         else
-          # CI on upstream: use registry + gha + inline
+          # CI on upstream: use shared deps cache + component-specific cache
+          # Order matters: try shared deps first (most likely to have common layers)
           CACHE_TO=$(
             printf '%s\n' \
-              "type=registry,ref=${img}:buildcache,mode=max" \
-              "type=registry,ref=${img}:buildcache-${os},mode=max" \
+              "type=registry,ref=${shared_deps}:buildcache-${arch},mode=max" \
+              "type=registry,ref=${img}:buildcache-${arch},mode=max" \
               "type=inline" \
-              "type=gha,scope=buildkit-${comp}-${os},mode=max"
+              "type=gha,scope=buildkit-deps-${os}-${arch},mode=max" \
+              "type=gha,scope=buildkit-${scope_arch},mode=max"
           )
           CACHE_FROM=$(
             printf '%s\n' \
+              "type=registry,ref=${shared_deps}:buildcache-${arch}" \
+              "type=registry,ref=${shared_deps}:buildcache" \
+              "type=registry,ref=${img}:buildcache-${arch}" \
               "type=registry,ref=${img}:buildcache" \
-              "type=registry,ref=${img}:buildcache-${os}" \
               "type=registry,ref=${img}:latest" \
-              "type=gha,scope=buildkit-${comp}-${os}" \
-              "type=gha,scope=buildkit-${comp}"
+              "type=gha,scope=buildkit-deps-${os}-${arch}" \
+              "type=gha,scope=buildkit-${scope_arch}" \
+              "type=gha,scope=buildkit-${scope_os}"
           )
         fi
 

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.mk.outputs.matrix }}
+      components: ${{ steps.mk.outputs.components }}
     steps:
       - uses: actions/checkout@v4
 
@@ -63,21 +64,44 @@ jobs:
             const b64 = `${{ steps.cfg.outputs.components_b64 }}` || '';
             if (!b64) {
               core.setOutput('matrix', JSON.stringify({ include: [{ component: 'noop' }] }));
+              core.setOutput('components', JSON.stringify({ include: [{ component: 'noop' }] }));
               return;
             }
             const comps = JSON.parse(Buffer.from(b64, 'base64').toString('utf8'));
-            const include = Object.entries(comps)
+            const components = Object.entries(comps)
               .filter(([_, v]) => v && v.registry === 'dockerhub')
-              .map(([k]) => ({ component: k }));
-            const uniq = Array.from(new Map(include.map(i => [i.component, i])).values());
-            core.setOutput('matrix', JSON.stringify(uniq.length ? { include: uniq } : { include: [{ component: 'noop' }] }));
+              .map(([k]) => k);
+            const uniqComponents = [...new Set(components)];
+
+            // Output just the component list for manifest creation
+            const componentMatrix = uniqComponents.length
+              ? { include: uniqComponents.map(c => ({ component: c })) }
+              : { include: [{ component: 'noop' }] };
+            core.setOutput('components', JSON.stringify(componentMatrix));
+
+            // Build cross-product matrix: components × platforms
+            const platforms = [
+              { platform: 'linux/amd64', arch: 'amd64', runner: 'ubuntu-latest' },
+              { platform: 'linux/arm64', arch: 'arm64', runner: 'ubuntu-24.04-arm' }
+            ];
+
+            const matrix = [];
+            for (const comp of uniqComponents) {
+              for (const p of platforms) {
+                matrix.push({ component: comp, ...p });
+              }
+            }
+
+            core.setOutput('matrix', JSON.stringify(matrix.length ? { include: matrix } : { include: [{ component: 'noop' }] }));
+            console.log(`Components: ${uniqComponents.join(', ')}`);
+            console.log(`Matrix size: ${matrix.length} jobs (${uniqComponents.length} components × 2 platforms)`);
 
   docker-edge:
-    name: ${{ matrix.component }}
+    name: ${{ matrix.component }} (${{ matrix.arch }})
     needs: plan
     if: ${{ fromJson(needs.plan.outputs.matrix).include[0].component != 'noop' }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.plan.outputs.matrix) }}
@@ -87,13 +111,73 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Determine libc for component
+        id: libc
+        run: |
+          # Connectors runtime must use glibc because it dlopen()s glibc plugins
+          if [ "${{ matrix.component }}" = "rust-connectors" ]; then
+            echo "libc=glibc" >> "$GITHUB_OUTPUT"
+          else
+            echo "libc=musl" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: ./.github/actions/utils/docker-buildx
         with:
           task: publish
-          libc: musl
+          libc: ${{ steps.libc.outputs.libc }}
           component: ${{ matrix.component }}
           version: edge
-          dry_run: ${{ github.event.repository.fork }} # forks: always dry-run
+          platform: ${{ matrix.platform }}
+          dry_run: ${{ github.event.repository.fork }}
+
+  docker-manifests:
+    name: Create manifests
+    needs: [plan, docker-edge]
+    if: ${{ !github.event.repository.fork && fromJson(needs.plan.outputs.components).include[0].component != 'noop' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.components) }}
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve image from config
+        id: config
+        shell: bash
+        run: |
+          if ! command -v yq >/dev/null 2>&1; then
+            YQ_VERSION="v4.47.1"
+            YQ_CHECKSUM="0fb28c6680193c41b364193d0c0fc4a03177aecde51cfc04d506b1517158c2fb"
+            curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+            echo "${YQ_CHECKSUM}  /usr/local/bin/yq" | sha256sum -c - || exit 1
+            chmod +x /usr/local/bin/yq
+          fi
+          image=$(yq ".components.${{ matrix.component }}.image" .github/config/publish.yml)
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "📦 Image: $image"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          IMAGE="${{ steps.config.outputs.image }}"
+          VERSION="edge"
+
+          echo "Creating manifest for $IMAGE:$VERSION"
+
+          docker manifest create "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+          docker manifest push "${IMAGE}:${VERSION}"
+          echo "✅ Pushed manifest: ${IMAGE}:${VERSION}"
 
   build-artifacts:
     name: Build artifacts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -136,10 +136,14 @@ jobs:
     outputs:
       targets: ${{ steps.mk.outputs.targets }}
       non_rust_targets: ${{ steps.mk.outputs.non_rust_targets }}
+      non_docker_targets: ${{ steps.mk.outputs.non_docker_targets }}
+      docker_matrix: ${{ steps.mk.outputs.docker_matrix }}
+      docker_components: ${{ steps.mk.outputs.docker_components }}
       count: ${{ steps.mk.outputs.count }}
       go_sdk_version: ${{ steps.mk.outputs.go_sdk_version }}
       has_python: ${{ steps.mk.outputs.has_python }}
       has_rust_crates: ${{ steps.mk.outputs.has_rust_crates }}
+      has_docker: ${{ steps.mk.outputs.has_docker }}
     steps:
       - name: Download latest copy script from master
         if: inputs.use_latest_ci
@@ -263,15 +267,40 @@ jobs:
               }
             }
 
+            // Separate Docker targets from other non-Rust targets
+            const dockerTargets = nonRustTargets.filter(t => t.type === 'docker');
+            const nonDockerTargets = nonRustTargets.filter(t => t.type !== 'docker');
+
             console.log(`Publishing ${targets.length} components:`);
             targets.forEach(t => console.log(`  - ${t.name} (${t.type}) -> ${t.registry || 'N/A'}`));
             console.log(`  (${nonRustTargets.length} non-Rust, ${targets.length - nonRustTargets.length} Rust crates)`);
+            console.log(`  (${dockerTargets.length} Docker, ${nonDockerTargets.length} other SDKs)`);
 
             // Output all targets for reference and tag creation
             core.setOutput('targets', JSON.stringify(targets.length ? { include: targets } : { include: [{ key: 'noop', type: 'noop' }] }));
 
             // Output only non-Rust targets for the parallel publish job
             core.setOutput('non_rust_targets', JSON.stringify(nonRustTargets.length ? { include: nonRustTargets } : { include: [{ key: 'noop', type: 'noop' }] }));
+
+            // Output non-Docker, non-Rust targets (SDKs only)
+            core.setOutput('non_docker_targets', JSON.stringify(nonDockerTargets.length ? { include: nonDockerTargets } : { include: [{ key: 'noop', type: 'noop' }] }));
+
+            // Build Docker matrix: components × platforms for native runner builds
+            const platforms = [
+              { platform: 'linux/amd64', arch: 'amd64', runner: 'ubuntu-latest' },
+              { platform: 'linux/arm64', arch: 'arm64', runner: 'ubuntu-24.04-arm' }
+            ];
+
+            const dockerMatrix = [];
+            for (const t of dockerTargets) {
+              for (const p of platforms) {
+                dockerMatrix.push({ ...t, ...p });
+              }
+            }
+
+            core.setOutput('docker_matrix', JSON.stringify(dockerMatrix.length ? { include: dockerMatrix } : { include: [{ key: 'noop', type: 'noop' }] }));
+            core.setOutput('docker_components', JSON.stringify(dockerTargets.length ? { include: dockerTargets } : { include: [{ key: 'noop', type: 'noop' }] }));
+            core.setOutput('has_docker', String(dockerTargets.length > 0));
 
             core.setOutput('count', String(targets.length));
             core.setOutput('go_sdk_version', goVersion);
@@ -603,24 +632,179 @@ jobs:
         if: always()
         run: echo "status=${{ job.status }}" >> "$GITHUB_OUTPUT"
 
-  publish:
-    name: ${{ matrix.name }}
-    needs:
-      [validate, plan, check-tags, build-python-wheels, publish-rust-crates]
+  # Docker publishing on native runners (no QEMU emulation)
+  publish-docker:
+    name: Docker ${{ matrix.name }} (${{ matrix.arch }})
+    needs: [validate, plan, check-tags, build-python-wheels, publish-rust-crates]
     if: |
       always() &&
       needs.validate.outputs.has_targets == 'true' &&
-      fromJson(needs.plan.outputs.non_rust_targets).include[0].key != 'noop' &&
+      needs.plan.outputs.has_docker == 'true' &&
+      fromJson(needs.plan.outputs.docker_matrix).include[0].key != 'noop' &&
+      (needs.build-python-wheels.result == 'success' || needs.build-python-wheels.result == 'skipped') &&
+      (needs.publish-rust-crates.result == 'success' || needs.publish-rust-crates.result == 'skipped')
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.docker_matrix) }}
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Download latest copy script from master
+        if: inputs.use_latest_ci
+        run: |
+          curl -sSL "https://raw.githubusercontent.com/${{ github.repository }}/master/scripts/copy-latest-from-master.sh" \
+            -o /tmp/copy-latest-from-master.sh
+          chmod +x /tmp/copy-latest-from-master.sh
+          echo "✅ Downloaded latest copy script from master"
+
+      - name: Checkout at commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+          fetch-depth: 0
+
+      - name: Save and apply latest CI from master
+        if: inputs.use_latest_ci
+        run: |
+          /tmp/copy-latest-from-master.sh save \
+            .github \
+            scripts \
+            web/Dockerfile \
+            core/server/Dockerfile \
+            core/ai/mcp/Dockerfile \
+            core/connectors/runtime/Dockerfile \
+            core/bench/dashboard/server/Dockerfile
+
+          /tmp/copy-latest-from-master.sh apply
+
+      - name: Ensure version extractor is executable
+        run: |
+          test -x scripts/extract-version.sh || chmod +x scripts/extract-version.sh
+
+      - name: Extract version
+        id: ver
+        run: |
+          VERSION=$(scripts/extract-version.sh "${{ matrix.key }}")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "✅ Resolved ${{ matrix.key }} -> version=$VERSION"
+
+      - name: Determine libc for component
+        id: libc
+        run: |
+          # Connectors runtime must use glibc because it dlopen()s glibc plugins
+          if [ "${{ matrix.key }}" = "rust-connectors" ]; then
+            echo "libc=glibc" >> "$GITHUB_OUTPUT"
+          else
+            echo "libc=musl" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish Docker image
+        uses: ./.github/actions/utils/docker-buildx
+        with:
+          task: publish
+          libc: ${{ steps.libc.outputs.libc }}
+          component: ${{ matrix.key }}
+          version: ${{ steps.ver.outputs.version }}
+          platform: ${{ matrix.platform }}
+          dry_run: ${{ inputs.dry_run }}
+
+  # Create multi-arch Docker manifests after platform-specific images are pushed
+  docker-manifests:
+    name: Docker manifests
+    needs: [validate, plan, publish-docker]
+    if: |
+      always() &&
+      needs.validate.outputs.has_targets == 'true' &&
+      needs.plan.outputs.has_docker == 'true' &&
+      fromJson(needs.plan.outputs.docker_components).include[0].key != 'noop' &&
+      needs.publish-docker.result == 'success' &&
+      inputs.dry_run == false
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.plan.outputs.docker_components) }}
+    env:
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Ensure version extractor is executable
+        run: |
+          test -x scripts/extract-version.sh || chmod +x scripts/extract-version.sh
+
+      - name: Extract version
+        id: ver
+        run: |
+          VERSION=$(scripts/extract-version.sh "${{ matrix.key }}")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve image from config
+        id: config
+        run: |
+          if ! command -v yq >/dev/null 2>&1; then
+            YQ_VERSION="v4.47.1"
+            YQ_CHECKSUM="0fb28c6680193c41b364193d0c0fc4a03177aecde51cfc04d506b1517158c2fb"
+            curl -sSL -o /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64
+            echo "${YQ_CHECKSUM}  /usr/local/bin/yq" | sha256sum -c - || exit 1
+            chmod +x /usr/local/bin/yq
+          fi
+          image=$(yq ".components.${{ matrix.key }}.image" .github/config/publish.yml)
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "📦 Image: $image"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKERHUB_USER }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Create and push manifest
+        run: |
+          IMAGE="${{ steps.config.outputs.image }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+
+          echo "Creating manifest for $IMAGE:$VERSION"
+
+          docker manifest create "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+          docker manifest push "${IMAGE}:${VERSION}"
+          echo "✅ Pushed manifest: ${IMAGE}:${VERSION}"
+
+          # Also create 'latest' tag for stable releases (not edge/rc/alpha/beta)
+          if [[ ! "$VERSION" =~ (edge|rc|alpha|beta) ]]; then
+            echo "Creating 'latest' manifest"
+            docker manifest create "${IMAGE}:latest" \
+              "${IMAGE}:${VERSION}-amd64" \
+              "${IMAGE}:${VERSION}-arm64"
+            docker manifest push "${IMAGE}:latest"
+            echo "✅ Pushed manifest: ${IMAGE}:latest"
+          fi
+
+  # Non-Docker, non-Rust publishing (Python, Node, Java, C#, Go SDKs)
+  # Note: This job runs in parallel with Docker publishing - no dependency between them
+  publish:
+    name: ${{ matrix.name }}
+    needs: [validate, plan, check-tags, build-python-wheels, publish-rust-crates]
+    if: |
+      always() &&
+      needs.validate.outputs.has_targets == 'true' &&
+      fromJson(needs.plan.outputs.non_docker_targets).include[0].key != 'noop' &&
       (needs.build-python-wheels.result == 'success' || needs.build-python-wheels.result == 'skipped') &&
       (needs.publish-rust-crates.result == 'success' || needs.publish-rust-crates.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.plan.outputs.non_rust_targets) }}
+      matrix: ${{ fromJson(needs.plan.outputs.non_docker_targets) }}
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       NEXUS_USER: ${{ secrets.NEXUS_USER }}
@@ -667,7 +851,7 @@ jobs:
           test -x scripts/extract-version.sh || chmod +x scripts/extract-version.sh
 
       - name: Setup Rust toolchain (if needed)
-        if: matrix.type == 'rust' || matrix.type == 'docker' || matrix.type == 'python'
+        if: matrix.type == 'rust' || matrix.type == 'python'
         uses: ./.github/actions/utils/setup-rust-with-cache
         with:
           cache-targets: false
@@ -695,18 +879,6 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG"       >> "$GITHUB_OUTPUT"
           echo "✅ Resolved ${{ matrix.key }} -> version=$VERSION tag=${TAG:-<none>}"
-
-      # ─────────────────────────────────────────
-      # Docker Publishing
-      # ─────────────────────────────────────────
-      - name: Publish Docker image
-        if: matrix.type == 'docker'
-        uses: ./.github/actions/utils/docker-buildx
-        with:
-          task: publish
-          component: ${{ matrix.key }}
-          version: ${{ steps.ver.outputs.version }}
-          dry_run: ${{ inputs.dry_run }}
 
       # ─────────────────────────────────────────
       # Python SDK Publishing
@@ -774,6 +946,8 @@ jobs:
         check-tags,
         build-python-wheels,
         publish-rust-crates,
+        publish-docker,
+        docker-manifests,
         publish,
       ]
     if: |
@@ -783,6 +957,8 @@ jobs:
       inputs.skip_tag_creation == false &&
       (needs.publish.result == 'success' || needs.publish.result == 'skipped') &&
       (needs.publish-rust-crates.result == 'success' || needs.publish-rust-crates.result == 'skipped') &&
+      (needs.publish-docker.result == 'success' || needs.publish-docker.result == 'skipped') &&
+      (needs.docker-manifests.result == 'success' || needs.docker-manifests.result == 'skipped') &&
       (needs.build-python-wheels.result == 'success' || needs.build-python-wheels.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
@@ -873,6 +1049,8 @@ jobs:
         check-tags,
         build-python-wheels,
         publish-rust-crates,
+        publish-docker,
+        docker-manifests,
         publish,
         create-tags,
       ]
@@ -1021,13 +1199,31 @@ jobs:
               echo
             fi
 
-            # Other publishing status
-            echo "### Other Publishing"
+            # Docker publishing status
+            if [ "${{ needs.plan.outputs.has_docker }}" = "true" ]; then
+              echo "### Docker Publishing (Native Runners)"
+              case "${{ needs.publish-docker.result }}" in
+                success)   echo "✅ **Docker images built and pushed successfully on native runners**" ;;
+                failure)   echo "❌ **Docker image publishing failed - check logs for details**" ;;
+                skipped)   echo "⏭️ **Docker publishing was skipped**" ;;
+              esac
+              echo
+              echo "### Docker Manifests"
+              case "${{ needs.docker-manifests.result }}" in
+                success)   echo "✅ **Multi-arch manifests created successfully**" ;;
+                failure)   echo "❌ **Manifest creation failed - check logs for details**" ;;
+                skipped)   echo "⏭️ **Manifest creation was skipped**" ;;
+              esac
+              echo
+            fi
+
+            # SDK publishing status
+            echo "### SDK Publishing"
             case "${{ needs.publish.result }}" in
-              success)   echo "✅ **Publishing completed successfully**" ;;
-              failure)   echo "❌ **Publishing failed - check logs for details**" ;;
-              cancelled) echo "🚫 **Publishing was cancelled**" ;;
-              *)         echo "⏭️ **Publishing was skipped**" ;;
+              success)   echo "✅ **SDK publishing completed successfully**" ;;
+              failure)   echo "❌ **SDK publishing failed - check logs for details**" ;;
+              cancelled) echo "🚫 **SDK publishing was cancelled**" ;;
+              *)         echo "⏭️ **SDK publishing was skipped**" ;;
             esac
             if [ "${{ inputs.dry_run }}" = "true" ]; then
               echo
@@ -1055,6 +1251,8 @@ jobs:
         plan,
         build-python-wheels,
         publish-rust-crates,
+        publish-docker,
+        docker-manifests,
         publish,
         create-tags,
         summary,

--- a/core/ai/mcp/Dockerfile
+++ b/core/ai/mcp/Dockerfile
@@ -33,7 +33,7 @@ ARG LIBC=musl
 ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
-RUN apk add --no-cache zig && \
+RUN apk add --no-cache zig make autoconf automake libtool pkgconfig && \
     cargo install cargo-zigbuild --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \
@@ -48,6 +48,7 @@ COPY --from=planner /app/recipe.json recipe.json
 #
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM}-${LIBC} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM}-${LIBC} \
+    --mount=type=cache,target=/app/target,id=cargo-target-${TARGETPLATFORM}-${LIBC} \
     case "$TARGETPLATFORM:$LIBC" in \
     "linux/amd64:musl") RUST_TARGET="x86_64-unknown-linux-musl" ;; \
     "linux/arm64:musl") RUST_TARGET="aarch64-unknown-linux-musl" ;; \
@@ -77,10 +78,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported platform/libc combination: $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-mcp && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-mcp && \
     cp /app/target/${RUST_TARGET}/debug/iggy-mcp /app/iggy-mcp; \
     else \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-mcp --release && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-mcp --release && \
     cp /app/target/${RUST_TARGET}/release/iggy-mcp /app/iggy-mcp; \
     fi
 

--- a/core/bench/dashboard/server/Dockerfile
+++ b/core/bench/dashboard/server/Dockerfile
@@ -31,6 +31,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl \
     curl \
     ca-certificates \
+    autoconf \
+    automake \
+    libtool \
     && rm -rf /var/lib/apt/lists/*
 
 # Install cargo-binstall

--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -29,11 +29,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM --platform=$BUILDPLATFORM chef AS builder
 ARG PROFILE=release
 ARG TARGETPLATFORM
-ARG LIBC=musl
+ARG LIBC=glibc
 ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
-RUN apk add --no-cache zig && \
+RUN apk add --no-cache zig make autoconf automake libtool pkgconfig && \
     cargo install cargo-zigbuild --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \
@@ -48,6 +48,7 @@ COPY --from=planner /app/recipe.json recipe.json
 #
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM}-${LIBC} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM}-${LIBC} \
+    --mount=type=cache,target=/app/target,id=cargo-target-${TARGETPLATFORM}-${LIBC} \
     case "$TARGETPLATFORM:$LIBC" in \
     "linux/amd64:musl") RUST_TARGET="x86_64-unknown-linux-musl" ;; \
     "linux/arm64:musl") RUST_TARGET="aarch64-unknown-linux-musl" ;; \
@@ -77,10 +78,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported platform/libc combination: $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-connectors && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-connectors && \
     cp /app/target/${RUST_TARGET}/debug/iggy-connectors /app/iggy-connectors; \
     else \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-connectors --release && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-connectors --release && \
     cp /app/target/${RUST_TARGET}/release/iggy-connectors /app/iggy-connectors; \
     fi
 

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -18,11 +18,10 @@
 ARG RUST_VERSION=1.92
 ARG ALPINE_VERSION=3.22
 
-# ── from-source path (unchanged) ──────────────────────────────────────────────
+# ── from-source path ─────────────────────────────────────────────────────────
 FROM --platform=$BUILDPLATFORM lukemathwalker/cargo-chef:latest-rust-${RUST_VERSION}-alpine AS chef
 WORKDIR /app
-#RUN apk add --no-cache musl-dev pkgconfig openssl-dev openssl-libs-static
-RUN apk add musl-dev
+RUN apk add --no-cache musl-dev pkgconfig
 
 FROM --platform=$BUILDPLATFORM chef AS planner
 COPY . .
@@ -35,7 +34,7 @@ ARG LIBC=musl
 ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
-RUN apk add --no-cache zig && \
+RUN apk add --no-cache zig make autoconf automake libtool pkgconfig && \
     cargo install cargo-zigbuild --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \
@@ -47,6 +46,7 @@ COPY --from=planner /app/recipe.json recipe.json
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARGETPLATFORM}-${LIBC} \
     --mount=type=cache,target=/usr/local/cargo/git,id=cargo-git-${TARGETPLATFORM}-${LIBC} \
+    --mount=type=cache,target=/app/target,id=cargo-target-${TARGETPLATFORM}-${LIBC} \
     case "$TARGETPLATFORM:$LIBC" in \
     "linux/amd64:musl")  RUST_TARGET="x86_64-unknown-linux-musl" ;; \
     "linux/arm64:musl")  RUST_TARGET="aarch64-unknown-linux-musl" ;; \
@@ -73,11 +73,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-server --bin iggy && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-server --bin iggy && \
     cp /app/target/${RUST_TARGET}/debug/iggy-server /app/iggy-server && \
     cp /app/target/${RUST_TARGET}/debug/iggy /app/iggy; \
     else \
-    cargo zigbuild --target ${RUST_TARGET} --bin iggy-server --bin iggy --release && \
+    cargo zigbuild --locked --target ${RUST_TARGET} --bin iggy-server --bin iggy --release && \
     cp /app/target/${RUST_TARGET}/release/iggy-server /app/iggy-server && \
     cp /app/target/${RUST_TARGET}/release/iggy /app/iggy; \
     fi


### PR DESCRIPTION
- Replace QEMU with native ubuntu-24.04-arm runners for arm64 builds
- Share compiled deps across components via apache/iggy:buildcache-{arch}
- Fix cache key collisions by adding runner.arch
- Fix double compilation by adding target cache mount to chef cook step
- Add hwloc build dependencies and --locked flag to Dockerfiles
- Split Docker into dedicated job, unblock SDK publishing
- Don't compile connectors runtime with musl