### PR TITLE
feat(bench): add --username/--password and reuse admin client

### DIFF
--- a/core/bench/src/actors/consumer/client/high_level.rs
+++ b/core/bench/src/actors/consumer/client/high_level.rs
@@ -24,7 +24,7 @@ use crate::actors::{
     },
 };
 
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use futures_util::StreamExt;
 use iggy::prelude::*;
 use std::{sync::Arc, time::Duration};
@@ -104,7 +104,12 @@ impl BenchmarkInit for HighLevelConsumerClient {
         let topic_id_str = "topic-1";
         let client = self.client_factory.create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory.username(),
+            self.client_factory.password(),
+        )
+        .await;
 
         let stream_id_str = self.config.stream_id.clone();
 

--- a/core/bench/src/actors/consumer/client/low_level.rs
+++ b/core/bench/src/actors/consumer/client/low_level.rs
@@ -20,7 +20,7 @@ use crate::actors::consumer::client::BenchmarkConsumerClient;
 use crate::actors::consumer::client::interface::{BenchmarkConsumerConfig, ConsumerClient};
 use crate::actors::{ApiLabel, BatchMetrics, BenchmarkInit};
 use crate::benchmarks::common::create_consumer;
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use crate::utils::{batch_total_size_bytes, batch_user_size_bytes};
 use iggy::prelude::*;
 use std::sync::Arc;
@@ -121,7 +121,12 @@ impl BenchmarkInit for LowLevelConsumerClient {
 
         let client = self.client_factory.create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory.username(),
+            self.client_factory.password(),
+        )
+        .await;
 
         let stream_id: Identifier = self.config.stream_id.as_str().try_into().unwrap();
         let topic_id = topic_id_str.try_into().unwrap();

