### PR TITLE
fix(server): report correct current_offset after segment deletion

### DIFF
--- a/core/server/src/shard/system/consumer_offsets.rs
+++ b/core/server/src/shard/system/consumer_offsets.rs
@@ -143,10 +143,7 @@ impl IggyShard {
         let partition_current_offset = self
             .metadata
             .get_partition_stats(&ns)
-            .map(|s| {
-                let count = s.messages_count_inconsistent();
-                if count > 0 { count - 1 } else { 0 }
-            })
+            .map(|s| s.current_offset())
             .unwrap_or(0);
 
         let offset = match polling_consumer {


### PR DESCRIPTION
get_consumer_offset derived partition_current_offset from
messages_count - 1. After segment deletion, messages_count
is decremented but the partition offset is immutable, so
clients saw a stale value (e.g. 17 instead of 24 after
deleting 7 messages). Use current_offset() directly since
it reflects the true highest offset written.
