### PR TITLE
perf(ci): use opt-level=2, optimize sccache usage

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -103,14 +103,35 @@ runs:
     - name: Build and test
       if: inputs.task == 'test'
       run: |
-        # Build all targets first
+        build_start=$(date +%s)
         cargo build --locked --all-targets
+        build_end=$(date +%s)
+        build_duration=$((build_end - build_start))
+        echo "::notice::Build completed in ${build_duration}s ($(date -ud @${build_duration} +'%M:%S'))"
 
-        # Use nextest if available, otherwise use cargo test
+        test_start=$(date +%s)
         if command -v cargo-nextest &> /dev/null; then
           cargo nextest run --locked --no-fail-fast
         else
           cargo test --locked --no-fail-fast
+        fi
+        test_end=$(date +%s)
+        test_duration=$((test_end - test_start))
+        echo "::notice::Tests completed in ${test_duration}s ($(date -ud @${test_duration} +'%M:%S'))"
+
+        echo ""
+        echo "========================================="
+        echo "Build time: ${build_duration}s ($(date -ud @${build_duration} +'%M:%S'))"
+        echo "Test time:  ${test_duration}s ($(date -ud @${test_duration} +'%M:%S'))"
+        echo "Total time: $((build_duration + test_duration))s ($(date -ud @$((build_duration + test_duration)) +'%M:%S'))"
+        echo "========================================="
+
+        if command -v sccache &> /dev/null; then
+          echo ""
+          echo "========================================="
+          echo "sccache statistics:"
+          echo "========================================="
+          sccache --show-stats
         fi
       shell: bash
 

--- a/.github/actions/utils/setup-rust-with-cache/action.yml
+++ b/.github/actions/utils/setup-rust-with-cache/action.yml
@@ -69,9 +69,8 @@ runs:
           ~/.cache/sccache
           ~/Library/Caches/sccache
           ~/.local/share/sccache
-        key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+        key: sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
         restore-keys: |
-          sccache-${{ runner.os }}-${{ runner.arch }}-${{ github.job }}-
           sccache-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Install sccache
@@ -80,24 +79,44 @@ runs:
         # Check if sccache is already installed
         if ! command -v sccache &> /dev/null; then
           echo "Installing sccache..."
-          SCCACHE_VERSION="v0.8.2"
+          SCCACHE_VERSION="v0.13.0"
 
-          # Detect architecture
+          # Detect OS and architecture
+          OS="$(uname -s)"
           ARCH="$(uname -m)"
-          case "$ARCH" in
-            x86_64)  SCCACHE_ARCH="x86_64-unknown-linux-musl" ;;
-            aarch64) SCCACHE_ARCH="aarch64-unknown-linux-musl" ;;
-            *)
-              echo "⚠️ Unsupported architecture: $ARCH, skipping sccache"
-              exit 0
-              ;;
-          esac
+
+          if [[ "$OS" == "Linux" ]]; then
+            case "$ARCH" in
+              x86_64)  SCCACHE_ARCH="x86_64-unknown-linux-musl" ;;
+              aarch64) SCCACHE_ARCH="aarch64-unknown-linux-musl" ;;
+              *)
+                echo "⚠️ Unsupported Linux architecture: $ARCH, skipping sccache"
+                exit 0
+                ;;
+            esac
+          elif [[ "$OS" == "Darwin" ]]; then
+            case "$ARCH" in
+              x86_64) SCCACHE_ARCH="x86_64-apple-darwin" ;;
+              arm64)  SCCACHE_ARCH="aarch64-apple-darwin" ;;
+              *)
+                echo "⚠️ Unsupported macOS architecture: $ARCH, skipping sccache"
+                exit 0
+                ;;
+            esac
+          else
+            echo "⚠️ Unsupported OS: $OS, skipping sccache"
+            exit 0
+          fi
 
           SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}.tar.gz"
-          echo "Downloading sccache for $SCCACHE_ARCH..."
+          echo "Downloading sccache $SCCACHE_VERSION for $SCCACHE_ARCH..."
 
           curl -L "$SCCACHE_URL" | tar xz
-          sudo mv "sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" /usr/local/bin/
+          if [[ "$OS" == "Darwin" ]]; then
+            mv "sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" /usr/local/bin/
+          else
+            sudo mv "sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}/sccache" /usr/local/bin/
+          fi
           rm -rf "sccache-${SCCACHE_VERSION}-${SCCACHE_ARCH}"
         fi
       shell: bash
@@ -141,13 +160,23 @@ runs:
           mkdir -p "$SCCACHE_DIR"
 
           echo "SCCACHE_DIR=$SCCACHE_DIR" >> $GITHUB_ENV
-          echo "SCCACHE_CACHE_SIZE=2G" >> $GITHUB_ENV
+          echo "SCCACHE_CACHE_SIZE=5G" >> $GITHUB_ENV
           echo "SCCACHE_ERROR_BEHAVIOR=warn" >> $GITHUB_ENV
           echo "SCCACHE_IGNORE_SERVER_IO_ERROR=1" >> $GITHUB_ENV
 
           # Don't use GHA cache backend - use local disk cache with actions/cache
           # This provides better control and persistence
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
+          # Disable incremental compilation - not useful in CI with sccache
+          echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
+
+          # Disable debug info in dev/test builds - faster compilation, smaller cache
+          echo "CARGO_PROFILE_DEV_DEBUG=0" >> $GITHUB_ENV
+          echo "CARGO_PROFILE_TEST_DEBUG=0" >> $GITHUB_ENV
+
+          # Use sparse registry protocol for faster dependency resolution
+          echo "CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse" >> $GITHUB_ENV
 
           # Start sccache server
           sccache --stop-server 2>/dev/null || true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,3 +215,6 @@ zip = "7.0.0"
 [profile.release]
 lto = true
 codegen-units = 1
+
+[profile.dev]
+opt-level = 2


### PR DESCRIPTION
Incremental compilation and debug symbols don't cache well
with sccache since they produce build-specific artifacts.
Disabling them ensures consistent cache keys across CI runs.

Sharing cache across jobs (instead of per-job isolation)
reduces the 10GB GitHub cache pressure from potentially many
separate caches to one shared pool. Added build/test timing
and sccache stats to track cache effectiveness over time.

Dev profile now uses opt-level=2 so spawned test binaries run faster.