### PR TITLE
fix(ci): unblock wheel collection when Windows is disabled

### DIFF
--- a/.github/workflows/_build_python_wheels.yml
+++ b/.github/workflows/_build_python_wheels.yml
@@ -237,7 +237,8 @@ jobs:
 
   collect:
     name: Collect all wheels
-    needs: [linux, macos, windows, sdist]
+    needs: [linux, macos, sdist] # TODO(hubcio): add windows back when re-enabled
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     outputs:
       artifact_name: ${{ steps.output.outputs.artifact_name }}


### PR DESCRIPTION
Skipping the windows job propagates to collect via needs,
so python-wheels-all was never uploaded.