--- a/core/bench/src/actors/producer/client/high_level.rs
+++ b/core/bench/src/actors/producer/client/high_level.rs
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use crate::{
     actors::{
         ApiLabel, BatchMetrics, BenchmarkInit,
@@ -84,7 +84,12 @@ impl BenchmarkInit for HighLevelProducerClient {
 
         let client = self.client_factory.create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory.username(),
+            self.client_factory.password(),
+        )
+        .await;
 
         let stream_id_str = self.config.stream_id.clone();
 

--- a/core/bench/src/actors/producer/client/low_level.rs
+++ b/core/bench/src/actors/producer/client/low_level.rs
@@ -18,7 +18,7 @@
 
 use std::sync::Arc;
 
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use crate::{
     actors::{
         ApiLabel, BatchMetrics, BenchmarkInit,
@@ -92,7 +92,12 @@ impl BenchmarkInit for LowLevelProducerClient {
 
         let client = self.client_factory.create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory.username(),
+            self.client_factory.password(),
+        )
+        .await;
 
         let partitioning = match partitions {
             0 => panic!("Partition count must be greater than 0"),

--- a/core/bench/src/analytics/report_builder.rs
+++ b/core/bench/src/analytics/report_builder.rs
@@ -19,7 +19,6 @@
 use std::{collections::HashMap, thread};
 
 use super::metrics::group::{from_individual_metrics, from_producers_and_consumers_statistics};
-use crate::utils::ClientFactory;
 use crate::utils::get_server_stats;
 use bench_report::{
     actor_kind::ActorKind,
@@ -31,8 +30,7 @@ use bench_report::{
     server_stats::{BenchmarkCacheMetrics, BenchmarkCacheMetricsKey, BenchmarkServerStats},
 };
 use chrono::{DateTime, Utc};
-use iggy::prelude::{CacheMetrics, CacheMetricsKey, IggyTimestamp, Stats};
-use std::sync::Arc;
+use iggy::prelude::{CacheMetrics, CacheMetricsKey, IggyClient, IggyTimestamp, Stats};
 
 pub struct BenchmarkReportBuilder;
 
@@ -43,7 +41,7 @@ impl BenchmarkReportBuilder {
         mut params: BenchmarkParams,
         mut individual_metrics: Vec<BenchmarkIndividualMetrics>,
         moving_average_window: u32,
-        client_factory: &Arc<dyn ClientFactory>,
+        admin_client: &IggyClient,
     ) -> BenchmarkReport {
         let uuid = uuid::Uuid::new_v4();
 
@@ -51,7 +49,7 @@ impl BenchmarkReportBuilder {
             DateTime::<Utc>::from_timestamp_micros(IggyTimestamp::now().as_micros() as i64)
                 .map_or_else(|| String::from("unknown"), |dt| dt.to_rfc3339());
 
-        let server_stats = get_server_stats(client_factory)
+        let server_stats = get_server_stats(admin_client)
             .await
             .expect("Failed to get server stats");
 

--- a/core/bench/src/args/common.rs
+++ b/core/bench/src/args/common.rs
@@ -30,7 +30,10 @@ use bench_report::benchmark_kind::BenchmarkKind;
 use bench_report::numeric_parameter::BenchmarkNumericParameter;
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser};
-use iggy::prelude::{IggyByteSize, IggyDuration, IggyExpiry, TransportProtocol};
+use iggy::prelude::{
+    DEFAULT_ROOT_PASSWORD, DEFAULT_ROOT_USERNAME, IggyByteSize, IggyDuration, IggyExpiry,
+    TransportProtocol,
+};
 use std::num::NonZeroU32;
 use std::str::FromStr;
 
@@ -47,7 +50,7 @@ pub struct IggyBenchArgs {
     pub message_size: BenchmarkNumericParameter,
 
     /// Number of messages per batch
-    #[arg(long, short = 'p', value_parser = BenchmarkNumericParameter::from_str, default_value_t = BenchmarkNumericParameter::Value(DEFAULT_MESSAGES_PER_BATCH.get()))]
+    #[arg(long, short = 'P', value_parser = BenchmarkNumericParameter::from_str, default_value_t = BenchmarkNumericParameter::Value(DEFAULT_MESSAGES_PER_BATCH.get()))]
     pub messages_per_batch: BenchmarkNumericParameter,
 
     /// Number of message batches per actor (producer / consumer / producing consumer).
@@ -80,6 +83,14 @@ pub struct IggyBenchArgs {
     /// Use high-level API for actors
     #[arg(long, short = 'H', default_value_t = false)]
     pub high_level_api: bool,
+
+    /// Username for server authentication
+    #[arg(long, short = 'u', default_value_t = DEFAULT_ROOT_USERNAME.to_string())]
+    pub username: String,
+
+    /// Password for server authentication
+    #[arg(long, short = 'p', default_value_t = DEFAULT_ROOT_PASSWORD.to_string())]
+    pub password: String,
 }
 
 impl IggyBenchArgs {
@@ -301,6 +312,14 @@ impl IggyBenchArgs {
 
     pub const fn high_level_api(&self) -> bool {
         self.high_level_api
+    }
+
+    pub fn username(&self) -> &str {
+        &self.username
+    }
+
+    pub fn password(&self) -> &str {
+        &self.password
     }
 
     /// Generates the output directory name based on benchmark parameters.

--- a/core/bench/src/args/examples.rs
+++ b/core/bench/src/args/examples.rs
@@ -50,7 +50,7 @@ const EXAMPLES: &str = r#"EXAMPLES:
     You can customize various parameters for any benchmark mode:
 
     Global options (before the benchmark command):
-    --messages-per-batch (-p): Number of messages per batch [default: 1000]
+    --messages-per-batch (-P): Number of messages per batch [default: 1000]
                                For random batch sizes, use range format: "100..1000"
     --message-batches (-b): Total number of batches [default: 1000]
     --total-messages-size (-T): Total size of messages to send (e.g., "1GB", "500MB")
@@ -61,6 +61,8 @@ const EXAMPLES: &str = r#"EXAMPLES:
     --warmup-time (-w): Warmup duration [default: 0s]
     --sampling-time (-t): Metrics sampling interval [default: 10ms]
     --moving-average-window (-W): Window size for moving average [default: 20]
+    --username (-u): Username for server authentication [default: iggy]
+    --password (-p): Password for server authentication [default: iggy]
 
     Benchmark-specific options (after the benchmark command):
     --streams (-s): Number of streams
@@ -120,6 +122,13 @@ const EXAMPLES: &str = r#"EXAMPLES:
 
     $ cargo r -r --bin iggy-bench -- pinned-producer \
         --streams 5 --producers 5 \
+        tcp --server-address 192.168.1.100:8090
+
+    With custom credentials:
+
+    $ cargo r -r --bin iggy-bench -- \
+        --username admin --password secret \
+        pinned-producer --streams 5 --producers 5 \
         tcp --server-address 192.168.1.100:8090
 
 6) Output Data and Results:

--- a/core/bench/src/benchmarks/benchmark.rs
+++ b/core/bench/src/benchmarks/benchmark.rs
@@ -17,7 +17,7 @@
  */
 
 use crate::args::kind::BenchmarkKindCommand;
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use crate::{args::common::IggyBenchArgs, utils::client_factory::create_client_factory};
 use async_trait::async_trait;
 use bench_report::benchmark_kind::BenchmarkKind;
@@ -99,7 +99,12 @@ pub trait Benchmarkable: Send {
         let partitions_count: u32 = self.args().number_of_partitions();
         let client = self.client_factory().create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory().username(),
+            self.client_factory().password(),
+        )
+        .await;
         let streams = client.get_streams().await?;
         for i in 1..=number_of_streams {
             let stream_name = format!("bench-stream-{i}");
@@ -139,7 +144,12 @@ pub trait Benchmarkable: Send {
         let number_of_streams = self.args().streams();
         let client = self.client_factory().create_client().await;
         let client = IggyClient::create(client, None, None);
-        login_root(&client).await;
+        authenticate(
+            &client,
+            self.client_factory().username(),
+            self.client_factory().password(),
+        )
+        .await;
         let streams = client.get_streams().await?;
         for i in 1..=number_of_streams {
             let stream_name = format!("bench-stream-{i}");

--- a/core/bench/src/benchmarks/common.rs
+++ b/core/bench/src/benchmarks/common.rs
@@ -17,7 +17,7 @@
  */
 
 use super::{CONSUMER_GROUP_BASE_ID, CONSUMER_GROUP_NAME_PREFIX};
-use crate::utils::{ClientFactory, login_root};
+use crate::utils::{ClientFactory, authenticate};
 use crate::{
     actors::{
         consumer::typed_benchmark_consumer::TypedBenchmarkConsumer,
@@ -76,7 +76,12 @@ pub async fn init_consumer_groups(
     let client = IggyClient::create(client, None, None);
     let cg_count = args.number_of_consumer_groups();
 
-    login_root(&client).await;
+    authenticate(
+        &client,
+        client_factory.username(),
+        client_factory.password(),
+    )
+    .await;
     for i in 1..=cg_count {
         let consumer_group_id = CONSUMER_GROUP_BASE_ID + i;
         let stream_name = format!("bench-stream-{i}");

--- a/core/bench/src/utils/mod.rs
+++ b/core/bench/src/utils/mod.rs
@@ -22,7 +22,7 @@ use bench_report::{
     transport::BenchmarkTransport,
 };
 use iggy::prelude::*;
-use std::{fs, path::Path, sync::Arc};
+use std::{fs, path::Path};
 use tracing::{error, info};
 
 use crate::args::{
@@ -37,7 +37,7 @@ use crate::args::{
     },
 };
 
-pub use client_factory::{ClientFactory, login_root};
+pub use client_factory::{ClientFactory, authenticate};
 
 pub mod batch_generator;
 pub mod client_factory;
@@ -61,30 +61,14 @@ pub fn batch_user_size_bytes(polled_messages: &PolledMessages) -> u64 {
         .sum()
 }
 
-pub async fn get_server_stats(client_factory: &Arc<dyn ClientFactory>) -> Result<Stats, IggyError> {
-    let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, None, None);
-
-    client.connect().await?;
-    client
-        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
-        .await?;
-
+pub async fn get_server_stats(client: &IggyClient) -> Result<Stats, IggyError> {
     client.get_stats().await
 }
 
 pub async fn collect_server_logs_and_save_to_file(
-    client_factory: &Arc<dyn ClientFactory>,
+    client: &IggyClient,
     output_dir: &Path,
 ) -> Result<(), IggyError> {
-    let client = client_factory.create_client().await;
-    let client = IggyClient::create(client, None, None);
-
-    client.connect().await?;
-    client
-        .login_user(DEFAULT_ROOT_USERNAME, DEFAULT_ROOT_PASSWORD)
-        .await?;
-
     let snapshot = client
         .snapshot(
             SnapshotCompression::Deflated,


### PR DESCRIPTION
Authentication was hardcoded to default root credentials and
post-benchmark operations created throwaway clients. Propagate
-u/-p credentials through ClientFactory, reuse a single admin
client in the runner. Reassign -p from --messages-per-batch
(now -P) to --password for iggy CLI compatibility.
