### PR TITLE
fix(server): maintain message availability during async disk I/O

### DIFF
--- a/core/common/src/types/message/messages_batch.rs
+++ b/core/common/src/types/message/messages_batch.rs
@@ -75,8 +75,18 @@ impl IggyMessagesBatch {
         &self.messages
     }
 
+    /// Get the messages as a cloned `Bytes` (cheap Arc increment).
+    pub fn messages_bytes(&self) -> Bytes {
+        self.messages.clone()
+    }
+
     /// Get the indexes slice
     pub fn indexes_slice(&self) -> &[u8] {
+        &self.indexes
+    }
+
+    /// Get a reference to the indexes
+    pub fn indexes(&self) -> &IggyIndexes {
         &self.indexes
     }
 

--- a/core/common/src/types/message/polled_messages.rs
+++ b/core/common/src/types/message/polled_messages.rs
@@ -111,12 +111,16 @@ fn messages_from_bytes_and_count(buffer: Bytes, count: u32) -> Result<Vec<IggyMe
         let payload = buffer.slice(position..payload_end);
         position = payload_end;
 
+        let user_headers_end = position + header.user_headers_length as usize;
+        if user_headers_end > buf_len {
+            break;
+        }
         let user_headers = if header.user_headers_length > 0 {
-            Some(buffer.slice(position..position + header.user_headers_length as usize))
+            Some(buffer.slice(position..user_headers_end))
         } else {
             None
         };
