### PR TITLE
fix(connectors): prevent state loss on source connector restart

### DIFF
--- a/core/connectors/runtime/src/state.rs
+++ b/core/connectors/runtime/src/state.rs
@@ -102,6 +102,11 @@ impl StateProvider for FileStateProvider {
             Error::CannotWriteStateFile
         })?;
 
+        file.sync_all().await.map_err(|error| {
+            error!("Cannot sync state file: {}. {error}.", self.path);
+            Error::CannotWriteStateFile
+        })?;
+
         debug!("Saved state file: {}", self.path);
         Ok(())
     }


### PR DESCRIPTION
Source handler tasks were fire-and-forget (JoinHandle dropped),
so the tokio runtime could cancel them mid-state-save during
shutdown. FileStateProvider::save() uses a non-atomic truncate
then write sequence - cancellation between the two left the
state file empty. On restart the connector loaded no tracking
offsets and re-polled all rows from the source database.

Retain handler JoinHandles and await them (with timeout) after
dropping flume senders but before shutting down Iggy clients.
Also add sync_all() after write_all() in save() to ensure
data reaches disk before returning.
