### PR TITLE
fix(server): prevent stale segment indices across await points

### DIFF
--- a/core/server/src/streaming/segments/mod.rs
+++ b/core/server/src/streaming/segments/mod.rs
@@ -24,7 +24,9 @@ mod types;
 pub mod storage;
 
 pub use indexes::IggyIndexesMut;
+pub use indexes::IndexReader;
 pub use indexes::IndexWriter;
+pub use messages::MessagesReader;
 pub use messages::MessagesWriter;
 pub use segment::Segment;
 pub use types::IggyMessageHeaderViewMut;


### PR DESCRIPTION
The message_cleaner can remove front segments from the log
vec while other operations yield at .await points on the
same compio thread. Code that captured a segment vec index
before an await and used it after would access the wrong
segment or panic on out-of-bounds.

Three fixes applied consistently:

1. delete_segments_base: pre-create the replacement segment
   before draining, then drain + add in a single borrow_mut
   so the log is never empty across awaits (prevents "active
   segment called on empty log" panic). Removes the now-
   unused init_log_in_local_partitions.

2. append_messages / rotate_segment: recompute segment_index
   after each await instead of caching it before.

3. Polling (load_messages_from_disk, by_timestamp): replace
   pre-computed segment_range with per-iteration re-resolve
   by start_offset (stable identity). Extract shared lookup
   into resolve_segment_storage helper that clones Rc readers
   so fds survive concurrent segment deletion.

This issue is not reproducible in normal tests. Benchmark
stress test will be implemented in next PR.