### PR TITLE
ci(rust): add code coverage reporting with Codecov

### DIFF
--- a/.github/actions/csharp-dotnet/pre-merge/action.yml
+++ b/.github/actions/csharp-dotnet/pre-merge/action.yml
@@ -35,8 +35,6 @@ runs:
     - name: Setup Rust with cache
       if: inputs.task == 'test' || inputs.task == 'e2e'
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        shared-key: dev
 
     - name: Restore dependencies
       run: |

--- a/.github/actions/go/pre-merge/action.yml
+++ b/.github/actions/go/pre-merge/action.yml
@@ -119,8 +119,6 @@ runs:
     - name: Setup Rust with cache for e2e
       if: inputs.task == 'e2e'
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        shared-key: dev
 
     - name: Setup server for e2e tests
       if: inputs.task == 'e2e'

--- a/.github/actions/java-gradle/pre-merge/action.yml
+++ b/.github/actions/java-gradle/pre-merge/action.yml
@@ -79,8 +79,6 @@ runs:
     - name: Setup Rust with cache
       if: inputs.task == 'test'
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        shared-key: dev
 
     - name: Start Iggy server
       if: inputs.task == 'test'

--- a/.github/actions/node-npm/pre-merge/action.yml
+++ b/.github/actions/node-npm/pre-merge/action.yml
@@ -37,8 +37,6 @@ runs:
     - name: Setup Rust with cache
       if: inputs.task == 'e2e'
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        shared-key: dev
 
     - name: Install netcat
       if: inputs.task == 'e2e'

--- a/.github/actions/python-maturin/pre-merge/action.yml
+++ b/.github/actions/python-maturin/pre-merge/action.yml
@@ -33,8 +33,6 @@ runs:
 
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        shared-key: dev
 
     - name: Cache pip
       uses: actions/cache@v4

--- a/.github/actions/rust/post-merge/action.yml
+++ b/.github/actions/rust/post-merge/action.yml
@@ -35,8 +35,6 @@ runs:
   steps:
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache
-      with:
-        enabled: "false"  # Post-merge runs infrequently, no need to cache
 
     - name: Validate package
       run: |

--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -44,7 +44,7 @@ runs:
     - name: Setup Rust with cache
       uses: ./.github/actions/utils/setup-rust-with-cache
       with:
-        shared-key: dev
+        print-cache-status: ${{ inputs.task == 'test' }}
 
     - name: Install tools for specific tasks
       run: |
@@ -99,9 +99,17 @@ runs:
         echo -n "test" | gnome-keyring-daemon --unlock
       shell: bash
 
-    - name: Build and test
+    - name: Install cargo-llvm-cov
+      if: inputs.task == 'test'
+      uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-llvm-cov
+
+    - name: Build and test with coverage
       if: inputs.task == 'test'
       run: |
+        source <(cargo llvm-cov show-env --export-prefix)
+
         bins_start=$(date +%s)
         cargo build --locked
         bins_end=$(date +%s)
@@ -135,6 +143,10 @@ runs:
         echo "Total build:                   ${build_duration}s ($(date -ud @${build_duration} +'%M:%S'))"
         echo "Total time:                    ${total_duration}s ($(date -ud @${total_duration} +'%M:%S'))"
         echo "========================================="
+
+        cargo llvm-cov report --codecov --output-path codecov.json
+        echo "Coverage report generated: codecov.json"
+        ls -la codecov.json
       shell: bash
 
     - name: Backwards compatibility check

--- a/.github/actions/utils/setup-go-with-cache/action.yml
+++ b/.github/actions/utils/setup-go-with-cache/action.yml
@@ -52,7 +52,7 @@ runs:
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
-        cache: ${{ inputs.enabled }}
+        cache: ${{ inputs.enabled == 'true' }}
         cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Setup additional Go module cache

--- a/.github/actions/utils/setup-rust-with-cache/action.yml
+++ b/.github/actions/utils/setup-rust-with-cache/action.yml
@@ -19,14 +19,22 @@ name: setup-rust-with-cache
 description: Setup Rust toolchain with Swatinem/rust-cache
 
 inputs:
-  enabled:
-    description: "Whether to enable caching"
+  read-cache:
+    description: "Whether to read from cache"
     required: false
     default: "true"
   shared-key:
-    description: "Shared cache key across jobs (e.g., 'dev', 'dev-coverage')"
+    description: "Shared cache key across jobs"
     required: false
-    default: ""
+    default: "dev"
+  save-cache:
+    description: "Whether to save cache (true/false)"
+    required: false
+    default: "false"
+  print-cache-status:
+    description: "Whether to print cache status to job summary"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -49,10 +57,25 @@ runs:
       shell: bash
 
     - name: Setup Rust cache
-      if: inputs.enabled == 'true'
+      id: rust-cache
+      if: inputs.read-cache == 'true'
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: ${{ inputs.shared-key }}
+        save-if: ${{ inputs.save-cache == 'true' }}
+
+    - name: Cache status
+      if: inputs.read-cache == 'true' && inputs.print-cache-status == 'true'
+      run: |
+        echo "### Rust Cache" >> $GITHUB_STEP_SUMMARY
+        if [ "${{ steps.rust-cache.outputs.cache-hit }}" == "true" ]; then
+          echo "✅ Cache hit" >> $GITHUB_STEP_SUMMARY
+        elif [ -d "target" ]; then
+          echo "🔶 Partial cache hit" >> $GITHUB_STEP_SUMMARY
+        else
+          echo "❌ Cache miss" >> $GITHUB_STEP_SUMMARY
+        fi
+      shell: bash
 
     - name: Install cargo-nextest
       if: runner.os == 'Linux'
