### PR TITLE
fix(integration): prevent flaky connector sink tests from f64 round-trip mismatch

### DIFF
--- a/core/integration/tests/connectors/mod.rs
+++ b/core/integration/tests/connectors/mod.rs
@@ -49,7 +49,7 @@ pub fn create_test_messages(count: usize) -> Vec<TestMessage> {
             id: i as u64,
             name: format!("user_{}", i - 1),
             count: ((i - 1) * 10) as u32,
-            amount: (i - 1) as f64 * 99.99,
+            amount: (i - 1) as f64 * 100.0,
             active: (i - 1) % 2 == 0,
             timestamp: (base_timestamp + (i - 1) as u64 * ONE_DAY_MICROS) as i64,
         })


### PR DESCRIPTION
The serde_json (Ryu) and simd_json serializers format
non-exact f64 values differently. Multiplying by 99.99
produced values like 1099.89 that round-tripped as
1099.8899999999999 through the connector SDK's
simd_json path, causing assertion failures in Quickwit
sink tests.

Multiplying by 100.0 produces exact integers (0.0,
100.0, 200.0, ...) that all IEEE 754 serializers
represent identically.
