### PR TITLE
fix(server): prevent message unavailability during background persistence

### DIFF
--- a/core/server/src/streaming/partitions/helpers.rs
+++ b/core/server/src/streaming/partitions/helpers.rs
@@ -430,6 +430,29 @@ pub fn append_to_journal(
     }
 }
 
+/// Commit journal and set in-flight buffer with frozen batches.
+/// Returns frozen batches for persisting to disk.
+pub fn commit_journal_with_in_flight()
+-> impl FnOnce(ComponentsById<PartitionRefMut>) -> Vec<iggy_common::IggyMessagesBatch> {
+    |(.., log)| {
+        let mut batches = log.journal_mut().commit();
+        if batches.is_empty() {
+            return Vec::new();
+        }
+        log.ensure_indexes();
+        batches.append_indexes_to(log.active_indexes_mut().unwrap());
+        let frozen: Vec<_> = batches.iter_mut().map(|b| b.freeze()).collect();
+        log.set_in_flight(frozen.clone());
+        frozen
+    }
+}
+
+pub fn clear_in_flight() -> impl FnOnce(ComponentsById<PartitionRefMut>) {
+    |(.., log)| {
+        log.clear_in_flight();
+    }
+}
+
 pub fn commit_journal() -> impl FnOnce(ComponentsById<PartitionRefMut>) -> IggyMessagesBatchSet {
     |(.., log)| {
         let batches = log.journal_mut().commit();


### PR DESCRIPTION
Messages were unavailable when background message_saver committed the
journal (emptying it) and started async disk I/O before completion.
Polling during this window found neither journal nor disk data.

The fix freezes journal batches and sets them in the in-flight buffer
before async persist. Readers now merge in-flight data with segments,
maintaining availability throughout the disk write operation.
