### PR TITLE
chore(repo): advance to year 2026

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/core/bench/dashboard/frontend/src/components/footer.rs
+++ b/core/bench/dashboard/frontend/src/components/footer.rs
@@ -32,7 +32,7 @@ pub fn footer() -> Html {
                 <span class="separator">{"|"}</span>
                 {"v"}{env!("CARGO_PKG_VERSION")}
                 <span class="separator">{"|"}</span>
-                {" 2025 Apache Iggy (Incubating). Built with ❤️ for the message streaming community."}
+                {" 2026 Apache Iggy (Incubating). Built with ❤️ for the message streaming community."}
             </div>
         </footer>
     }

--- a/foreign/csharp/NOTICE
+++ b/foreign/csharp/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/foreign/go/NOTICE
+++ b/foreign/go/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/foreign/java/NOTICE
+++ b/foreign/java/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/foreign/node/NOTICE
+++ b/foreign/node/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/foreign/python/NOTICE
+++ b/foreign/python/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/web/NOTICE
+++ b/web/NOTICE
@@ -1,5 +1,5 @@
 Apache Iggy (Incubating)
-Copyright 2025 The Apache Software Foundation
+Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Changes copyright year to 2026 from 2025 in `NOTICE.md` files. 