### PR TITLE
feat(java): implement Java SDK BDD tests with Cucumber

### DIFF
--- a/bdd/docker-compose.yml
+++ b/bdd/docker-compose.yml
@@ -262,6 +262,22 @@ services:
     networks:
       - iggy-bdd-network
 
+  java-bdd:
+    build:
+      context: ..
+      dockerfile: bdd/java/Dockerfile
+    depends_on:
+      iggy-server:
+        condition: service_healthy
+    environment:
+      - IGGY_ROOT_USERNAME=iggy
+      - IGGY_ROOT_PASSWORD=iggy
+      - IGGY_TCP_ADDRESS=iggy-server:8090
+    volumes:
+      - ./scenarios/basic_messaging.feature:/app/features/basic_messaging.feature
+    networks:
+      - iggy-bdd-network
+
 networks:
   iggy-bdd-network:
     driver: bridge

--- a/bdd/java/Dockerfile
+++ b/bdd/java/Dockerfile
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG RUST_VERSION=1.92
+FROM rust:${RUST_VERSION}
+
+FROM gradle:8.13-jdk17
+
+WORKDIR /workspace
+COPY . .
+
+WORKDIR /workspace/bdd/java
+RUN mkdir -p src/test/resources/features
+
+# Create entrypoint script to copy mounted features at runtime
+RUN echo '#!/bin/bash\n\
+set -e\n\
+if [ -d /app/features ]; then\n\
+  cp -f /app/features/*.feature /workspace/bdd/java/src/test/resources/features/ 2>/dev/null || true\n\
+fi\n\
+exec "$@"' > /entrypoint.sh && chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["gradle", "--no-daemon", "test"]

