### PR TITLE
fix(ci): fix example jobs, pin images

### DIFF
--- a/.github/actions/utils/setup-rust-with-cache/action.yml
+++ b/.github/actions/utils/setup-rust-with-cache/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Install system dependencies (macOS)
       if: runner.os == 'macOS'
       run: |
-        brew install hwloc pkg-config
+        brew install hwloc
       shell: bash
 
     - name: Setup Rust toolchain

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -70,6 +70,7 @@ jobs:
           flags: rust
           fail_ci_if_error: false
           verbose: true
+          override_pr: ${{ github.event.pull_request.number }}
 
       # Python SDK
       - name: Set up Docker Buildx for Python

--- a/.github/workflows/_test_examples.yml
+++ b/.github/workflows/_test_examples.yml
@@ -48,7 +48,7 @@ jobs:
         uses: ./.github/actions/utils/setup-rust-with-cache
 
       - name: Setup Node with cache for examples
-        if: inputs.component == 'examples-suite'
+        if: inputs.component == 'examples-suite' && inputs.task == 'examples-node'
         uses: ./.github/actions/utils/setup-node-with-cache
         with:
           node-version: "23"
@@ -56,13 +56,13 @@ jobs:
           workspace: examples/node
 
       - name: Setup Python
-        if: inputs.component == 'examples-suite'
+        if: inputs.component == 'examples-suite' && inputs.task == 'examples-python'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache pip
-        if: inputs.component == 'examples-suite'
+        if: inputs.component == 'examples-suite' && inputs.task == 'examples-python'
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip

--- a/core/integration/tests/connectors/fixtures/quickwit/container.rs
+++ b/core/integration/tests/connectors/fixtures/quickwit/container.rs
@@ -31,7 +31,7 @@ use tracing::info;
 use uuid::Uuid;
 
 const QUICKWIT_IMAGE: &str = "quickwit/quickwit";
-const QUICKWIT_TAG: &str = "0.8.1";
+const QUICKWIT_TAG: &str = "0.8.2";
 const QUICKWIT_PORT: u16 = 7280;
 const QUICKWIT_READY_MSG: &str = "REST server is ready";
 const QUICKWIT_LISTEN_ADDRESS: &str = "0.0.0.0";

--- a/core/integration/tests/connectors/fixtures/wiremock.rs
+++ b/core/integration/tests/connectors/fixtures/wiremock.rs
@@ -26,6 +26,8 @@ use testcontainers_modules::testcontainers::core::{IntoContainerPort, Mount};
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, GenericImage, ImageExt};
 
+const WIREMOCK_IMAGE: &str = "wiremock/wiremock";
+const WIREMOCK_TAG: &str = "3.13.2";
 const WIREMOCK_PORT: u16 = 8080;
 
 struct WireMockContainer {
@@ -41,7 +43,7 @@ impl WireMockContainer {
             message: format!("Failed to get current dir: {e}"),
         })?;
 
-        let container = GenericImage::new("wiremock/wiremock", "latest")
+        let container = GenericImage::new(WIREMOCK_IMAGE, WIREMOCK_TAG)
             .with_exposed_port(WIREMOCK_PORT.tcp())
             .with_wait_for(Healthcheck(HealthWaitStrategy::default()))
             .with_mount(Mount::bind_mount(

--- a/foreign/node/package.json
+++ b/foreign/node/package.json
@@ -42,7 +42,7 @@
     "commitlint": "commitlint --edit",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "author": "github.com/T1B0",
   "license": "Apache-2.0",


### PR DESCRIPTION
Node setup ran for all example jobs, causing husky "not found"
errors. Scope Node/Python setup to respective tasks and make
husky tolerate missing binary. Pin wiremock and quickwit
images.