### PR TITLE
ci: add --no-format to cargo sort check

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Cargo sort
       if: inputs.task == 'sort'
-      run: cargo sort --check --workspace
+      run: cargo sort --check --no-format --workspace
       shell: bash
 
     - name: Cargo machete

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -131,7 +131,7 @@ repos:
 
       - id: cargo-sort
         name: cargo sort
-        entry: cargo sort --workspace
+        entry: cargo sort --no-format --workspace
         language: system
         files: (^|/)Cargo\.toml$
         pass_filenames: false


### PR DESCRIPTION
Prevents conflict with taplo which enforces multi-line
arrays via array_auto_expand in .taplo.toml.
