### PR TITLE
refactor(server): add type-safe auth with proof-carrying code pattern

### DIFF
--- a/core/server/src/binary/command.rs
+++ b/core/server/src/binary/command.rs
@@ -18,9 +18,9 @@
 
 use crate::define_server_command_enum;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use bytes::{BufMut, Bytes, BytesMut};
-use enum_dispatch::enum_dispatch;
 use iggy_common::SenderKind;
 use iggy_common::change_password::ChangePassword;
 use iggy_common::create_consumer_group::CreateConsumerGroup;
@@ -72,70 +72,83 @@ use strum::EnumString;
 use tracing::error;
 
 define_server_command_enum! {
-    Ping(Ping), PING_CODE, PING, false;
-    GetStats(GetStats), GET_STATS_CODE, GET_STATS, false;
-    GetMe(GetMe), GET_ME_CODE, GET_ME, false;
-    GetClient(GetClient), GET_CLIENT_CODE, GET_CLIENT, true;
-    GetClients(GetClients), GET_CLIENTS_CODE, GET_CLIENTS, false;
-    GetSnapshot(GetSnapshot), GET_SNAPSHOT_FILE_CODE, GET_SNAPSHOT_FILE, false;
-    GetClusterMetadata(GetClusterMetadata), GET_CLUSTER_METADATA_CODE, GET_CLUSTER_METADATA, false;
-    PollMessages(PollMessages), POLL_MESSAGES_CODE, POLL_MESSAGES, true;
-    FlushUnsavedBuffer(FlushUnsavedBuffer), FLUSH_UNSAVED_BUFFER_CODE, FLUSH_UNSAVED_BUFFER, true;
-    GetUser(GetUser), GET_USER_CODE, GET_USER, true;
-    GetUsers(GetUsers), GET_USERS_CODE, GET_USERS, false;
-    CreateUser(CreateUser), CREATE_USER_CODE, CREATE_USER, true;
-    DeleteUser(DeleteUser), DELETE_USER_CODE, DELETE_USER, true;
-    UpdateUser(UpdateUser), UPDATE_USER_CODE, UPDATE_USER, true;
-    UpdatePermissions(UpdatePermissions), UPDATE_PERMISSIONS_CODE, UPDATE_PERMISSIONS, true;
-    ChangePassword(ChangePassword), CHANGE_PASSWORD_CODE, CHANGE_PASSWORD, true;
-    LoginUser(LoginUser), LOGIN_USER_CODE, LOGIN_USER, true;
-    LogoutUser(LogoutUser), LOGOUT_USER_CODE, LOGOUT_USER, false;
-    GetPersonalAccessTokens(GetPersonalAccessTokens), GET_PERSONAL_ACCESS_TOKENS_CODE, GET_PERSONAL_ACCESS_TOKENS, false;
-    CreatePersonalAccessToken(CreatePersonalAccessToken), CREATE_PERSONAL_ACCESS_TOKEN_CODE, CREATE_PERSONAL_ACCESS_TOKEN, true;
-    DeletePersonalAccessToken(DeletePersonalAccessToken), DELETE_PERSONAL_ACCESS_TOKEN_CODE, DELETE_PERSONAL_ACCESS_TOKEN, false;
-    LoginWithPersonalAccessToken(LoginWithPersonalAccessToken), LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, LOGIN_WITH_PERSONAL_ACCESS_TOKEN, true;
-    SendMessages(SendMessages), SEND_MESSAGES_CODE, SEND_MESSAGES, false;
-    GetConsumerOffset(GetConsumerOffset), GET_CONSUMER_OFFSET_CODE, GET_CONSUMER_OFFSET, true;
-    StoreConsumerOffset(StoreConsumerOffset), STORE_CONSUMER_OFFSET_CODE, STORE_CONSUMER_OFFSET, true;
-    DeleteConsumerOffset(DeleteConsumerOffset), DELETE_CONSUMER_OFFSET_CODE, DELETE_CONSUMER_OFFSET, true;
-    GetStream(GetStream), GET_STREAM_CODE, GET_STREAM, true;
-    GetStreams(GetStreams), GET_STREAMS_CODE, GET_STREAMS, false;
-    CreateStream(CreateStream), CREATE_STREAM_CODE, CREATE_STREAM, true;
-    DeleteStream(DeleteStream), DELETE_STREAM_CODE, DELETE_STREAM, true;
-    UpdateStream(UpdateStream), UPDATE_STREAM_CODE, UPDATE_STREAM, true;
-    PurgeStream(PurgeStream), PURGE_STREAM_CODE, PURGE_STREAM, true;
-    GetTopic(GetTopic), GET_TOPIC_CODE, GET_TOPIC, true;
-    GetTopics(GetTopics), GET_TOPICS_CODE, GET_TOPICS, false;
-    CreateTopic(CreateTopic), CREATE_TOPIC_CODE, CREATE_TOPIC, true;
-    DeleteTopic(DeleteTopic), DELETE_TOPIC_CODE, DELETE_TOPIC, true;
-    UpdateTopic(UpdateTopic), UPDATE_TOPIC_CODE, UPDATE_TOPIC, true;
-    PurgeTopic(PurgeTopic), PURGE_TOPIC_CODE, PURGE_TOPIC, true;
-    CreatePartitions(CreatePartitions), CREATE_PARTITIONS_CODE, CREATE_PARTITIONS, true;
-    DeletePartitions(DeletePartitions), DELETE_PARTITIONS_CODE, DELETE_PARTITIONS, true;
-    DeleteSegments(DeleteSegments), DELETE_SEGMENTS_CODE, DELETE_SEGMENTS, true;
-    GetConsumerGroup(GetConsumerGroup), GET_CONSUMER_GROUP_CODE, GET_CONSUMER_GROUP, true;
-    GetConsumerGroups(GetConsumerGroups), GET_CONSUMER_GROUPS_CODE, GET_CONSUMER_GROUPS, false;
-    CreateConsumerGroup(CreateConsumerGroup), CREATE_CONSUMER_GROUP_CODE, CREATE_CONSUMER_GROUP, true;
-    DeleteConsumerGroup(DeleteConsumerGroup), DELETE_CONSUMER_GROUP_CODE, DELETE_CONSUMER_GROUP, true;
-    JoinConsumerGroup(JoinConsumerGroup), JOIN_CONSUMER_GROUP_CODE, JOIN_CONSUMER_GROUP, true;
-    LeaveConsumerGroup(LeaveConsumerGroup), LEAVE_CONSUMER_GROUP_CODE, LEAVE_CONSUMER_GROUP, true;
+    @unauth {
+        Ping(Ping), PING_CODE, PING, false;
+        LoginUser(LoginUser), LOGIN_USER_CODE, LOGIN_USER, true;
+        LoginWithPersonalAccessToken(LoginWithPersonalAccessToken), LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE, LOGIN_WITH_PERSONAL_ACCESS_TOKEN, true;
+    }
+    @auth {
+        GetStats(GetStats), GET_STATS_CODE, GET_STATS, false;
+        GetMe(GetMe), GET_ME_CODE, GET_ME, false;
+        GetClient(GetClient), GET_CLIENT_CODE, GET_CLIENT, true;
+        GetClients(GetClients), GET_CLIENTS_CODE, GET_CLIENTS, false;
+        GetSnapshot(GetSnapshot), GET_SNAPSHOT_FILE_CODE, GET_SNAPSHOT_FILE, false;
+        GetClusterMetadata(GetClusterMetadata), GET_CLUSTER_METADATA_CODE, GET_CLUSTER_METADATA, false;
+        PollMessages(PollMessages), POLL_MESSAGES_CODE, POLL_MESSAGES, true;
+        FlushUnsavedBuffer(FlushUnsavedBuffer), FLUSH_UNSAVED_BUFFER_CODE, FLUSH_UNSAVED_BUFFER, true;
+        GetUser(GetUser), GET_USER_CODE, GET_USER, true;
+        GetUsers(GetUsers), GET_USERS_CODE, GET_USERS, false;
+        CreateUser(CreateUser), CREATE_USER_CODE, CREATE_USER, true;
+        DeleteUser(DeleteUser), DELETE_USER_CODE, DELETE_USER, true;
+        UpdateUser(UpdateUser), UPDATE_USER_CODE, UPDATE_USER, true;
+        UpdatePermissions(UpdatePermissions), UPDATE_PERMISSIONS_CODE, UPDATE_PERMISSIONS, true;
+        ChangePassword(ChangePassword), CHANGE_PASSWORD_CODE, CHANGE_PASSWORD, true;
+        LogoutUser(LogoutUser), LOGOUT_USER_CODE, LOGOUT_USER, false;
+        GetPersonalAccessTokens(GetPersonalAccessTokens), GET_PERSONAL_ACCESS_TOKENS_CODE, GET_PERSONAL_ACCESS_TOKENS, false;
+        CreatePersonalAccessToken(CreatePersonalAccessToken), CREATE_PERSONAL_ACCESS_TOKEN_CODE, CREATE_PERSONAL_ACCESS_TOKEN, true;
+        DeletePersonalAccessToken(DeletePersonalAccessToken), DELETE_PERSONAL_ACCESS_TOKEN_CODE, DELETE_PERSONAL_ACCESS_TOKEN, false;
+        SendMessages(SendMessages), SEND_MESSAGES_CODE, SEND_MESSAGES, false;
+        GetConsumerOffset(GetConsumerOffset), GET_CONSUMER_OFFSET_CODE, GET_CONSUMER_OFFSET, true;
+        StoreConsumerOffset(StoreConsumerOffset), STORE_CONSUMER_OFFSET_CODE, STORE_CONSUMER_OFFSET, true;
+        DeleteConsumerOffset(DeleteConsumerOffset), DELETE_CONSUMER_OFFSET_CODE, DELETE_CONSUMER_OFFSET, true;
+        GetStream(GetStream), GET_STREAM_CODE, GET_STREAM, true;
+        GetStreams(GetStreams), GET_STREAMS_CODE, GET_STREAMS, false;
+        CreateStream(CreateStream), CREATE_STREAM_CODE, CREATE_STREAM, true;
+        DeleteStream(DeleteStream), DELETE_STREAM_CODE, DELETE_STREAM, true;
+        UpdateStream(UpdateStream), UPDATE_STREAM_CODE, UPDATE_STREAM, true;
+        PurgeStream(PurgeStream), PURGE_STREAM_CODE, PURGE_STREAM, true;
+        GetTopic(GetTopic), GET_TOPIC_CODE, GET_TOPIC, true;
+        GetTopics(GetTopics), GET_TOPICS_CODE, GET_TOPICS, false;
+        CreateTopic(CreateTopic), CREATE_TOPIC_CODE, CREATE_TOPIC, true;
+        DeleteTopic(DeleteTopic), DELETE_TOPIC_CODE, DELETE_TOPIC, true;
+        UpdateTopic(UpdateTopic), UPDATE_TOPIC_CODE, UPDATE_TOPIC, true;
+        PurgeTopic(PurgeTopic), PURGE_TOPIC_CODE, PURGE_TOPIC, true;
+        CreatePartitions(CreatePartitions), CREATE_PARTITIONS_CODE, CREATE_PARTITIONS, true;
+        DeletePartitions(DeletePartitions), DELETE_PARTITIONS_CODE, DELETE_PARTITIONS, true;
+        DeleteSegments(DeleteSegments), DELETE_SEGMENTS_CODE, DELETE_SEGMENTS, true;
+        GetConsumerGroup(GetConsumerGroup), GET_CONSUMER_GROUP_CODE, GET_CONSUMER_GROUP, true;
+        GetConsumerGroups(GetConsumerGroups), GET_CONSUMER_GROUPS_CODE, GET_CONSUMER_GROUPS, false;
+        CreateConsumerGroup(CreateConsumerGroup), CREATE_CONSUMER_GROUP_CODE, CREATE_CONSUMER_GROUP, true;
+        DeleteConsumerGroup(DeleteConsumerGroup), DELETE_CONSUMER_GROUP_CODE, DELETE_CONSUMER_GROUP, true;
+        JoinConsumerGroup(JoinConsumerGroup), JOIN_CONSUMER_GROUP_CODE, JOIN_CONSUMER_GROUP, true;
+        LeaveConsumerGroup(LeaveConsumerGroup), LEAVE_CONSUMER_GROUP_CODE, LEAVE_CONSUMER_GROUP, true;
+    }
 }
 
