### PR TITLE
fix(server): handle entity ID gaps on bootstrap after deletions

### DIFF
--- a/core/server/src/shard/system/consumer_offsets.rs
+++ b/core/server/src/shard/system/consumer_offsets.rs
@@ -200,7 +200,15 @@ impl IggyShard {
         partition_ids: &[usize],
     ) -> Result<(), IggyError> {
         for &partition_id in partition_ids {
-            // Skip if offset does not exist.
+            // Skip if partition was deleted
+            let partition_exists = self
+                .streams
+                .with_partitions(stream_id, topic_id, |p| p.exists(partition_id));
+            if !partition_exists {
+                continue;
+            }
+
+            // Skip if offset does not exist
             let has_offset = self
                 .streams
                 .with_partition_by_id(

--- a/core/server/src/slab/consumer_groups.rs
+++ b/core/server/src/slab/consumer_groups.rs
@@ -171,3 +171,30 @@ impl Default for ConsumerGroups {
         }
     }
 }
+
+impl ConsumerGroups {
+    /// Construct from pre-built entries with specific IDs.
+    pub fn from_entries(
+        entries: impl IntoIterator<Item = (usize, consumer_group::ConsumerGroup)>,
+    ) -> Self {
+        let entries: Vec<_> = entries.into_iter().collect();
+
+        let mut index = AHashMap::with_capacity(entries.len());
+        let mut root_entries = Vec::with_capacity(entries.len());
+        let mut members_entries = Vec::with_capacity(entries.len());
+
+        for (id, cg) in entries {
+            let (mut root, members) = cg.into_components();
+            root.update_id(id);
+            index.insert(root.key().clone(), id);
+            root_entries.push((id, root));
+            members_entries.push((id, members));
+        }
+
+        Self {
+            index,
+            root: root_entries.into_iter().collect(),
+            members: members_entries.into_iter().collect(),
+        }
+    }
+}

--- a/core/server/src/slab/partitions.rs
+++ b/core/server/src/slab/partitions.rs
@@ -209,6 +209,44 @@ impl Default for Partitions {
 }
 
 impl Partitions {
+    /// Construct from pre-built entries with specific IDs.
+    pub fn from_entries(entries: impl IntoIterator<Item = (usize, partition::Partition)>) -> Self {
+        let entries: Vec<_> = entries.into_iter().collect();
+
+        let mut root_entries = Vec::with_capacity(entries.len());
+        let mut stats_entries = Vec::with_capacity(entries.len());
+        let mut dedup_entries = Vec::with_capacity(entries.len());
+        let mut offset_entries = Vec::with_capacity(entries.len());
+        let mut consumer_offset_entries = Vec::with_capacity(entries.len());
+        let mut consumer_group_offset_entries = Vec::with_capacity(entries.len());
+        let mut log_entries = Vec::with_capacity(entries.len());
+
+        for (id, partition) in entries {
+            let (mut root, stats, dedup, offset, consumer_offset, consumer_group_offset, log) =
+                partition.into_components();
+            root.update_id(id);
+            root_entries.push((id, root));
+            stats_entries.push((id, stats));
+            dedup_entries.push((id, dedup));
+            offset_entries.push((id, offset));
+            consumer_offset_entries.push((id, consumer_offset));
+            consumer_group_offset_entries.push((id, consumer_group_offset));
+            log_entries.push((id, log));
+        }
+
+        Self {
+            root: root_entries.into_iter().collect(),
+            stats: stats_entries.into_iter().collect(),
+            message_deduplicator: dedup_entries.into_iter().collect(),
+            offset: offset_entries.into_iter().collect(),
+            consumer_offset: consumer_offset_entries.into_iter().collect(),
+            consumer_group_offset: consumer_group_offset_entries.into_iter().collect(),
+            log: log_entries.into_iter().collect(),
+        }
+    }
+}
+
+impl Partitions {
     pub fn len(&self) -> usize {
         self.root.len()
     }

--- a/core/server/src/slab/streams.rs
+++ b/core/server/src/slab/streams.rs
@@ -86,6 +86,31 @@ impl Default for Streams {
     }
 }
 
+impl Streams {
+    /// Construct from pre-built entries with specific IDs.
+    pub fn from_entries(entries: impl IntoIterator<Item = (usize, stream::Stream)>) -> Self {
+        let entries: Vec<_> = entries.into_iter().collect();
+
+        let mut index = AHashMap::with_capacity(entries.len());
+        let mut root_entries = Vec::with_capacity(entries.len());
+        let mut stats_entries = Vec::with_capacity(entries.len());
+
+        for (id, stream) in entries {
+            let (mut root, stats) = stream.into_components();
+            root.update_id(id);
+            index.insert(root.key().clone(), id);
+            root_entries.push((id, root));
+            stats_entries.push((id, stats));
+        }
+
+        Self {
+            index: RefCell::new(index),
+            root: RefCell::new(root_entries.into_iter().collect()),
+            stats: RefCell::new(stats_entries.into_iter().collect()),
+        }
+    }
+}
+
 impl<'a> From<&'a Streams> for stream::StreamRef<'a> {
     fn from(value: &'a Streams) -> Self {
         let root = value.root.borrow();

--- a/core/server/src/slab/topics.rs
+++ b/core/server/src/slab/topics.rs
@@ -137,6 +137,34 @@ impl Default for Topics {
     }
 }
 
+impl Topics {
+    /// Construct from pre-built entries with specific IDs.
+    pub fn from_entries(entries: impl IntoIterator<Item = (usize, topic::Topic)>) -> Self {
+        let entries: Vec<_> = entries.into_iter().collect();
+
+        let mut index = AHashMap::with_capacity(entries.len());
+        let mut root_entries = Vec::with_capacity(entries.len());
+        let mut auxilary_entries = Vec::with_capacity(entries.len());
+        let mut stats_entries = Vec::with_capacity(entries.len());
+
+        for (id, topic) in entries {
+            let (mut root, auxilary, stats) = topic.into_components();
+            root.update_id(id);
+            index.insert(root.key().clone(), id);
+            root_entries.push((id, root));
+            auxilary_entries.push((id, auxilary));
+            stats_entries.push((id, stats));
+        }
+
+        Self {
+            index: RefCell::new(index),
+            root: RefCell::new(root_entries.into_iter().collect()),
+            auxilaries: RefCell::new(auxilary_entries.into_iter().collect()),
+            stats: RefCell::new(stats_entries.into_iter().collect()),
+        }
+    }
+}
+
 impl EntityComponentSystem<InteriorMutability> for Topics {
     type Idx = ContainerId;
     type Entity = topic::Topic;

--- a/core/server/src/streaming/streams/stream.rs
+++ b/core/server/src/streaming/streams/stream.rs
@@ -90,6 +90,10 @@ impl StreamRoot {
         &mut self.topics
     }
 
+    pub fn set_topics(&mut self, topics: Topics) {
+        self.topics = topics;
+    }
+
     pub fn created_at(&self) -> IggyTimestamp {
         self.created_at
     }

--- a/core/server/src/streaming/topics/topic.rs
+++ b/core/server/src/streaming/topics/topic.rs
@@ -328,6 +328,14 @@ impl TopicRoot {
         &mut self.consumer_groups
     }
 
+    pub fn set_partitions(&mut self, partitions: Partitions) {
+        self.partitions = partitions;
+    }
+
+    pub fn set_consumer_groups(&mut self, consumer_groups: ConsumerGroups) {
+        self.consumer_groups = consumer_groups;
+    }
+
     pub fn created_at(&self) -> IggyTimestamp {
         self.created_at
     }


### PR DESCRIPTION
Server panicked on restart when streams, topics, partitions, or consumer
groups had been deleted, creating gaps in ID sequences.

The issue: `slab.insert()` auto-assigns sequential IDs (0, 1, 2...),
but after deletions the state file contains non-sequential IDs (e.g.,
{0, 2} after deleting ID 1). On restart, bootstrap called `insert()`
which returned sequential IDs, causing assertion failures when the
assigned ID didn't match the expected ID from state.

The fix uses `Slab::from_iter()` via new `from_entries()` constructors
on Streams, Topics, Partitions, and ConsumerGroups. This correctly
places entities at their original keys regardless of gaps.