### PR TITLE
fix(python): gate Unix-only APIs to fix Windows SDK build

### DIFF
--- a/core/common/Cargo.toml
+++ b/core/common/Cargo.toml
@@ -48,7 +48,6 @@ derive_more = { workspace = true }
 err_trail = { workspace = true }
 human-repr = { workspace = true }
 humantime = { workspace = true }
-nix = { workspace = true }
 once_cell = { workspace = true }
 rcgen = { workspace = true }
 ring = { workspace = true }
@@ -62,6 +61,9 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 tungstenite = { workspace = true }
 twox-hash = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }

--- a/core/common/src/sender/mod.rs
+++ b/core/common/src/sender/mod.rs
@@ -37,8 +37,11 @@ use compio::net::TcpStream;
 use compio_quic::{RecvStream, SendStream};
 use compio_tls::TlsStream;
 use std::future::Future;
+#[cfg(unix)]
 use std::os::fd::{AsFd, OwnedFd};
-use tracing::{debug, error};
+use tracing::debug;
+#[cfg(unix)]
+use tracing::error;
 
 macro_rules! forward_async_methods {
     (
@@ -117,6 +120,7 @@ impl SenderKind {
         Self::WebSocketTls(stream)
     }
 
+    #[cfg(unix)]
     pub fn take_and_migrate_tcp(&mut self) -> Option<OwnedFd> {
         match self {
             SenderKind::Tcp(tcp_sender) => {


### PR DESCRIPTION
iggy_common used std::os::fd and nix::unistd::dup
unconditionally, breaking compilation on Windows
targets (x86_64-pc-windows-msvc) during Python SDK
release.
