### PR TITLE
fix(server): fix consumer group leave race and append_messages

### DIFF
--- a/core/server/src/shard/system/clients.rs
+++ b/core/server/src/shard/system/clients.rs
@@ -37,7 +37,7 @@ impl IggyShard {
         let consumer_groups: Vec<(u32, u32, u32)>;
 
         {
-            let client = self.client_manager.delete_client(client_id);
+            let client = self.client_manager.try_get_client(client_id);
             if client.is_none() {
                 error!("Client with ID: {client_id} was not found in the client manager.",);
                 return;
@@ -65,6 +65,7 @@ impl IggyShard {
                 client_id,
             )
         }
+        self.client_manager.delete_client(client_id);
     }
 
     pub fn get_client(

--- a/core/server/src/slab/streams.rs
+++ b/core/server/src/slab/streams.rs
@@ -1307,6 +1307,7 @@ impl Streams {
                         .clone(),
                 )
             });
+        let guard = messages_writer.lock.lock().await;
 
         let saved = messages_writer
             .as_ref()
@@ -1350,6 +1351,7 @@ impl Streams {
             streaming_partitions::helpers::update_index_and_increment_stats(saved, config),
         );
 
+        drop(guard);
         Ok(batch_count)
     }
 

--- a/core/server/src/streaming/segments/messages/messages_writer.rs
+++ b/core/server/src/streaming/segments/messages/messages_writer.rs
@@ -33,6 +33,7 @@ pub struct MessagesWriter {
     file: File,
     messages_size_bytes: Rc<AtomicU64>,
     fsync: bool,
+    pub lock: tokio::sync::Mutex<()>,
 }
 
 // Safety: We are guaranteeing that MessagesWriter will never be used from multiple threads
@@ -86,6 +87,7 @@ impl MessagesWriter {
             file,
             messages_size_bytes,
             fsync,
+            lock: tokio::sync::Mutex::new(()),
         })
     }
 


### PR DESCRIPTION
This PR fixes an race condition when client leaves consumer group, members collection was in inconsistent state, leading to panic on the `remove` method call. 

Additionally fixes an concurrency issue affecting `current_position` pointer in active segment, leading to incorrect indexes being written to disk. The scenario only happen in cases when every request `append_messages` from the client triggered commit of the journal and disk store.  