### PR TITLE
feat(connectors): add --version flag support to connector runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4555,6 +4555,7 @@ dependencies = [
  "axum",
  "axum-server",
  "chrono",
+ "clap",
  "dashmap",
  "dlopen2",
  "dotenvy",

--- a/core/connectors/runtime/Cargo.toml
+++ b/core/connectors/runtime/Cargo.toml
@@ -33,6 +33,7 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 axum-server = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true }
 dashmap = { workspace = true }
 dlopen2 = { workspace = true }
 dotenvy = { workspace = true }

--- a/core/connectors/runtime/src/main.rs
+++ b/core/connectors/runtime/src/main.rs
@@ -18,6 +18,7 @@
  */
 
 use crate::configs::connectors::{ConnectorsConfigProvider, create_connectors_config_provider};
+use clap::Parser;
 use configs::connectors::ConfigFormat;
 use configs::runtime::ConnectorsRuntimeConfig;
 use dlopen2::wrapper::{Container, WrapperApi};
@@ -56,6 +57,10 @@ mod transform;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
+#[derive(Parser, Debug)]
+#[command(author = "Apache Iggy (Incubating)", version)]
+struct Args {}
+
 static PLUGIN_ID: AtomicU32 = AtomicU32::new(1);
 const ALLOWED_PLUGIN_EXTENSIONS: [&str; 3] = ["so", "dylib", "dll"];
 const DEFAULT_CONFIG_PATH: &str = "core/connectors/runtime/config.toml";
@@ -89,11 +94,16 @@ struct SinkApi {
     close: extern "C" fn(id: u32) -> i32,
 }
 
+fn print_ascii_art(text: &str) {
+    let standard_font = FIGfont::standard().unwrap();
+    let figure = standard_font.convert(text);
+    println!("{}", figure.unwrap());
+}
+
 #[tokio::main]
 async fn main() -> Result<(), RuntimeError> {
-    let standard_font = FIGfont::standard().unwrap();
-    let figure = standard_font.convert("Iggy Connectors");
-    println!("{}", figure.unwrap());
+    Args::parse();
+    print_ascii_art("Iggy Connectors");
 
     if let Ok(env_path) = std::env::var("IGGY_CONNECTORS_ENV_PATH") {
         if dotenvy::from_path(&env_path).is_ok() {

--- a/core/server/src/main.rs
+++ b/core/server/src/main.rs
@@ -101,6 +101,12 @@ fn extract_panic_message(payload: Box<dyn std::any::Any + Send>) -> String {
         .unwrap_or_else(|| "unknown panic".to_string())
 }
 
+fn print_ascii_art(text: &str) {
+    let standard_font = FIGfont::standard().unwrap();
+    let figure = standard_font.convert(text);
+    println!("{}", figure.unwrap());
+}
+
 #[instrument(skip_all, name = "trace_start_server")]
 fn main() -> Result<(), ServerError> {
     let rt = match compio::runtime::Runtime::new() {
@@ -115,14 +121,6 @@ fn main() -> Result<(), ServerError> {
         }
     };
     rt.block_on(async move {
-        let standard_font = FIGfont::standard().unwrap();
-        let figure = standard_font.convert("Iggy Server");
-        println!("{}", figure.unwrap());
-
-        if let Some(sha) = option_env!("VERGEN_GIT_SHA") {
-            println!("Commit SHA: {sha}");
-        }
-
         if let Ok(env_path) = std::env::var("IGGY_ENV_PATH") {
             if dotenvy::from_path(&env_path).is_ok() {
                 println!("Loaded environment variables from path: {env_path}");
@@ -134,6 +132,8 @@ fn main() -> Result<(), ServerError> {
             );
         }
         let args = Args::parse();
+        print_ascii_art("Iggy Server");
+
         let is_follower = args.follower;
 
         // FIRST DISCRETE LOADING STEP.


### PR DESCRIPTION
Extract print_ascii_art() in both server and connector runtime.
Add clap-based Args struct to connector runtime for consistent
version output via -V/--version flag.
