### PR TITLE
perf(ci): add reusable Go setup action and reduce cache bloat

### DIFF
--- a/.github/actions/go/pre-merge/action.yml
+++ b/.github/actions/go/pre-merge/action.yml
@@ -26,31 +26,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Go
-      uses: actions/setup-go@v5
+    - name: Setup Go with cache
+      uses: ./.github/actions/utils/setup-go-with-cache
       with:
-        go-version: "1.23.0"
-        cache-dependency-path: |
-          foreign/go/go.sum
-          bdd/go/go.sum
-          examples/go/go.sum
-
-    - name: Download dependencies
-      run: |
-        if [ -f "foreign/go/go.mod" ]; then
-          cd foreign/go && go mod download
-          cd ..
-        fi
-
-        if [ -f "bdd/go/go.mod" ]; then
-          cd bdd/go && go mod download
-          cd ..
-        fi
-
-        if [ -f "examples/go/go.mod" ]; then
-          cd examples/go && go mod download
-        fi
-      shell: bash
+        enabled: "false"
 
     - name: Tidy Check
       shell: bash

--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -45,8 +45,9 @@ runs:
       uses: ./.github/actions/utils/setup-rust-with-cache
       with:
         cache-targets: false # Only cache registry and git deps, not target dir (sccache handles that)
-        # Only test (most comprehensive) and build-* tasks should save cache
-        save-cache: ${{ inputs.task == 'test' || startsWith(inputs.task, 'build-') }}
+        # Only test (most comprehensive) and macOS builds should save cache;
+        # aarch64-linux builds are fast enough and we don't want to bloat the cache with platform-specific artifacts
+        save-cache: ${{ inputs.task == 'test' || inputs.task == 'build-macos-aarch64' }}
 
     - name: Install tools for specific tasks
       run: |

--- a/.github/actions/utils/setup-go-with-cache/action.yml
+++ b/.github/actions/utils/setup-go-with-cache/action.yml
@@ -1,0 +1,104 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# NOTE: this action sets up the Go toolchain + caching for dependencies,
+#       it is a convenience wrapper, so that we can use it in all workflows.
+
+name: setup-go-with-cache
+description: Setup Go toolchain and comprehensive caching (go mod cache + golangci-lint cache)
+inputs:
+  go-version:
+    description: "Go version to use"
+    required: false
+    default: "1.23.0"
+  enabled:
+    description: "Whether to enable caching"
+    required: false
+    default: "true"
+  cache-dependency-path:
+    description: "Paths to go.sum files for caching (newline separated)"
+    required: false
+    default: |
+      foreign/go/go.sum
+      bdd/go/go.sum
+      examples/go/go.sum
+  download-deps:
+    description: "Whether to download module dependencies"
+    required: false
+    default: "true"
+  golangci-lint-version:
+    description: "golangci-lint version for cache key"
+    required: false
+    default: "v1.61"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Go toolchain
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: ${{ inputs.enabled }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+
+    - name: Setup additional Go module cache
+      if: inputs.enabled == 'true'
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          go-mod-${{ runner.os }}-${{ runner.arch }}-
+
+    - name: Setup golangci-lint cache
+      if: inputs.enabled == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/golangci-lint
+        key: golangci-lint-${{ runner.os }}-${{ inputs.golangci-lint-version }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          golangci-lint-${{ runner.os }}-${{ inputs.golangci-lint-version }}-
+
+    - name: Download Go module dependencies
+      if: inputs.download-deps == 'true'
+      run: |
+        echo "📦 Downloading Go module dependencies..."
+
+        download_if_exists() {
+          local dir="$1"
+          if [ -f "${dir}/go.mod" ]; then
+            echo "  → ${dir}"
+            cd "${dir}" && go mod download && cd - > /dev/null
+          fi
+        }
+
+        download_if_exists "foreign/go"
+        download_if_exists "bdd/go"
+        download_if_exists "examples/go"
+
+        echo "✅ Go dependencies downloaded"
+      shell: bash
+
+    - name: Verify Go installation
+      run: |
+        echo "✅ Go setup complete"
+        go version
+        echo "GOPATH: $(go env GOPATH)"
+        echo "GOCACHE: $(go env GOCACHE)"
+      shell: bash

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -106,11 +106,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Setup Go with cache
+        uses: ./.github/actions/utils/setup-go-with-cache
         with:
           go-version: "1.23"
-          cache: false
+          enabled: "false"
+          download-deps: "false"
 
       - name: Install addlicense
         run: go install github.com/google/addlicense@4529cd558fa0bf07ab0f2650e36d089fb1c07c89

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -85,6 +85,14 @@ jobs:
         with:
           gradle-version: "9.2.1"
 
+      - name: Setup Go with cache for examples
+        if: inputs.component == 'examples-suite' && inputs.task == 'examples-go'
+        uses: ./.github/actions/utils/setup-go-with-cache
+        with:
+          enabled: "false"
+          cache-dependency-path: examples/go/go.sum
+          download-deps: "false"
+
       - name: Build common binaries for all examples
         if: inputs.component == 'examples-suite'
         run: |


### PR DESCRIPTION
Go setup was duplicated across workflows with inconsistent caching.
Created setup-go-with-cache action (mirroring setup-rust-with-cache)
to centralize Go toolchain setup.

Disabled caching for Go workflows and Rust aarch64/macos builds:
- Go caches were creating redundant entries per-PR
- Platform-specific Rust builds are fast enough without cache
- Reduces cache usage toward GitHub's 10GB limit
