### PR TITLE
ci(python): enable auto-publish for Python SDK on post-merge

### DIFF
--- a/.github/config/publish.yml
+++ b/.github/config/publish.yml
@@ -94,7 +94,7 @@ components:
 
   # ── Other SDKs ─────────────────────────────────────────────────────────────
   sdk-python:
-    tag_pattern: "^python-sdk-([0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?)$"
+    tag_pattern: "^python-sdk-([0-9]+\\.[0-9]+\\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?(?:\\+[0-9A-Za-z.-]+)?)$"
     registry: pypi
     version_file: "foreign/python/pyproject.toml"
     version_regex: '(?m)^\s*version\s*=\s*"([^"]+)"'

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -57,7 +57,7 @@ jobs:
             chmod +x /usr/local/bin/yq
           fi
 
-      # TODO(hubcio): Add sdk-python (it has to contain `dev`), sdk-node, sdk-java (SNAPSHOT?) when ready for edge auto-publish
+      # TODO(hubcio): Add sdk-node, sdk-java (SNAPSHOT?) when ready for edge auto-publish
       - name: Check all components
         id: check
         run: |
@@ -94,13 +94,13 @@ jobs:
 
           # Check SDKs for pre-release versions without tags
           SDKS_TO_PUBLISH=""
-          for sdk in sdk-csharp sdk-go; do
+          for sdk in sdk-python sdk-csharp sdk-go; do
             VERSION=$(scripts/extract-version.sh "$sdk")
             TAG=$(scripts/extract-version.sh "$sdk" --tag)
 
             echo "Checking $sdk: version=$VERSION, tag=$TAG"
 
-            if [[ ! "$VERSION" =~ -(edge|rc) ]]; then
+            if [[ ! "$VERSION" =~ -(edge|rc) ]] && [[ ! "$VERSION" =~ (\.dev|rc)[0-9]+$ ]]; then
               echo "  ⏭️ Stable version - skipping"
               continue
             fi


### PR DESCRIPTION
The existing pre-release check only matched semver suffixes
like -edge.1 and -rc.1, which excluded Python's PEP 440
versioning (.dev1, rc1). Broadening the regex to also match
PEP 440 formats brings sdk-python into the auto-publish
loop alongside sdk-csharp and sdk-go.

Also fixes sdk-python tag_pattern in publish.yml to accept
'.' as a pre-release separator (e.g. python-sdk-0.6.4.dev1).
