### PR TITLE
ci(java): enable auto-publish for Java SDK with SNAPSHOT semantics

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -57,7 +57,6 @@ jobs:
             chmod +x /usr/local/bin/yq
           fi
 
-      # TODO(hubcio): Add sdk-java (SNAPSHOT?) when ready for edge auto-publish
       - name: Check all components
         id: check
         run: |
@@ -94,11 +93,25 @@ jobs:
 
           # Check SDKs for pre-release versions without tags
           SDKS_TO_PUBLISH=""
-          for sdk in sdk-python sdk-node sdk-csharp sdk-go; do
+          for sdk in sdk-python sdk-node sdk-java sdk-csharp sdk-go; do
             VERSION=$(scripts/extract-version.sh "$sdk")
             TAG=$(scripts/extract-version.sh "$sdk" --tag)
 
             echo "Checking $sdk: version=$VERSION, tag=$TAG"
+
+            # Maven SNAPSHOT versions are mutable -- republish when SDK sources change,
+            # skip tag gate since no tag will be created for SNAPSHOTs
+            if [[ "$VERSION" =~ -SNAPSHOT$ ]]; then
+              SDK_NAME="${sdk#sdk-}"
+              SDK_DIR="foreign/$SDK_NAME"
+              if ! git diff --name-only HEAD~1 HEAD -- "$SDK_DIR/" | grep -q .; then
+                echo "  ⏭️ SNAPSHOT - no changes in $SDK_DIR/"
+                continue
+              fi
+              echo "  ✅ SNAPSHOT version - will publish"
+              SDKS_TO_PUBLISH="${SDKS_TO_PUBLISH:+$SDKS_TO_PUBLISH,}$SDK_NAME"
+              continue
+            fi
 
             if [[ ! "$VERSION" =~ -(edge|rc) ]] && [[ ! "$VERSION" =~ (\.dev|rc)[0-9]+$ ]]; then
               echo "  ⏭️ Stable version - skipping"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -462,6 +462,12 @@ jobs:
             VERSION=$(scripts/extract-version.sh "$KEY" 2>/dev/null || echo "ERROR")
             TAG=$(scripts/extract-version.sh "$KEY" --tag 2>/dev/null || echo "ERROR")
 
+            if [[ "$VERSION" =~ -SNAPSHOT$ ]]; then
+              echo "ℹ️ $NAME: SNAPSHOT version, no tag will be created"
+              echo "| $NAME | $VERSION | _(none)_ | ℹ️ SNAPSHOT (no tag) |" >> $GITHUB_STEP_SUMMARY
+              continue
+            fi
+
             if [ "$VERSION" = "ERROR" ] || [ "$TAG" = "ERROR" ]; then
               echo "❌ Failed to extract version/tag for $NAME"
               echo "| $NAME | ERROR | ERROR | ❌ Failed to extract |" >> $GITHUB_STEP_SUMMARY
@@ -1012,6 +1018,12 @@ jobs:
 
             VERSION=$(scripts/extract-version.sh "$KEY")
             TAG=$(scripts/extract-version.sh "$KEY" --tag)
+
+            # SNAPSHOT versions are mutable; tagging would block future publishes
+            if [[ "$VERSION" =~ -SNAPSHOT$ ]]; then
+              echo "ℹ️ Skipping git tag for $NAME (SNAPSHOT version)"
+              continue
+            fi
 
             # In auto-publish mode (create_edge_docker_tag=true), skip Docker components
             # with stable versions - only pre-release versions should get versioned tags.


### PR DESCRIPTION
SNAPSHOT versions are mutable -- republished on every build.
They bypass the tag gate (no tag created) and use a path
filter on foreign/java/ to skip unrelated pushes. Removing
SNAPSHOT from the version stops auto-publish automatically.
