### PR TITLE
fix(server): memory leak in segment rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5011,6 +5011,7 @@ dependencies = [
  "socket2 0.6.2",
  "sqlx",
  "strum",
+ "sysinfo 0.38.0",
  "tempfile",
  "test-case",
  "testcontainers-modules",

--- a/core/integration/Cargo.toml
+++ b/core/integration/Cargo.toml
@@ -67,6 +67,7 @@ server = { workspace = true }
 socket2 = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }
+sysinfo = { workspace = true }
 tempfile = { workspace = true }
 test-case = { workspace = true }
 testcontainers-modules = { workspace = true }


### PR DESCRIPTION
Segment rotation accumulated memory indefinitely because sealed segments retained their 16MB index buffers and kept file writers open. Under heavy write load with frequent rotations, this caused memory to balloon from ~100MB to 20GB+.

The fix clears index buffers for sealed segments (when cache_indexes != All) and closes their writers immediately after sealing. Writers are never needed post-seal, and this also releases io_uring/kernel file handle resources.