### PR TITLE
fix(ci): add xz-dev and xz-static to Alpine Docker builds for liblzma linking

### DIFF
--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -33,7 +33,7 @@ ARG LIBC=glibc
 ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
-RUN apk add --no-cache zig make autoconf automake libtool pkgconfig hwloc-dev && \
+RUN apk add --no-cache zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static && \
     cargo install cargo-zigbuild --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -34,7 +34,7 @@ ARG LIBC=musl
 ARG IGGY_CI_BUILD
 ENV IGGY_CI_BUILD=${IGGY_CI_BUILD}
 
-RUN apk add --no-cache zig make autoconf automake libtool pkgconfig hwloc-dev && \
+RUN apk add --no-cache zig make autoconf automake libtool pkgconfig hwloc-dev xz-dev xz-static && \
     cargo install cargo-zigbuild --locked && \
     rustup target add \
     x86_64-unknown-linux-musl \


### PR DESCRIPTION
The async_zip crate with lzma/xz features requires liblzma-sys
which needs the system liblzma.a static library. Alpine splits
static libraries into separate -static packages.
