### PR TITLE
refactor(consensus): decouple pipeline from VsrConsensus internals

### DIFF
--- a/core/partitions/src/iggy_partitions.rs
+++ b/core/partitions/src/iggy_partitions.rs
@@ -457,7 +457,7 @@ where
                 return;
             };
 
-            if entry.message.header().checksum != header.prepare_checksum {
+            if entry.header.checksum != header.prepare_checksum {
                 warn!("on_ack: checksum mismatch");
                 return;
             }
@@ -476,8 +476,7 @@ where
                 return;
             };
 
-            let prepare = entry.message;
-            let prepare_header = *prepare.header();
+            let prepare_header = entry.header;
 
             // Data was already appended to the partition journal during
             // on_replicate. Now that quorum is reached, update the partition's

--- a/core/simulator/src/deps.rs
+++ b/core/simulator/src/deps.rs
@@ -91,6 +91,9 @@ impl<S: Storage<Buffer = Vec<u8>>> Journal<S> for SimJournal<S> {
     where
         Self: 'a;
 
+    // TODO(hubcio): validate that the caller's checksum matches the stored
+    // header - currently this looks up by op only, ignoring the checksum.
+    // A real journal implementation must reject mismatches.
     async fn entry(&self, header: &Self::Header) -> Option<Self::Entry> {
         let headers = unsafe { &*self.headers.get() };
         let offsets = unsafe { &*self.offsets.get() };

--- a/core/simulator/src/replica.rs
+++ b/core/simulator/src/replica.rs
@@ -19,7 +19,7 @@ use crate::bus::{MemBus, SharedMemBus};
 use crate::deps::{
     MemStorage, ReplicaPartitions, SimJournal, SimMetadata, SimMuxStateMachine, SimSnapshot,
 };
-use consensus::VsrConsensus;
+use consensus::{LocalPipeline, VsrConsensus};
 use iggy_common::IggyByteSize;
 use iggy_common::sharding::ShardId;
 use metadata::stm::consumer_group::{ConsumerGroups, ConsumerGroupsInner};
@@ -50,6 +50,7 @@ impl Replica {
             id,
             replica_count,
             SharedMemBus(Arc::clone(&bus)),
+            LocalPipeline::new(),
         );
         metadata_consensus.init();
 
@@ -59,6 +60,7 @@ impl Replica {
             id,
             replica_count,
             SharedMemBus(Arc::clone(&bus)),
+            LocalPipeline::new(),
         );
         partitions_consensus.init();
 


### PR DESCRIPTION
VsrConsensus hardcoded LocalPipeline and PipelineEntry stored
full Message<PrepareHeader> (header + body), even though only 
the header is needed for quorum tracking. This coupled the
consensus pipeline to a specific implementation and wasted
memory on message bodies that already live in the journal.

Parameterize VsrConsensus<B, P = LocalPipeline> over the
Pipeline trait so implementations can be swapped.
Slim PipelineEntry to store only PrepareHeader; at commit
time on_ack fetches the full message from the journal.
