### PR TITLE
ci(java): detect Netty ByteBuf memory leaks in CI tests

### DIFF
--- a/.github/actions/java-gradle/pre-merge/action.yml
+++ b/.github/actions/java-gradle/pre-merge/action.yml
@@ -93,6 +93,16 @@ runs:
         USE_EXTERNAL_SERVER: true
       run: ./gradlew test
 
+    - name: Check for ByteBuf leaks
+      if: ${{ !cancelled() && inputs.task == 'test' }}
+      shell: bash
+      run: |
+        if grep -r "LEAK:" foreign/java/java-sdk/build/test-results/ 2>/dev/null; then
+          echo "::error::Netty ByteBuf memory leaks detected in test output!"
+          exit 1
+        fi
+        echo "No ByteBuf leaks detected"
+
     - name: Generate coverage report
       if: inputs.task == 'test'
       shell: bash

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BaseIntegrationTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/BaseIntegrationTest.java
@@ -21,6 +21,7 @@ package org.apache.iggy.client;
 
 import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.Ulimit;
+import io.netty.util.ResourceLeakDetector;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.slf4j.Logger;
@@ -55,6 +56,7 @@ public abstract class BaseIntegrationTest {
 
     @BeforeAll
     static void setupContainer() {
+        ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
         if (!USE_EXTERNAL_SERVER) {
             log.info("Starting Iggy Server Container...");
             iggyServer = new GenericContainer<>(DockerImageName.parse("apache/iggy:edge"))


### PR DESCRIPTION
The Java SDK uses Netty ByteBuf for network I/O, but
leaks were not being caught during testing. Leaked
buffers can cause OOM failures in long-running
processes.

Enable Netty's PARANOID leak detector in integration
tests and add a CI step that scans test output for
LEAK markers, failing the build if any are found.