### PR TITLE
fix(ci): prevent v8/musl build failures in artifacts and Docker

### DIFF
--- a/.github/workflows/_build_rust_artifacts.yml
+++ b/.github/workflows/_build_rust_artifacts.yml
@@ -145,11 +145,10 @@ jobs:
           fi
 
           # iggy-bench-dashboard-server enables charming's "ssr" feature (deno_core -> v8).
-          # v8 has no prebuilt binary for aarch64-unknown-linux-musl, so exclude dashboard
-          # crates to prevent cargo feature unification from pulling V8 into unrelated binaries.
-          # TODO: build V8 from source (V8_FROM_SOURCE=1, ~30min + clang) or wait for upstream support.
+          # rusty_v8 has no prebuilt static libraries for any musl target, so exclude
+          # dashboard crates to prevent cargo feature unification from pulling V8.
           exclude_flags=()
-          if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]]; then
+          if [[ "${{ matrix.libc }}" == "musl" ]]; then
             exclude_flags+=(--workspace --exclude iggy-bench-dashboard-server --exclude bench-dashboard-frontend)
           fi
 

--- a/core/ai/mcp/Dockerfile
+++ b/core/ai/mcp/Dockerfile
@@ -57,9 +57,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported platform/libc combination: $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild \
+      -p iggy-mcp; \
     else \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release \
+      -p iggy-mcp; \
     fi
 
 COPY . .

--- a/core/connectors/runtime/Dockerfile
+++ b/core/connectors/runtime/Dockerfile
@@ -60,9 +60,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported platform/libc combination: $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild \
+      -p iggy-connectors; \
     else \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release \
+      -p iggy-connectors; \
     fi
 
 COPY . .

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -58,9 +58,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
     *) echo "Unsupported $TARGETPLATFORM/$LIBC" && exit 1 ;; \
     esac && \
     if [ "$PROFILE" = "debug" ]; then \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild \
+      -p server -p iggy-cli; \
     else \
-    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release; \
+    cargo chef cook --recipe-path recipe.json --target ${RUST_TARGET} --zigbuild --release \
+      -p server -p iggy-cli; \
     fi
 
 COPY . .


### PR DESCRIPTION
charming's "ssr" feature pulls deno_core -> rusty_v8, which
has no prebuilt static libraries for any musl target. The
bench-dashboard exclusion only covered aarch64-musl, leaving
x86_64-musl broken after #2833 added the ssr feature.

Extend the musl exclusion to all musl targets in the artifact
build. Scope each Dockerfile's cargo-chef cook to only the
packages it ships (-p), avoiding workspace-wide feature
unification that drags in v8 for images that never use it.