-/// Indicates whether a command handler completed normally or migrated the connection.
 pub enum HandlerResult {
-    /// Command completed, connection stays on current shard.
     Finished,
-
-    /// Connection was migrated to another shard. Source shard should exit without cleanup.
     Migrated { to_shard: u16 },
 }
 
-#[enum_dispatch]
-pub trait ServerCommandHandler {
-    /// Return the command code
+/// Handler for commands requiring authentication - receives [`Auth`] proof token.
+pub trait AuthenticatedHandler {
     fn code(&self) -> u32;
 
-    /// Handle the command execution
+    #[allow(async_fn_in_trait)]
+    async fn handle(
+        self,
+        sender: &mut SenderKind,
+        length: u32,
+        auth: Auth,
+        session: &Session,
+        shard: &Rc<IggyShard>,
+    ) -> Result<HandlerResult, IggyError>;
+}
+
+/// Handler for commands not requiring authentication (Ping, LoginUser, LoginWithPersonalAccessToken).
+pub trait UnauthenticatedHandler {
+    fn code(&self) -> u32;
+
     #[allow(async_fn_in_trait)]
     async fn handle(
         self,
@@ -147,7 +160,6 @@ pub trait ServerCommandHandler {
 }
 
 pub trait BinaryServerCommand {
-    /// Parse command from sender
     #[allow(async_fn_in_trait)]
     async fn from_sender(
         sender: &mut SenderKind,

--- a/core/server/src/binary/handlers/cluster/get_cluster_metadata_handler.rs
+++ b/core/server/src/binary/handlers/cluster/get_cluster_metadata_handler.rs
@@ -19,27 +19,28 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 //use crate::streaming::systems::system::SharedSystem;
-use anyhow::Result;
 use iggy_common::get_cluster_metadata::GetClusterMetadata;
 use iggy_common::{BytesSerializable, IggyError, SenderKind};
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for GetClusterMetadata {
+impl AuthenticatedHandler for GetClusterMetadata {
     fn code(&self) -> u32 {
         iggy_common::GET_CLUSTER_METADATA_CODE
     }
 
-    #[instrument(skip_all, name = "trace_get_cluster_metadata", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_get_cluster_metadata", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/consumer_groups/join_consumer_group_handler.rs
+++ b/core/server/src/binary/handlers/consumer_groups/join_consumer_group_handler.rs
@@ -17,30 +17,30 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::consumer_groups::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::join_consumer_group::JoinConsumerGroup;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for JoinConsumerGroup {
+impl AuthenticatedHandler for JoinConsumerGroup {
     fn code(&self) -> u32 {
         iggy_common::JOIN_CONSUMER_GROUP_CODE
     }
 
-    #[instrument(skip_all, name = "trace_join_consumer_group", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string(), iggy_group_id = self.group_id.as_string()))]
+    #[instrument(skip_all, name = "trace_join_consumer_group", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string(), iggy_group_id = self.group_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/consumer_groups/leave_consumer_group_handler.rs
+++ b/core/server/src/binary/handlers/consumer_groups/leave_consumer_group_handler.rs
@@ -18,30 +18,30 @@
 
 use super::COMPONENT;
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
-use iggy_common::SenderKind;
-
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
+use iggy_common::SenderKind;
 use iggy_common::leave_consumer_group::LeaveConsumerGroup;
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for LeaveConsumerGroup {
+impl AuthenticatedHandler for LeaveConsumerGroup {
     fn code(&self) -> u32 {
         iggy_common::LEAVE_CONSUMER_GROUP_CODE
     }
 
-    #[instrument(skip_all, name = "trace_leave_consumer_group", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string(), iggy_group_id = self.group_id.as_string()))]
+    #[instrument(skip_all, name = "trace_leave_consumer_group", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string(), iggy_group_id = self.group_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/consumer_offsets/delete_consumer_offset_handler.rs
+++ b/core/server/src/binary/handlers/consumer_offsets/delete_consumer_offset_handler.rs
@@ -17,20 +17,20 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::consumer_offsets::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::delete_consumer_offset::DeleteConsumerOffset;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for DeleteConsumerOffset {
+impl AuthenticatedHandler for DeleteConsumerOffset {
     fn code(&self) -> u32 {
         iggy_common::DELETE_CONSUMER_OFFSET_CODE
     }
@@ -39,6 +39,7 @@ impl ServerCommandHandler for DeleteConsumerOffset {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/consumer_offsets/get_consumer_offset_handler.rs
+++ b/core/server/src/binary/handlers/consumer_offsets/get_consumer_offset_handler.rs
@@ -17,20 +17,20 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use iggy_common::IggyError;
 use iggy_common::SenderKind;
 use iggy_common::get_consumer_offset::GetConsumerOffset;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetConsumerOffset {
+impl AuthenticatedHandler for GetConsumerOffset {
     fn code(&self) -> u32 {
         iggy_common::GET_CONSUMER_OFFSET_CODE
     }
@@ -39,6 +39,7 @@ impl ServerCommandHandler for GetConsumerOffset {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/consumer_offsets/store_consumer_offset_handler.rs
+++ b/core/server/src/binary/handlers/consumer_offsets/store_consumer_offset_handler.rs
@@ -19,20 +19,20 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::consumer_offsets::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
 use iggy_common::SenderKind;
 use iggy_common::store_consumer_offset::StoreConsumerOffset;
 use tracing::debug;
 
-impl ServerCommandHandler for StoreConsumerOffset {
+impl AuthenticatedHandler for StoreConsumerOffset {
     fn code(&self) -> u32 {
         iggy_common::STORE_CONSUMER_OFFSET_CODE
     }
@@ -41,6 +41,7 @@ impl ServerCommandHandler for StoreConsumerOffset {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/partitions/create_partitions_handler.rs
+++ b/core/server/src/binary/handlers/partitions/create_partitions_handler.rs
@@ -17,34 +17,34 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::partitions::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::slab::traits_ext::EntityMarker;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use crate::streaming::{streams, topics};
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::create_partitions::CreatePartitions;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for CreatePartitions {
+impl AuthenticatedHandler for CreatePartitions {
     fn code(&self) -> u32 {
         iggy_common::CREATE_PARTITIONS_CODE
     }
 
-    #[instrument(skip_all, name = "trace_create_partitions", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
+    #[instrument(skip_all, name = "trace_create_partitions", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -86,7 +86,7 @@ impl ServerCommandHandler for CreatePartitions {
         shard
         .state
         .apply(
-            session.get_user_id(),
+            auth.user_id(),
             &EntryCommand::CreatePartitions(self),
         )
         .await

--- a/core/server/src/binary/handlers/partitions/delete_partitions_handler.rs
+++ b/core/server/src/binary/handlers/partitions/delete_partitions_handler.rs
@@ -17,32 +17,32 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::partitions::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::delete_partitions::DeletePartitions;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for DeletePartitions {
+impl AuthenticatedHandler for DeletePartitions {
     fn code(&self) -> u32 {
         iggy_common::DELETE_PARTITIONS_CODE
     }
 
-    #[instrument(skip_all, name = "trace_delete_partitions", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
+    #[instrument(skip_all, name = "trace_delete_partitions", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -83,7 +83,7 @@ impl ServerCommandHandler for DeletePartitions {
         shard
         .state
         .apply(
-            session.get_user_id(),
+            auth.user_id(),
             &EntryCommand::DeletePartitions(self),
         )
         .await

--- a/core/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
+++ b/core/server/src/binary/handlers/personal_access_tokens/create_personal_access_token_handler.rs
@@ -17,34 +17,34 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::personal_access_tokens::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
 use crate::state::models::CreatePersonalAccessTokenWithHash;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::create_personal_access_token::CreatePersonalAccessToken;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for CreatePersonalAccessToken {
+impl AuthenticatedHandler for CreatePersonalAccessToken {
     fn code(&self) -> u32 {
         iggy_common::CREATE_PERSONAL_ACCESS_TOKEN_CODE
     }
 
-    #[instrument(skip_all, name = "trace_create_personal_access_token", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_create_personal_access_token", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -68,7 +68,7 @@ impl ServerCommandHandler for CreatePersonalAccessToken {
         shard
             .state
             .apply(
-                session.get_user_id(),
+                auth.user_id(),
                 &EntryCommand::CreatePersonalAccessToken(CreatePersonalAccessTokenWithHash {
                     command: CreatePersonalAccessToken {
                         name: self.name.to_owned(),

--- a/core/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
+++ b/core/server/src/binary/handlers/personal_access_tokens/delete_personal_access_token_handler.rs
@@ -17,30 +17,31 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::personal_access_tokens::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::delete_personal_access_token::DeletePersonalAccessToken;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for DeletePersonalAccessToken {
+impl AuthenticatedHandler for DeletePersonalAccessToken {
     fn code(&self) -> u32 {
         iggy_common::DELETE_PERSONAL_ACCESS_TOKEN_CODE
     }
 
-    #[instrument(skip_all, name = "trace_delete_personal_access_token", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_delete_personal_access_token", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -55,7 +56,7 @@ impl ServerCommandHandler for DeletePersonalAccessToken {
 
         // Broadcast the event to other shards
         let event = crate::shard::transmission::event::ShardEvent::DeletedPersonalAccessToken {
-            user_id: session.get_user_id(),
+            user_id: auth.user_id(),
             name: self.name.clone(),
         };
         shard.broadcast_event_to_all_shards(event).await?;
@@ -63,7 +64,7 @@ impl ServerCommandHandler for DeletePersonalAccessToken {
         shard
             .state
             .apply(
-                session.get_user_id(),
+                auth.user_id(),
                 &EntryCommand::DeletePersonalAccessToken(DeletePersonalAccessToken {
                     name: self.name,
                 }),

--- a/core/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
+++ b/core/server/src/binary/handlers/personal_access_tokens/get_personal_access_tokens_handler.rs
@@ -17,12 +17,13 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::personal_access_tokens::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
@@ -31,7 +32,7 @@ use iggy_common::get_personal_access_tokens::GetPersonalAccessTokens;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetPersonalAccessTokens {
+impl AuthenticatedHandler for GetPersonalAccessTokens {
     fn code(&self) -> u32 {
         iggy_common::GET_PERSONAL_ACCESS_TOKENS_CODE
     }
@@ -40,6 +41,7 @@ impl ServerCommandHandler for GetPersonalAccessTokens {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
+++ b/core/server/src/binary/handlers/personal_access_tokens/login_with_personal_access_token_handler.rs
@@ -19,19 +19,18 @@ use crate::shard::IggyShard;
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    BinaryServerCommand, HandlerResult, ServerCommand, UnauthenticatedHandler,
 };
 use crate::binary::handlers::personal_access_tokens::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::login_with_personal_access_token::LoginWithPersonalAccessToken;
 use iggy_common::{IggyError, SenderKind};
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for LoginWithPersonalAccessToken {
+impl UnauthenticatedHandler for LoginWithPersonalAccessToken {
     fn code(&self) -> u32 {
         iggy_common::LOGIN_WITH_PERSONAL_ACCESS_TOKEN_CODE
     }

--- a/core/server/src/binary/handlers/streams/update_stream_handler.rs
+++ b/core/server/src/binary/handlers/streams/update_stream_handler.rs
@@ -17,32 +17,32 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::streams::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::update_stream::UpdateStream;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for UpdateStream {
+impl AuthenticatedHandler for UpdateStream {
     fn code(&self) -> u32 {
         iggy_common::UPDATE_STREAM_CODE
     }
 
-    #[instrument(skip_all, name = "trace_update_stream", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string()))]
+    #[instrument(skip_all, name = "trace_update_stream", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -61,7 +61,7 @@ impl ServerCommandHandler for UpdateStream {
         shard.broadcast_event_to_all_shards(event).await?;
         shard
             .state
-            .apply(session.get_user_id(), &EntryCommand::UpdateStream(self))
+            .apply(auth.user_id(), &EntryCommand::UpdateStream(self))
             .await
             .error(|e: &IggyError| {
                 format!("{COMPONENT} (error: {e}) - failed to apply update stream with id: {stream_id}, session: {session}")

--- a/core/server/src/binary/handlers/system/get_client_handler.rs
+++ b/core/server/src/binary/handlers/system/get_client_handler.rs
@@ -17,11 +17,12 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use iggy_common::IggyError;
 use iggy_common::SenderKind;
@@ -29,7 +30,7 @@ use iggy_common::get_client::GetClient;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetClient {
+impl AuthenticatedHandler for GetClient {
     fn code(&self) -> u32 {
         iggy_common::GET_CLIENT_CODE
     }
@@ -38,6 +39,7 @@ impl ServerCommandHandler for GetClient {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/system/get_clients_handler.rs
+++ b/core/server/src/binary/handlers/system/get_clients_handler.rs
@@ -17,12 +17,13 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::system::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
@@ -31,7 +32,7 @@ use iggy_common::get_clients::GetClients;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetClients {
+impl AuthenticatedHandler for GetClients {
     fn code(&self) -> u32 {
         iggy_common::GET_CLIENTS_CODE
     }
@@ -40,6 +41,7 @@ impl ServerCommandHandler for GetClients {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/system/get_me_handler.rs
+++ b/core/server/src/binary/handlers/system/get_me_handler.rs
@@ -17,12 +17,13 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::system::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
@@ -30,7 +31,7 @@ use iggy_common::SenderKind;
 use iggy_common::get_me::GetMe;
 use std::rc::Rc;
 
-impl ServerCommandHandler for GetMe {
+impl AuthenticatedHandler for GetMe {
     fn code(&self) -> u32 {
         iggy_common::GET_ME_CODE
     }
@@ -39,6 +40,7 @@ impl ServerCommandHandler for GetMe {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/system/get_snapshot.rs
+++ b/core/server/src/binary/handlers/system/get_snapshot.rs
@@ -17,10 +17,11 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use bytes::Bytes;
 use iggy_common::IggyError;
@@ -29,7 +30,7 @@ use iggy_common::get_snapshot::GetSnapshot;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetSnapshot {
+impl AuthenticatedHandler for GetSnapshot {
     fn code(&self) -> u32 {
         iggy_common::GET_SNAPSHOT_FILE_CODE
     }
@@ -38,6 +39,7 @@ impl ServerCommandHandler for GetSnapshot {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/system/get_stats_handler.rs
+++ b/core/server/src/binary/handlers/system/get_stats_handler.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::system::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
@@ -27,6 +27,7 @@ use crate::shard::transmission::frame::ShardResponse;
 use crate::shard::transmission::message::{
     ShardMessage, ShardRequest, ShardRequestPayload, ShardSendRequestResult,
 };
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use err_trail::ErrContext;
 use iggy_common::SenderKind;
@@ -35,7 +36,7 @@ use iggy_common::{Identifier, IggyError};
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetStats {
+impl AuthenticatedHandler for GetStats {
     fn code(&self) -> u32 {
         iggy_common::GET_STATS_CODE
     }
@@ -44,6 +45,7 @@ impl ServerCommandHandler for GetStats {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -55,7 +57,7 @@ impl ServerCommandHandler for GetStats {
             topic_id: Identifier::default(),
             partition_id: 0,
             payload: ShardRequestPayload::GetStats {
-                user_id: session.get_user_id(),
+                user_id: auth.user_id(),
             },
         };
 

--- a/core/server/src/binary/handlers/system/ping_handler.rs
+++ b/core/server/src/binary/handlers/system/ping_handler.rs
@@ -16,10 +16,9 @@
  * under the License.
  */
 
-use crate::binary::command::{BinaryServerCommand, HandlerResult, ServerCommandHandler};
+use crate::binary::command::{BinaryServerCommand, HandlerResult, UnauthenticatedHandler};
 use crate::shard::IggyShard;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use iggy_common::IggyError;
 use iggy_common::IggyTimestamp;
 use iggy_common::SenderKind;
@@ -27,7 +26,7 @@ use iggy_common::ping::Ping;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for Ping {
+impl UnauthenticatedHandler for Ping {
     fn code(&self) -> u32 {
         iggy_common::PING_CODE
     }

--- a/core/server/src/binary/handlers/topics/get_topics_handler.rs
+++ b/core/server/src/binary/handlers/topics/get_topics_handler.rs
@@ -17,22 +17,22 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
 use crate::slab::traits_ext::{EntityComponentSystem, IntoComponents};
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use crate::streaming::streams;
-use anyhow::Result;
 use iggy_common::IggyError;
 use iggy_common::SenderKind;
 use iggy_common::get_topics::GetTopics;
 use std::rc::Rc;
 use tracing::debug;
 
-impl ServerCommandHandler for GetTopics {
+impl AuthenticatedHandler for GetTopics {
     fn code(&self) -> u32 {
         iggy_common::GET_TOPICS_CODE
     }
@@ -41,11 +41,11 @@ impl ServerCommandHandler for GetTopics {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
         debug!("session: {session}, command: {self}");
-        shard.ensure_authenticated(session)?;
         shard.ensure_stream_exists(&self.stream_id)?;
         let numeric_stream_id = shard
             .streams
@@ -53,7 +53,7 @@ impl ServerCommandHandler for GetTopics {
         shard
             .permissioner
             .borrow()
-            .get_topics(session.get_user_id(), numeric_stream_id)?;
+            .get_topics(auth.user_id(), numeric_stream_id)?;
 
         let response = shard.streams.with_topics(&self.stream_id, |topics| {
             topics.with_components(|topics| {

--- a/core/server/src/binary/handlers/topics/purge_topic_handler.rs
+++ b/core/server/src/binary/handlers/topics/purge_topic_handler.rs
@@ -17,30 +17,31 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::topics::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::shard::IggyShard;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::purge_topic::PurgeTopic;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for PurgeTopic {
+impl AuthenticatedHandler for PurgeTopic {
     fn code(&self) -> u32 {
         iggy_common::PURGE_TOPIC_CODE
     }
 
-    #[instrument(skip_all, name = "trace_purge_topic", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
+    #[instrument(skip_all, name = "trace_purge_topic", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id, iggy_stream_id = self.stream_id.as_string(), iggy_topic_id = self.topic_id.as_string()))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -66,7 +67,7 @@ impl ServerCommandHandler for PurgeTopic {
 
         shard
             .state
-            .apply(session.get_user_id(), &EntryCommand::PurgeTopic(self))
+            .apply(auth.user_id(), &EntryCommand::PurgeTopic(self))
             .await
             .error(|e: &IggyError| {
                 format!(

--- a/core/server/src/binary/handlers/users/create_user_handler.rs
+++ b/core/server/src/binary/handlers/users/create_user_handler.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::users::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
@@ -30,9 +30,9 @@ use crate::shard::transmission::message::{
 };
 use crate::state::command::EntryCommand;
 use crate::state::models::CreateUserWithId;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use crate::streaming::utils::crypto;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::create_user::CreateUser;
 use iggy_common::{Identifier, IggyError, SenderKind};
@@ -40,16 +40,17 @@ use std::rc::Rc;
 use tracing::debug;
 use tracing::instrument;
 
-impl ServerCommandHandler for CreateUser {
+impl AuthenticatedHandler for CreateUser {
     fn code(&self) -> u32 {
         iggy_common::CREATE_USER_CODE
     }
 
-    #[instrument(skip_all, name = "trace_create_user", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_create_user", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -60,7 +61,7 @@ impl ServerCommandHandler for CreateUser {
             topic_id: Identifier::default(),
             partition_id: 0,
             payload: ShardRequestPayload::CreateUser {
-                user_id: session.get_user_id(),
+                user_id: auth.user_id(),
                 username: self.username.clone(),
                 password: self.password.clone(),
                 status: self.status,
@@ -106,7 +107,7 @@ impl ServerCommandHandler for CreateUser {
                     shard
                         .state
                         .apply(
-                            session.get_user_id(),
+                            auth.user_id(),
                             &EntryCommand::CreateUser(CreateUserWithId {
                                 user_id,
                                 command: CreateUser {
@@ -140,7 +141,7 @@ impl ServerCommandHandler for CreateUser {
                     shard
                         .state
                         .apply(
-                            session.get_user_id(),
+                            auth.user_id(),
                             &EntryCommand::CreateUser(CreateUserWithId {
                                 user_id,
                                 command: CreateUser {

--- a/core/server/src/binary/handlers/users/delete_user_handler.rs
+++ b/core/server/src/binary/handlers/users/delete_user_handler.rs
@@ -19,11 +19,10 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::users::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::shard::transmission::frame::ShardResponse;
@@ -31,24 +30,25 @@ use crate::shard::transmission::message::{
     ShardMessage, ShardRequest, ShardRequestPayload, ShardSendRequestResult,
 };
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::delete_user::DeleteUser;
 use iggy_common::{Identifier, IggyError, SenderKind};
 use tracing::info;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for DeleteUser {
+impl AuthenticatedHandler for DeleteUser {
     fn code(&self) -> u32 {
         iggy_common::DELETE_USER_CODE
     }
 
-    #[instrument(skip_all, name = "trace_delete_user", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_delete_user", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -59,7 +59,7 @@ impl ServerCommandHandler for DeleteUser {
             topic_id: Identifier::default(),
             partition_id: 0,
             payload: ShardRequestPayload::DeleteUser {
-                session_user_id: session.get_user_id(),
+                session_user_id: auth.user_id(),
                 user_id: self.user_id,
             },
         };

--- a/core/server/src/binary/handlers/users/get_user_handler.rs
+++ b/core/server/src/binary/handlers/users/get_user_handler.rs
@@ -19,18 +19,19 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use iggy_common::IggyError;
 use iggy_common::SenderKind;
 use iggy_common::get_user::GetUser;
 use tracing::debug;
 
-impl ServerCommandHandler for GetUser {
+impl AuthenticatedHandler for GetUser {
     fn code(&self) -> u32 {
         iggy_common::GET_USER_CODE
     }
@@ -39,6 +40,7 @@ impl ServerCommandHandler for GetUser {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/users/get_users_handler.rs
+++ b/core/server/src/binary/handlers/users/get_users_handler.rs
@@ -19,12 +19,13 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::users::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
 use err_trail::ErrContext;
 use iggy_common::IggyError;
@@ -32,7 +33,7 @@ use iggy_common::SenderKind;
 use iggy_common::get_users::GetUsers;
 use tracing::debug;
 
-impl ServerCommandHandler for GetUsers {
+impl AuthenticatedHandler for GetUsers {
     fn code(&self) -> u32 {
         iggy_common::GET_USERS_CODE
     }
@@ -41,6 +42,7 @@ impl ServerCommandHandler for GetUsers {
         self,
         sender: &mut SenderKind,
         _length: u32,
+        _auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {

--- a/core/server/src/binary/handlers/users/login_user_handler.rs
+++ b/core/server/src/binary/handlers/users/login_user_handler.rs
@@ -17,21 +17,20 @@
  */
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    BinaryServerCommand, HandlerResult, ServerCommand, UnauthenticatedHandler,
 };
 use crate::binary::handlers::users::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
 use crate::binary::mapper;
 use crate::shard::IggyShard;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::login_user::LoginUser;
 use iggy_common::{IggyError, SenderKind};
 use std::rc::Rc;
 use tracing::{debug, info, instrument, warn};
 
-impl ServerCommandHandler for LoginUser {
+impl UnauthenticatedHandler for LoginUser {
     fn code(&self) -> u32 {
         iggy_common::LOGIN_USER_CODE
     }

--- a/core/server/src/binary/handlers/users/update_permissions_handler.rs
+++ b/core/server/src/binary/handlers/users/update_permissions_handler.rs
@@ -19,32 +19,32 @@
 use std::rc::Rc;
 
 use crate::binary::command::{
-    BinaryServerCommand, HandlerResult, ServerCommand, ServerCommandHandler,
+    AuthenticatedHandler, BinaryServerCommand, HandlerResult, ServerCommand,
 };
 use crate::binary::handlers::users::COMPONENT;
 use crate::binary::handlers::utils::receive_and_validate;
-
 use crate::shard::IggyShard;
 use crate::shard::transmission::event::ShardEvent;
 use crate::state::command::EntryCommand;
+use crate::streaming::auth::Auth;
 use crate::streaming::session::Session;
-use anyhow::Result;
 use err_trail::ErrContext;
 use iggy_common::update_permissions::UpdatePermissions;
 use iggy_common::{IggyError, SenderKind};
 use tracing::info;
 use tracing::{debug, instrument};
 
-impl ServerCommandHandler for UpdatePermissions {
+impl AuthenticatedHandler for UpdatePermissions {
     fn code(&self) -> u32 {
         iggy_common::UPDATE_PERMISSIONS_CODE
     }
 
-    #[instrument(skip_all, name = "trace_update_permissions", fields(iggy_user_id = session.get_user_id(), iggy_client_id = session.client_id))]
+    #[instrument(skip_all, name = "trace_update_permissions", fields(iggy_user_id = auth.user_id(), iggy_client_id = session.client_id))]
     async fn handle(
         self,
         sender: &mut SenderKind,
         _length: u32,
+        auth: Auth,
         session: &Session,
         shard: &Rc<IggyShard>,
     ) -> Result<HandlerResult, IggyError> {
@@ -64,10 +64,7 @@ impl ServerCommandHandler for UpdatePermissions {
 
         shard
             .state
-            .apply(
-                session.get_user_id(),
-                &EntryCommand::UpdatePermissions(self),
-            )
+            .apply(auth.user_id(), &EntryCommand::UpdatePermissions(self))
             .await?;
         sender.send_empty_ok_response().await?;
         Ok(HandlerResult::Finished)

--- a/core/server/src/quic/listener.rs
+++ b/core/server/src/quic/listener.rs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-use crate::binary::command::{ServerCommand, ServerCommandHandler};
+use crate::binary::command::ServerCommand;
 use crate::server_error::ConnectionError;
 use crate::shard::IggyShard;
 use crate::shard::task_registry::ShutdownToken;
@@ -187,7 +187,7 @@ async fn handle_stream(
 
     trace!("Received a QUIC command: {command}, payload size: {length}");
 
-    match command.handle(&mut sender, length, session, &shard).await {
+    match command.dispatch(&mut sender, length, session, &shard).await {
         Ok(_) => {
             trace!(
                 "Command was handled successfully, session: {:?}. QUIC response was sent.",

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -295,4 +295,18 @@ impl IggyShard {
             Err(IggyError::Unauthenticated)
         }
     }
+
+    pub fn auth(&self, session: &Session) -> Result<crate::streaming::auth::Auth, IggyError> {
+        if !session.is_active() {
+            error!("{COMPONENT} - session is inactive, session: {session}");
+            return Err(IggyError::StaleClient);
+        }
+
+        if !session.is_authenticated() {
+            error!("{COMPONENT} - unauthenticated access attempt, session: {session}");
+            return Err(IggyError::Unauthenticated);
+        }
+
+        Ok(crate::streaming::auth::Auth::new(session.get_user_id()))
+    }
 }

--- a/core/server/src/streaming/auth.rs
+++ b/core/server/src/streaming/auth.rs
@@ -1,0 +1,80 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//! Type-safe authentication proof system using proof-carrying code pattern.
+//!
+//! The [`Auth`] type can only be constructed via [`IggyShard::auth()`],
+//! ensuring any code holding an `Auth` value has passed authentication.
+
+use iggy_common::UserId;
+
+/// Proof of successful authentication.
+///
+/// # Invariants
+/// - `user_id` is always valid (never `u32::MAX`)
+/// - User was authenticated at construction time
+#[derive(Clone, Copy, Debug)]
+pub struct Auth {
+    user_id: UserId,
+    // Private field prevents external construction - only `Auth::new()` can create this.
+    _sealed: (),
+}
+
+impl Auth {
+    /// Only call after verifying user is authenticated.
+    #[inline]
+    pub(crate) fn new(user_id: UserId) -> Self {
+        debug_assert!(user_id != u32::MAX, "Auth created with invalid user_id");
+        Self {
+            user_id,
+            _sealed: (),
+        }
+    }
+
+    #[inline]
+    pub fn user_id(&self) -> UserId {
+        self.user_id
+    }
+}
+
+/// Sealed marker trait for authentication requirements.
+pub trait AuthRequirement: private::Sealed {
+    const NAME: &'static str;
+}
+
+/// Command requires authentication - handler receives [`Auth`] proof token.
+pub struct Authenticated;
+
+impl AuthRequirement for Authenticated {
+    const NAME: &'static str = "Authenticated";
+}
+
+impl private::Sealed for Authenticated {}
+
+/// Command does NOT require authentication (Ping, LoginUser, LoginWithPersonalAccessToken).
+pub struct Unauthenticated;
+
+impl AuthRequirement for Unauthenticated {
+    const NAME: &'static str = "Unauthenticated";
+}
+
+impl private::Sealed for Unauthenticated {}
+
+mod private {
+    pub trait Sealed {}
+}

--- a/core/server/src/streaming/mod.rs
+++ b/core/server/src/streaming/mod.rs
@@ -16,6 +16,7 @@
  * under the License.
  */
 
+pub mod auth;
 pub mod clients;
 pub mod deduplication;
 pub mod diagnostics;

--- a/core/server/src/tcp/connection_handler.rs
+++ b/core/server/src/tcp/connection_handler.rs
@@ -17,7 +17,6 @@
  */
 
 use crate::binary::command;
-use crate::binary::command::ServerCommandHandler;
 use crate::server_error::ConnectionError;
 use crate::shard::IggyShard;
 use crate::streaming::session::Session;
@@ -91,7 +90,7 @@ pub(crate) async fn handle_connection(
         let command = ServerCommand::from_code_and_reader(code, sender, length - 4).await?;
         debug!("Received a TCP command: {command}, payload size: {length}");
         let cmd_code = command.code();
-        match command.handle(sender, length, session, shard).await {
+        match command.dispatch(sender, length, session, shard).await {
             Ok(handler_result) => match handler_result {
                 command::HandlerResult::Finished => {
                     debug!(

--- a/core/server/src/websocket/connection_handler.rs
+++ b/core/server/src/websocket/connection_handler.rs
@@ -17,7 +17,6 @@
  */
 
 use crate::binary::command;
-use crate::binary::command::ServerCommandHandler;
 use crate::server_error::ConnectionError;
 use crate::shard::IggyShard;
 use crate::streaming::session::Session;
@@ -81,7 +80,7 @@ pub(crate) async fn handle_connection(
         let command = ServerCommand::from_code_and_reader(code, sender, length - 4).await?;
         debug!("Received a WebSocket command: {command}, payload size: {length}");
 
-        match command.handle(sender, length, session, shard).await {
+        match command.dispatch(sender, length, session, shard).await {
             Ok(_) => {
                 debug!(
                     "Command was handled successfully, session: {session}. WebSocket response was sent."


### PR DESCRIPTION
Introduce Auth proof type that can only be created via IggyShard::auth(), providing compile-time guarantees for handler authentication.