-        position += header.user_headers_length as usize;
+        position = user_headers_end;
 
         messages.push(IggyMessage {
             header,

--- a/core/integration/tests/server/scenarios/mod.rs
+++ b/core/integration/tests/server/scenarios/mod.rs
@@ -30,6 +30,7 @@ pub mod delete_segments_scenario;
 pub mod encryption_scenario;
 pub mod message_headers_scenario;
 pub mod message_size_scenario;
+pub mod read_during_persistence_scenario;
 pub mod stale_client_consumer_group_scenario;
 pub mod stream_size_validation_scenario;
 pub mod system_scenario;

--- a/core/integration/tests/server/scenarios/read_during_persistence_scenario.rs
+++ b/core/integration/tests/server/scenarios/read_during_persistence_scenario.rs
@@ -1,0 +1,195 @@
+/* Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+use bytes::Bytes;
+use iggy::prelude::*;
+use integration::{
+    tcp_client::TcpClientFactory,
+    test_server::{ClientFactory, IpAddrKind, SYSTEM_PATH_ENV_VAR, TestServer, login_root},
+};
+use serial_test::parallel;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+const STREAM_NAME: &str = "eventual-consistency-stream";
+const TOPIC_NAME: &str = "eventual-consistency-topic";
+const TEST_DURATION_SECS: u64 = 10;
+
+/// Test with two separate clients - one for sending, one for polling.
+///
+/// This should expose the race condition where messages are in-flight during
+/// disk write and unavailable for polling.
+#[tokio::test]
+#[parallel]
+async fn should_read_messages_immediately_after_send_with_aggressive_persistence() {
+    let env_vars = HashMap::from([
+        (
+            SYSTEM_PATH_ENV_VAR.to_owned(),
+            TestServer::get_random_path(),
+        ),
+        (
+            "IGGY_SYSTEM_PARTITION_MESSAGES_REQUIRED_TO_SAVE".to_owned(),
+            "32".to_owned(),
+        ),
+        (
+            "IGGY_SYSTEM_PARTITION_SIZE_OF_MESSAGES_REQUIRED_TO_SAVE".to_owned(),
+            "512B".to_owned(),
+        ),
+        (
+            "IGGY_SYSTEM_PARTITION_ENFORCE_FSYNC".to_owned(),
+            "false".to_owned(),
+        ),
+    ]);
+
+    let mut test_server = TestServer::new(Some(env_vars), true, None, IpAddrKind::V4);
+    test_server.start();
+    let server_addr = test_server.get_raw_tcp_addr().unwrap();
+
+    let producer_client = TcpClientFactory {
+        server_addr: server_addr.clone(),
+        ..Default::default()
+    }
+    .create_client()
+    .await;
+    let producer = IggyClient::create(producer_client, None, None);
+    login_root(&producer).await;
+
+    producer.create_stream(STREAM_NAME).await.unwrap();
+    producer
+        .create_topic(
+            &Identifier::named(STREAM_NAME).unwrap(),
+            TOPIC_NAME,
+            1,
+            CompressionAlgorithm::default(),
+            None,
+            IggyExpiry::NeverExpire,
+            MaxTopicSize::ServerDefault,
+        )
+        .await
+        .unwrap();
+
+    let consumer_client = TcpClientFactory {
+        server_addr,
+        ..Default::default()
+    }
+    .create_client()
+    .await;
+    let consumer = IggyClient::create(consumer_client, None, None);
+    login_root(&consumer).await;
+
+    let stream_id = Identifier::named(STREAM_NAME).unwrap();
+    let topic_id = Identifier::named(TOPIC_NAME).unwrap();
+    let consumer_kind = Consumer::default();
+
+    let test_duration = Duration::from_secs(TEST_DURATION_SECS);
+    let messages_per_batch = 32u32;
+    let payload = "X".repeat(1024);
+
+    let start = Instant::now();
+    let mut batches_sent = 0u64;
+    let mut messages_sent = 0u64;
+
+    println!(
+        "Starting test: 1KB messages, {} msgs/batch, duration: {}s",
+        messages_per_batch, TEST_DURATION_SECS
+    );
+
+    while start.elapsed() < test_duration {
+        let base_offset = batches_sent * messages_per_batch as u64;
+
+        let mut messages: Vec<IggyMessage> = (0..messages_per_batch)
+            .map(|i| {
+                IggyMessage::builder()
+                    .id((base_offset + i as u64 + 1) as u128)
+                    .payload(Bytes::from(format!(
+                        "{} - batch {} msg {}",
+                        payload, batches_sent, i
+                    )))
+                    .build()
+                    .expect("Failed to create message")
+            })
+            .collect();
+
+        println!("Sending batch {}", batches_sent);
+        let send_result = producer
+            .send_messages(
+                &stream_id,
+                &topic_id,
+                &Partitioning::partition_id(0),
+                &mut messages,
+            )
+            .await;
+        match &send_result {
+            Ok(_) => println!("Batch {} sent successfully", batches_sent),
+            Err(e) => println!("Batch {} send error: {:?}", batches_sent, e),
+        }
+        send_result.unwrap();
+
+        batches_sent += 1;
+        messages_sent += messages_per_batch as u64;
+
+        println!("Calling poll_messages after batch {}", batches_sent);
+        let poll_result = consumer
+            .poll_messages(
+                &stream_id,
+                &topic_id,
+                Some(0),
+                &consumer_kind,
+                &PollingStrategy::offset(0),
+                messages_sent as u32,
+                false,
+            )
+            .await;
+
+        let polled_count = match &poll_result {
+            Ok(polled) => polled.messages.len() as u64,
+            Err(e) => {
+                println!("Poll error: {:?}", e);
+                0
+            }
+        };
+
+        if polled_count < messages_sent {
+            let missing = messages_sent - polled_count;
+            let elapsed_ms = start.elapsed().as_millis();
+
+            panic!(
+                "RACE CONDITION DETECTED after {:.2}s/{}s ({} batches, {} messages), expected {} messages, got {}. Missing: {}",
+                elapsed_ms as f64 / 1000.0,
+                TEST_DURATION_SECS,
+                batches_sent,
+                messages_sent,
+                messages_sent,
+                polled_count,
+                missing
+            );
+        }
+
+        if batches_sent.is_multiple_of(1000) {
+            println!(
+                "Progress: {} batches, {} messages, elapsed: {:.2}s/{}s",
+                batches_sent,
+                messages_sent,
+                start.elapsed().as_secs_f64(),
+                TEST_DURATION_SECS
+            );
+        }
+    }
+
+    producer.delete_stream(&stream_id).await.unwrap();
+}

--- a/core/server/src/binary/handlers/messages/poll_messages_handler.rs
+++ b/core/server/src/binary/handlers/messages/poll_messages_handler.rs
@@ -92,7 +92,7 @@ impl ServerCommandHandler for PollMessages {
         let response_length = 4 + 8 + 4 + batch.size();
         let response_length_bytes = response_length.to_le_bytes();
 
-        let mut bufs = Vec::with_capacity(batch.containers_count() + 5);
+        let mut bufs = Vec::with_capacity(batch.containers_count() + 3);
         let mut partition_id_buf = PooledBuffer::with_capacity(4);
         let mut current_offset_buf = PooledBuffer::with_capacity(8);
         let mut count_buf = PooledBuffer::with_capacity(4);
@@ -104,7 +104,9 @@ impl ServerCommandHandler for PollMessages {
         bufs.push(current_offset_buf);
         bufs.push(count_buf);
 
-        batch.iter_mut().for_each(|m| bufs.push(m.take_messages()));
+        batch.iter_mut().for_each(|m| {
+            bufs.push(m.take_messages());
+        });
         trace!(
             "Sending {} messages to client ({} bytes) to client",
             batch.count(),

--- a/core/server/src/streaming/partitions/helpers.rs
+++ b/core/server/src/streaming/partitions/helpers.rs
@@ -15,13 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-use err_trail::ErrContext;
-use iggy_common::{ConsumerOffsetInfo, Identifier, IggyByteSize, IggyError};
-use std::{
-    ops::AsyncFnOnce,
-    sync::{Arc, atomic::Ordering},
-};
-
 use crate::{
     configs::{cache_indexes::CacheIndexesConfig, system::SystemConfig},
     slab::{
@@ -41,6 +34,12 @@ use crate::{
         polling_consumer::ConsumerGroupId,
         segments::{IggyIndexesMut, IggyMessagesBatchMut, IggyMessagesBatchSet, storage::Storage},
     },
+};
+use err_trail::ErrContext;
+use iggy_common::{ConsumerOffsetInfo, Identifier, IggyByteSize, IggyError};
+use std::{
+    ops::AsyncFnOnce,
+    sync::{Arc, atomic::Ordering},
 };
 
 pub fn get_partition_ids() -> impl FnOnce(&Partitions) -> Vec<usize> {

--- a/core/server/src/streaming/partitions/in_flight.rs
+++ b/core/server/src/streaming/partitions/in_flight.rs
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use iggy_common::IggyMessagesBatch;
+
+/// Holds batches that are being written to disk.
+///
+/// During async I/O, messages are transferred from the journal to disk.
+/// This buffer holds frozen (immutable, Arc-backed) copies so consumers
+/// can still read them during the write operation.
+#[derive(Debug, Default)]
+pub struct IggyMessagesBatchSetInFlight {
+    batches: Vec<IggyMessagesBatch>,
+    first_offset: u64,
+    last_offset: u64,
+}
+
+impl IggyMessagesBatchSetInFlight {
+    pub fn is_empty(&self) -> bool {
+        self.batches.is_empty()
+    }
+
+    pub fn first_offset(&self) -> u64 {
+        self.first_offset
+    }
+
+    pub fn last_offset(&self) -> u64 {
+        self.last_offset
+    }
+
+    pub fn set(&mut self, batches: Vec<IggyMessagesBatch>) {
+        if batches.is_empty() {
+            self.clear();
+            return;
+        }
+        self.first_offset = batches.first().and_then(|b| b.first_offset()).unwrap_or(0);
+        self.last_offset = batches.last().and_then(|b| b.last_offset()).unwrap_or(0);
+        self.batches = batches;
+    }
+
+    pub fn clear(&mut self) {
+        self.batches.clear();
+        self.first_offset = 0;
+        self.last_offset = 0;
+    }
+
+    pub fn get_by_offset(&self, start_offset: u64, count: u32) -> &[IggyMessagesBatch] {
+        if self.is_empty() || start_offset > self.last_offset {
+            return &[];
+        }
+
+        let end_offset = start_offset + count as u64 - 1;
+        if end_offset < self.first_offset {
+            return &[];
+        }
+
+        &self.batches
+    }
+
+    pub fn batches(&self) -> &[IggyMessagesBatch] {
+        &self.batches
+    }
+}

--- a/core/server/src/streaming/partitions/mod.rs
+++ b/core/server/src/streaming/partitions/mod.rs
@@ -18,6 +18,7 @@
 
 pub mod consumer_offset;
 pub mod helpers;
+pub mod in_flight;
 pub mod journal;
 pub mod log;
 pub mod partition;

--- a/core/server/src/streaming/segments/indexes/indexes_mut.rs
+++ b/core/server/src/streaming/segments/indexes/indexes_mut.rs
@@ -17,7 +17,7 @@
  */
 
 use iggy_common::PooledBuffer;
-use iggy_common::{INDEX_SIZE, IggyIndexView};
+use iggy_common::{INDEX_SIZE, IggyIndexView, IggyIndexes};
 use std::fmt;
 use std::ops::{Deref, Index as StdIndex};
 
@@ -54,6 +54,17 @@ impl IggyIndexesMut {
         let base_position = self.base_position;
         let buffer = std::mem::take(&mut self.buffer);
         (base_position, buffer)
+    }
+
+    /// Freezes the indexes buffer, converting to an immutable `IggyIndexes`.
+    ///
+    /// The returned `IggyIndexes` uses Arc-backed `Bytes`, allowing cheap clones.
+    pub fn freeze(&mut self) -> IggyIndexes {
+        let base_position = self.base_position;
+        let buffer = self.buffer.freeze();
+        self.saved_count = 0;
+        self.base_position = 0;
+        IggyIndexes::new(buffer, base_position)
     }
 
     /// Gets the size of all indexes messages


### PR DESCRIPTION
Messages were temporarily unreadable after journal commit but
before disk write completed. Freeze batches to Arc-backed
Bytes so the same data can be held in an in-flight buffer for
reads while compio writes.