@@ -79,7 +102,7 @@ runs:
       continue-on-error: true
 
     - name: Configure Cargo for CI
-      if: inputs.enabled == 'true'
+      if: inputs.read-cache == 'true'
       run: |
         echo "CARGO_INCREMENTAL=0" >> $GITHUB_ENV
         echo "CARGO_PROFILE_DEV_DEBUG=0" >> $GITHUB_ENV

--- a/.github/workflows/_build_rust_artifacts.yml
+++ b/.github/workflows/_build_rust_artifacts.yml
@@ -138,6 +138,12 @@ jobs:
             export CFLAGS="-mno-outline-atomics"
           fi
 
+          # musl builds: use musl-gcc as linker to ensure proper linking against musl libc
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
+            export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc
+          fi
+
           cargo build --locked --release --target ${{ matrix.target }} "${bin_flags[@]}"
 
       - name: Package binaries

--- a/.github/workflows/_common.yml
+++ b/.github/workflows/_common.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: ./.github/actions/utils/setup-rust-with-cache
         with:
-          enabled: "false" # Don't need cache for just checking licenses
+          read-cache: "false"
 
       - name: Install cargo-license
         run: cargo install cargo-license

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,10 +27,14 @@ on:
         type: string
         required: true
         description: "Task to run"
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read
   security-events: write
+  pull-requests: write
 
 jobs:
   run:
@@ -56,6 +60,16 @@ jobs:
         with:
           task: ${{ inputs.task }}
           component: ${{ inputs.component }}
+
+      - name: Upload coverage to Codecov
+        if: startsWith(inputs.component, 'rust') && inputs.task == 'test'
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          flags: rust
+          fail_ci_if_error: false
+          verbose: true
 
       # Python SDK
       - name: Set up Docker Buildx for Python
@@ -130,5 +144,6 @@ jobs:
             reports/**
             target/llvm-cov/**
             coverage.lcov
+            codecov.json
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/_test_bdd.yml
+++ b/.github/workflows/_test_bdd.yml
@@ -55,8 +55,6 @@ jobs:
       - name: Setup Rust with cache for BDD
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')
         uses: ./.github/actions/utils/setup-rust-with-cache
-        with:
-          shared-key: dev
 
       - name: Build server for BDD tests
         if: startsWith(inputs.component, 'bdd-') && startsWith(inputs.task, 'bdd-')

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Setup Rust with cache for examples
         if: inputs.component == 'examples-suite'
         uses: ./.github/actions/utils/setup-rust-with-cache
-        with:
-          shared-key: dev
 
       - name: Setup Node with cache for examples
         if: inputs.component == 'examples-suite'

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -133,12 +133,87 @@ jobs:
       create_edge_docker_tag: true
     secrets: inherit
 
+  warm-cache:
+    name: Warm cache (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Don't cache ubuntu-24.04-arm due to size
+        runner: [ubuntu-latest, macos-14]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Rust with cache
+        uses: ./.github/actions/utils/setup-rust-with-cache
+        with:
+          save-cache: "true"
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Compile tests
+        run: cargo test --no-run --locked
+
   build-artifacts:
     name: Build artifacts
     uses: ./.github/workflows/_build_rust_artifacts.yml
     with:
       version: edge
       upload_artifacts: true
+
+  coverage:
+    name: Coverage baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cleanup disk space
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install --yes gnome-keyring keyutils
+          rm -f $HOME/.local/share/keyrings/*
+          echo -n "test" | gnome-keyring-daemon --unlock
+
+      - name: Setup Rust with cache
+        uses: ./.github/actions/utils/setup-rust-with-cache
+        with:
+          save-cache: "true"
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Build and test with coverage
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo build --locked
+          cargo test --locked --no-run
+          if command -v cargo-nextest &> /dev/null; then
+            cargo nextest run --locked --no-fail-fast
+          else
+            cargo test --locked --no-fail-fast
+          fi
+        shell: bash
+
+      - name: Generate coverage report
+        run: |
+          source <(cargo llvm-cov show-env --export-prefix)
+          cargo llvm-cov report --codecov --output-path codecov.json
+        shell: bash
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          flags: rust
+          fail_ci_if_error: false
 
   create-prerelease:
     name: Create edge pre-release

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -28,7 +28,7 @@ concurrency:
 permissions:
   contents: read
   security-events: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   # Common checks - always run
@@ -56,6 +56,8 @@ jobs:
     with:
       component: ${{ matrix.component }}
       task: ${{ matrix.task }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Python SDK
   test-python:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+codecov:
+  require_ci_to_pass: false
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+  status:
+    project:
+      default:
+        informational: true
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        informational: true
+        target: 50%
+        threshold: 5%
+
+comment:
+  layout: "header, diff, flags, files"
+  behavior: default
+  require_changes: true
+  require_base: true
+  require_head: true
+
+ignore:
+  - "core/bench/**"
+  - "core/integration/**"
+  - "core/tools/**"
+  - "core/harness_derive/**"
+  - "bdd/**"
+  - "examples/**"
+  - "foreign/**"
+  - "web/**"
+  - "**/tests/**"


### PR DESCRIPTION
Integrate cargo-llvm-cov into test runs and upload reports to
Codecov. Coverage runs on pre-merge (PR comments) and post-merge
(baseline tracking). Configured as informational-only to avoid
blocking PRs on coverage changes.