--- a/bdd/java/build.gradle.kts
+++ b/bdd/java/build.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+plugins {
+    java
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.apache.iggy:iggy")
+    testImplementation("io.cucumber:cucumber-java:7.20.1")
+    testImplementation("io.cucumber:cucumber-junit-platform-engine:7.20.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/bdd/java/settings.gradle.kts
+++ b/bdd/java/settings.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+rootProject.name = "iggy-bdd-java"
+
+includeBuild("../../foreign/java")

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/BasicMessagingSteps.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.bdd;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.iggy.client.blocking.IggyBaseClient;
+import org.apache.iggy.client.blocking.tcp.IggyTcpClient;
+import org.apache.iggy.message.Message;
+import org.apache.iggy.message.Partitioning;
+import org.apache.iggy.message.PollingStrategy;
+import org.apache.iggy.stream.StreamBase;
+import org.apache.iggy.stream.StreamDetails;
+import org.apache.iggy.topic.CompressionAlgorithm;
+import org.apache.iggy.topic.TopicDetails;
+
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class BasicMessagingSteps {
+
+    private final TestContext context = new TestContext();
+
+    @Given("I have a running Iggy server")
+    public void runningServer() {
+        context.serverAddr = getenvOrDefault("IGGY_TCP_ADDRESS", "127.0.0.1:8090");
+        HostPort hostPort = HostPort.parse(context.serverAddr);
+
+        IggyTcpClient client = IggyTcpClient.builder()
+                .host(hostPort.host)
+                .port(hostPort.port)
+                .build();
+
+        client.system().ping();
+        context.client = client;
+    }
+
+    @Given("I am authenticated as the root user")
+    public void authenticatedRootUser() {
+        String username = getenvOrDefault("IGGY_ROOT_USERNAME", "iggy");
+        String password = getenvOrDefault("IGGY_ROOT_PASSWORD", "iggy");
+        getClient().users().login(username, password);
+    }
+
+    @Given("I have no streams in the system")
+    public void noStreamsInSystem() {
+        List<StreamBase> streams = getClient().streams().getStreams();
+        assertTrue(streams.isEmpty(), "System should have no streams initially");
+    }
+
+    @When("I create a stream with name {string}")
+    public void createStream(String streamName) {
+        StreamDetails stream = getClient().streams().createStream(streamName);
+        context.lastStreamId = stream.id();
+        context.lastStreamName = stream.name();
+    }
+
+    @Then("the stream should be created successfully")
+    public void streamCreatedSuccessfully() {
+        assertNotNull(context.lastStreamId, "Stream should have been created");
+    }
+
+    @Then("the stream should have name {string}")
+    public void streamHasName(String streamName) {
+        assertEquals(streamName, context.lastStreamName, "Stream should have expected name");
+        Optional<StreamDetails> stream = getClient().streams().getStream(context.lastStreamId);
+        assertTrue(stream.isPresent(), "Stream should exist");
+        assertEquals(streamName, stream.get().name(), "Stream should have expected name");
+    }
+
+    @When("I create a topic with name {string} in stream {int} with {int} partitions")
+    public void createTopic(String topicName, int streamId, int partitions) {
+        TopicDetails topic = getClient().topics().createTopic(
+                (long) streamId,
+                (long) partitions,
+                CompressionAlgorithm.None,
+                BigInteger.ZERO,
+                BigInteger.ZERO,
+                Optional.empty(),
+                topicName);
+
+        context.lastTopicId = topic.id();
+        context.lastTopicName = topic.name();
+        context.lastTopicPartitions = topic.partitionsCount();
+    }
+
+    @Then("the topic should be created successfully")
+    public void topicCreatedSuccessfully() {
+        assertNotNull(context.lastTopicId, "Topic should have been created");
+    }
+
+    @Then("the topic should have name {string}")
+    public void topicHasName(String topicName) {
+        assertEquals(topicName, context.lastTopicName, "Topic should have expected name");
+    }
+
+    @Then("the topic should have {int} partitions")
+    public void topicHasPartitions(int partitions) {
+        assertEquals((long) partitions, context.lastTopicPartitions, "Topic should have expected partitions");
+    }
+
+    @When("I send {int} messages to stream {int}, topic {int}, partition {int}")
+    public void sendMessages(int messageCount, int streamId, int topicId, int partitionId) {
+        List<Message> messages = new ArrayList<>();
+        for (int i = 0; i < messageCount; i++) {
+            String content = "test message " + i;
+            messages.add(Message.of(content));
+        }
+
+        getClient().messages().sendMessages(
+                (long) streamId,
+                (long) topicId,
+                Partitioning.partitionId((long) partitionId),
+                messages);
+
+        if (!messages.isEmpty()) {
+            context.lastSentMessage = "test message " + (messageCount - 1);
+        }
+    }
+
+    @Then("all messages should be sent successfully")
+    public void messagesSentSuccessfully() {
+        assertNotNull(context.lastSentMessage, "Last sent message should be captured");
+    }
+
+    @When("I poll messages from stream {int}, topic {int}, partition {int} starting from offset {int}")
+    public void pollMessages(int streamId, int topicId, int partitionId, int startOffset) {
+        context.lastPolledMessages = getClient().messages().pollMessages(
+                (long) streamId,
+                (long) topicId,
+                Optional.of((long) partitionId),
+                0L,
+                PollingStrategy.offset(BigInteger.valueOf(startOffset)),
+                100L,
+                true);
+    }
+
+    @Then("I should receive {int} messages")
+    public void shouldReceiveMessages(int expectedCount) {
+        assertNotNull(context.lastPolledMessages, "Should have polled messages");
+        assertEquals(expectedCount, context.lastPolledMessages.messages().size(), "Message count should match");
+    }
+
+    @Then("the messages should have sequential offsets from {int} to {int}")
+    public void messagesHaveSequentialOffsets(int startOffset, int endOffset) {
+        assertNotNull(context.lastPolledMessages, "Should have polled messages");
+
+        var messages = context.lastPolledMessages.messages();
+        for (int i = 0; i < messages.size(); i++) {
+            BigInteger expectedOffset = BigInteger.valueOf(startOffset + i);
+            assertEquals(expectedOffset, messages.get(i).header().offset(), "Offsets should be sequential");
+        }
+
+        assertFalse(messages.isEmpty(), "Should have at least one message");
+        BigInteger lastOffset = messages.get(messages.size() - 1).header().offset();
+        assertEquals(BigInteger.valueOf(endOffset), lastOffset, "Last offset should match");
+    }
+
+    @Then("each message should have the expected payload content")
+    public void messagesHaveExpectedPayload() {
+        assertNotNull(context.lastPolledMessages, "Should have polled messages");
+
+        var messages = context.lastPolledMessages.messages();
+        for (int i = 0; i < messages.size(); i++) {
+            String expectedPayload = "test message " + i;
+            String actualPayload = new String(messages.get(i).payload(), StandardCharsets.UTF_8);
+            assertEquals(expectedPayload, actualPayload, "Payload should match expected content");
+        }
+    }
+
+    @Then("the last polled message should match the last sent message")
+    public void lastPolledMessageMatchesSent() {
+        assertNotNull(context.lastSentMessage, "Should have a sent message to compare");
+        assertNotNull(context.lastPolledMessages, "Should have polled messages");
+
+        var messages = context.lastPolledMessages.messages();
+        assertFalse(messages.isEmpty(), "Should have at least one polled message");
+
+        String lastPayload = new String(messages.get(messages.size() - 1).payload(), StandardCharsets.UTF_8);
+        assertEquals(context.lastSentMessage, lastPayload, "Last message should match sent message");
+    }
+
+    private IggyBaseClient getClient() {
+        if (context.client == null) {
+            throw new IllegalStateException("Iggy client not initialized");
+        }
+        return context.client;
+    }
+
+    private static String getenvOrDefault(String key, String defaultValue) {
+        String value = System.getenv(key);
+        return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private static final class HostPort {
+        private final String host;
+        private final int port;
+
+        private HostPort(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+        private static HostPort parse(String address) {
+            String[] parts = address.split(":", 2);
+            String host = parts.length > 0 ? parts[0] : "127.0.0.1";
+            int port = parts.length > 1 ? Integer.parseInt(parts[1]) : 8090;
+
+            try {
+                String resolved = InetAddress.getByName(host).getHostAddress();
+                host = resolved;
+            } catch (UnknownHostException ignored) {
+                // Fall back to provided host if resolution fails.
+            }
+
+            return new HostPort(host, port);
+        }
+    }
+}

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/RunCucumberTest.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/RunCucumberTest.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.bdd;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class RunCucumberTest {}

--- a/bdd/java/src/test/java/org/apache/iggy/bdd/TestContext.java
+++ b/bdd/java/src/test/java/org/apache/iggy/bdd/TestContext.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iggy.bdd;
+
+import org.apache.iggy.client.blocking.IggyBaseClient;
+import org.apache.iggy.message.PolledMessages;
+
+class TestContext {
+    IggyBaseClient client;
+    String serverAddr;
+    Long lastStreamId;
+    String lastStreamName;
+    Long lastTopicId;
+    String lastTopicName;
+    Long lastTopicPartitions;
+    PolledMessages lastPolledMessages;
+    String lastSentMessage;
+}

--- a/bdd/java/src/test/resources/cucumber.properties
+++ b/bdd/java/src/test/resources/cucumber.properties
@@ -1,0 +1,3 @@
+cucumber.features=classpath:features
+cucumber.glue=org.apache.iggy.bdd
+cucumber.plugin=pretty

--- a/scripts/run-bdd-tests.sh
+++ b/scripts/run-bdd-tests.sh
@@ -53,18 +53,20 @@ case "$SDK" in
   go)     run_suite go-bdd     "🐹"   "Running Go BDD tests"     ;;
   node)   run_suite node-bdd   "🐢🚀" "Running Node BDD tests"   ;;
   csharp) run_suite csharp-bdd "🔷"   "Running C# BDD tests"     ;;
+  java)   run_suite java-bdd   "☕"   "Running Java BDD tests"   ;;
   all)
     run_suite rust-bdd   "🦀"   "Running Rust BDD tests"   || exit $?
     run_suite python-bdd "🐍"   "Running Python BDD tests" || exit $?
     run_suite go-bdd     "🐹"   "Running Go BDD tests"     || exit $?
     run_suite node-bdd   "🐢🚀" "Running Node BDD tests"   || exit $?
     run_suite csharp-bdd "🔷"   "Running C# BDD tests"     || exit $?
+    run_suite java-bdd   "☕"   "Running Java BDD tests"   || exit $?
     ;;
   clean)
     cleanup; exit 0 ;;
   *)
     log "❌ Unknown SDK: ${SDK}"
-    log "📖 Usage: $0 [rust|python|go|node|csharp|all|clean] [feature_file]"
+    log "📖 Usage: $0 [rust|python|go|node|csharp|java|all|clean] [feature_file]"
     exit 2 ;;
 esac
 


### PR DESCRIPTION
Following patterns from Python/Go/Rust BDD implementations:

- Add Cucumber-based BDD test implementation for Java SDK
- Create step definitions for basic messaging scenarios
- Add Java support to run-bdd-tests.sh script
