### PR TITLE
fix(server): resolve FIXMEs in bootstrap and shard

### DIFF
--- a/core/server/src/bootstrap.rs
+++ b/core/server/src/bootstrap.rs
@@ -176,10 +176,10 @@ pub fn create_shard_executor() -> Runtime {
         .coop_taskrun(true)
         .taskrun_flag(true);
 
-    // FIXME(hubcio): Only set thread_pool_limit(0) on non-macOS platforms
+    // Only set thread_pool_limit(0) on non-macOS platforms.
     // This causes a freeze on macOS with compio fs operations
     // see https://github.com/compio-rs/compio/issues/446
-    #[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+    #[cfg(not(target_os = "macos"))]
     proactor.thread_pool_limit(0);
 
     compio::runtime::RuntimeBuilder::new()

--- a/core/server/src/shard/mod.rs
+++ b/core/server/src/shard/mod.rs
@@ -179,9 +179,6 @@ impl IggyShard {
         info!("Starting...");
         self.init().await?;
 
-        // TODO: Fixme
-        //self.assert_init();
-
         self.init_tasks();
         let (shutdown_complete_tx, shutdown_complete_rx) = async_channel::bounded(1);
         let stop_receiver = self.get_stop_receiver();


### PR DESCRIPTION
- bootstrap: apply thread_pool_limit(0) only on non-macOS (was only excluding macos+aarch64); removes FIXME and avoids compio freeze on all macOS (see compio-rs/compio#446)
- shard: remove obsolete 'TODO: Fixme' and commented assert_init() in run()

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

Closes #

## Rationale

<!--
Why is this change needed? If the issue explains it well, a one-liner is fine.
-->

## What changed?

<!--
2-4 sentences. Problem first (before), then solution (after).

GOOD:

"Messages were unavailable when background message_saver committed the
journal and started async disk I/O before completion. Polling during
this window found neither journal nor disk data.

The fix freezes journal batches in the in-flight buffer before async persist."

GOOD:

"When many small messages accumulate in the journal, the flush passes
thousands of IO vectors to writev(), exceeding IOV_MAX (1024 on Linux)."

BAD:
- Walls of text
- "This PR adds..." (we can see the diff)
-->

## Local Execution

- Passed / not passed
- Pre-commit hooks ran / not ran

<!--
You must run your code locally before submitting.
"Relying on CI" is not acceptable - PRs from authors who haven't run the code will be closed.

Did you have `prek` installed? It runs automatically on commit and covers all project languages. See [CONTRIBUTING.md](https://github.com/apache/iggy/blob/master/CONTRIBUTING.md).
-->

## AI Usage

<!--
If AI tools were used, please answer:
1. Which tools? (e.g., GitHub Copilot, Claude, ChatGPT)
2. Scope of usage? (e.g., autocomplete, generated functions, entire implementation)
3. How did you verify the generated code works correctly?
4. Can you explain every line of the code if asked?

If no AI tools were used, write "None" or delete this section.
-->
