### PR TITLE
feat(bench): add --message-expiry CLI option for benchmark topics

### DIFF
--- a/core/bench/src/args/common.rs
+++ b/core/bench/src/args/common.rs
@@ -30,7 +30,7 @@ use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::numeric_parameter::BenchmarkNumericParameter;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
-use iggy::prelude::{IggyByteSize, IggyDuration, TransportProtocol};
+use iggy::prelude::{IggyByteSize, IggyDuration, IggyExpiry, TransportProtocol};
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
@@ -289,6 +289,10 @@ impl IggyBenchArgs {
 
     pub fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.benchmark_kind.inner().max_topic_size()
+    }
+
+    pub fn message_expiry(&self) -> IggyExpiry {
+        self.benchmark_kind.inner().message_expiry()
     }
 
     pub fn read_amplification(&self) -> Option<f32> {

--- a/core/bench/src/args/examples.rs
+++ b/core/bench/src/args/examples.rs
@@ -68,6 +68,7 @@ const EXAMPLES: &str = r#"EXAMPLES:
     --producers (-c): Number of producers
     --consumers (-c): Number of consumers
     --max-topic-size (-T): Max topic size (e.g., "1GiB")
+    --message-expiry (-e): Topic message expiry time (e.g., "1s", "5min", "1h")
 
     Examples with detailed configuration:
 

--- a/core/bench/src/args/kinds/balanced/consumer_group.rs
+++ b/core/bench/src/args/kinds/balanced/consumer_group.rs
@@ -82,7 +82,7 @@ impl BenchmarkKindProps for BalancedConsumerGroupArgs {
             cmd.error(
                 ErrorKind::ArgumentConflict,
                 format!(
-                    "In balanced consumer group, consumer groups number ({cg_number}) must be less than the number of streams ({streams})"
+                    "In balanced consumer group, consumer groups number ({cg_number}) must be greater than or equal to the number of streams ({streams})"
                 ),
             )
             .exit();

--- a/core/bench/src/args/kinds/balanced/producer.rs
+++ b/core/bench/src/args/kinds/balanced/producer.rs
@@ -26,7 +26,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 /// N producers sending to N separated stream-topic with single partition (one stream per one producer)
@@ -50,6 +50,10 @@ pub struct BalancedProducerArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GiB". If not provided then the server default will be used.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 }
 
 impl BenchmarkKindProps for BalancedProducerArgs {
@@ -79,6 +83,10 @@ impl BenchmarkKindProps for BalancedProducerArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
     fn validate(&self) {

--- a/core/bench/src/args/kinds/balanced/producer_and_consumer_group.rs
+++ b/core/bench/src/args/kinds/balanced/producer_and_consumer_group.rs
@@ -27,7 +27,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 /// Polling benchmark with consumer group
@@ -59,6 +59,10 @@ pub struct BalancedProducerAndConsumerGroupArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MiB", "1GiB". If not provided then the server default will be used.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 
     /// Consumer rate limit multiplier relative to producer rate.
     /// When measuring E2E latency, consumers may need higher throughput to prevent queue buildup.
@@ -123,5 +127,9 @@ impl BenchmarkKindProps for BalancedProducerAndConsumerGroupArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 }

--- a/core/bench/src/args/kinds/end_to_end/producing_consumer.rs
+++ b/core/bench/src/args/kinds/end_to_end/producing_consumer.rs
@@ -23,7 +23,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
@@ -42,6 +42,10 @@ pub struct EndToEndProducingConsumerArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GiB". If not provided then the server default will be used.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 }
 
 impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
@@ -71,6 +75,10 @@ impl BenchmarkKindProps for EndToEndProducingConsumerArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
     fn validate(&self) {

--- a/core/bench/src/args/kinds/end_to_end/producing_consumer_group.rs
+++ b/core/bench/src/args/kinds/end_to_end/producing_consumer_group.rs
@@ -27,7 +27,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
@@ -58,6 +58,10 @@ pub struct EndToEndProducingConsumerGroupArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GiB". If not provided then topic size will be unlimited.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 }
 
 impl BenchmarkKindProps for EndToEndProducingConsumerGroupArgs {
@@ -87,6 +91,10 @@ impl BenchmarkKindProps for EndToEndProducingConsumerGroupArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
     fn validate(&self) {

--- a/core/bench/src/args/kinds/pinned/producer.rs
+++ b/core/bench/src/args/kinds/pinned/producer.rs
@@ -21,7 +21,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
@@ -41,6 +41,10 @@ pub struct PinnedProducerArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MiB", "1GiB". If not provided then the server default will be used.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 }
 
 impl BenchmarkKindProps for PinnedProducerArgs {
@@ -70,6 +74,10 @@ impl BenchmarkKindProps for PinnedProducerArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
     fn validate(&self) {

--- a/core/bench/src/args/kinds/pinned/producer_and_consumer.rs
+++ b/core/bench/src/args/kinds/pinned/producer_and_consumer.rs
@@ -26,7 +26,7 @@ use crate::args::{
     transport::BenchmarkTransportCommand,
 };
 use clap::{CommandFactory, Parser, error::ErrorKind};
-use iggy::prelude::IggyByteSize;
+use iggy::prelude::{IggyByteSize, IggyExpiry};
 use std::num::NonZeroU32;
 
 #[derive(Parser, Debug, Clone)]
@@ -54,6 +54,10 @@ pub struct PinnedProducerAndConsumerArgs {
     /// Max topic size in human readable format, e.g. "1GiB", "2MB", "1GiB". If not provided then the server default will be used.
     #[arg(long, short = 'T')]
     pub max_topic_size: Option<IggyByteSize>,
+
+    /// Topic message expiry time in human readable format, e.g. "1s", "5min", "1h". If not provided, messages never expire.
+    #[arg(long, short = 'e')]
+    pub message_expiry: Option<IggyExpiry>,
 
     /// Consumer rate limit multiplier relative to producer rate.
     /// When measuring E2E latency, consumers may need higher throughput to prevent queue buildup.
@@ -89,6 +93,10 @@ impl BenchmarkKindProps for PinnedProducerAndConsumerArgs {
 
     fn max_topic_size(&self) -> Option<IggyByteSize> {
         self.max_topic_size
+    }
+
+    fn message_expiry(&self) -> IggyExpiry {
+        self.message_expiry.unwrap_or(IggyExpiry::NeverExpire)
     }
 
     fn read_amplification(&self) -> Option<f32> {

--- a/core/bench/src/args/props.rs
+++ b/core/bench/src/args/props.rs
@@ -17,7 +17,7 @@
  */
 
 use super::{output::BenchmarkOutputCommand, transport::BenchmarkTransportCommand};
-use iggy::prelude::{IggyByteSize, TransportProtocol};
+use iggy::prelude::{IggyByteSize, IggyExpiry, TransportProtocol};
 
 pub trait BenchmarkKindProps {
     fn streams(&self) -> u32;
@@ -27,6 +27,9 @@ pub trait BenchmarkKindProps {
     fn producers(&self) -> u32;
     fn transport_command(&self) -> &BenchmarkTransportCommand;
     fn max_topic_size(&self) -> Option<IggyByteSize>;
+    fn message_expiry(&self) -> IggyExpiry {
+        IggyExpiry::NeverExpire
+    }
     fn validate(&self);
 
     /// Consumer rate limit multiplier relative to producer rate.

--- a/core/bench/src/benchmarks/benchmark.rs
+++ b/core/bench/src/benchmarks/benchmark.rs
@@ -112,10 +112,11 @@ pub trait Benchmarkable: Send {
                     .args()
                     .max_topic_size()
                     .map_or(MaxTopicSize::Unlimited, MaxTopicSize::Custom);
+                let message_expiry = self.args().message_expiry();
 
                 info!(
-                    "Creating the test topic '{}' for stream '{}' with max topic size: {:?}",
-                    topic_name, stream_name, max_topic_size
+                    "Creating the test topic '{}' for stream '{}' with max topic size: {:?}, message expiry: {}",
+                    topic_name, stream_name, max_topic_size, message_expiry
                 );
 
                 client
@@ -125,7 +126,7 @@ pub trait Benchmarkable: Send {
                         partitions_count,
                         CompressionAlgorithm::default(),
                         None,
-                        IggyExpiry::NeverExpire,
+                        message_expiry,
                         max_topic_size,
                     )
                     .await?;


### PR DESCRIPTION
Benchmarks previously created topics with hardcoded NeverExpire policy,
preventing testing of expiry-related scenarios.

Add -e/--message-expiry flag to all producer benchmark kinds, allowing
configurable message expiry (e.g., "1s", "5min", "1h"). Consumer-only
benchmarks use the trait default since they don't create topics.
