### PR TITLE
fix(ci): pass Codecov token to C# and Java test jobs

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -110,6 +110,8 @@ jobs:
     with:
       component: ${{ matrix.component }}
       task: ${{ matrix.task }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # C# SDK
   test-csharp:
@@ -123,6 +125,8 @@ jobs:
     with:
       component: ${{ matrix.component }}
       task: ${{ matrix.task }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Other components
   test-other:


### PR DESCRIPTION
Coverage uploads from these jobs silently failed because
the reusable _test.yml workflow received no token. Only
the Rust job had the secrets block, so Codecov never
posted PR comments for C# or Java changes.
