### PR TITLE
fix(server): improve shutdown handling for critical task failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3008,6 +3008,9 @@ name = "err_trail"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b9e8330eccf84d08fb8efe2f923ddacc9f02c1359edfc33cc0af4100caf764"
+dependencies = [
+ "tracing",
+]
 
 [[package]]
 name = "errno"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ dlopen2 = "0.8.2"
 dotenvy = "0.15.7"
 enum_dispatch = "0.3.13"
 env_logger = "0.11.8"
-err_trail = "0.10.2"
+err_trail = { version = "0.10.2", features = ["tracing"] }
 error_set = "0.9.1"
 figlet-rs = "0.1.5"
 figment = { version = "0.10.19", features = ["toml", "env"] }

--- a/core/integration/tests/streaming/mod.rs
+++ b/core/integration/tests/streaming/mod.rs
@@ -19,7 +19,7 @@
 use iggy_common::{CompressionAlgorithm, Identifier, IggyError, IggyExpiry, MaxTopicSize};
 use server::{
     configs::system::SystemConfig,
-    shard::task_registry::TaskRegistry,
+    shard::{task_registry::TaskRegistry, transmission::connector::ShardConnector},
     slab::{streams::Streams, traits_ext::EntityMarker},
     streaming::{
         self,
@@ -118,8 +118,9 @@ async fn bootstrap_test_environment(
         });
     }
 
-    // Create a test task registry
-    let task_registry = Rc::new(TaskRegistry::new(shard_id));
+    // Create a test task registry with dummy stop sender from ShardConnector
+    let connector: ShardConnector<()> = ShardConnector::new(shard_id);
+    let task_registry = Rc::new(TaskRegistry::new(shard_id, vec![connector.stop_sender]));
 
     Ok(BootstrapResult {
         streams,

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -181,10 +181,7 @@ impl IggyShard {
         // Spawn shutdown handler
         compio::runtime::spawn(async move {
             let _ = stop_receiver.recv().await;
-            let shutdown_success = shard_for_shutdown.trigger_shutdown().await;
-            if !shutdown_success {
-                error!("shutdown timed out");
-            }
+            shard_for_shutdown.trigger_shutdown().await;
             let _ = shutdown_complete_tx.send(()).await;
         })
         .detach();

--- a/core/server/src/shard/tasks/continuous/http_server.rs
+++ b/core/server/src/shard/tasks/continuous/http_server.rs
@@ -29,6 +29,7 @@ pub fn spawn_http_server(shard: Rc<IggyShard>) {
     shard
         .task_registry
         .continuous("http_server")
+        .critical(true)
         .run(move |shutdown| http_server(shard_clone, shutdown))
         .spawn();
 }


### PR DESCRIPTION
- Add broadcast shutdown to all shards when critical task fails or panics
- Mark HTTP server as critical task
- Config writer now respects shutdown token via futures::select!
- CORS parsing returns Result instead of panicking on invalid config
- Enable err_trail tracing feature for automatic error logging
- Wrap continuous tasks with catch_unwind for panic detection
