### PR TITLE
fix(connectors): read only TOML files from local config directory

### DIFF
--- a/core/connectors/runtime/src/configs/connectors/local_provider.rs
+++ b/core/connectors/runtime/src/configs/connectors/local_provider.rs
@@ -169,7 +169,6 @@ impl LocalConnectorsConfigProvider<Created> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_file() {
-
                 if path.extension().and_then(|ext| ext.to_str()) != Some("toml") {
                     debug!("Skipping non-TOML file: {:?}", path);
                     continue;


### PR DESCRIPTION
- This PR updates the local connectors config provider to only read `.toml` files from the configuration directory, which is the only supported format.
- Non-TOML files are now safely ignored to avoid parsing errors.
- Issue Ref: apache#2507
