### PR TITLE
fix(ci): fix gnome-keyring locking mid-test in CI

### DIFF
--- a/.github/actions/rust/pre-merge/action.yml
+++ b/.github/actions/rust/pre-merge/action.yml
@@ -94,9 +94,11 @@ runs:
     - name: Install dependencies for Rust tests
       if: inputs.task == 'test' && runner.os == 'Linux'
       run: |
-        sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils
+        sudo apt-get update --yes && sudo apt-get install --yes musl-tools gnome-keyring keyutils dbus-x11
         rm -f $HOME/.local/share/keyrings/*
-        echo -n "test" | gnome-keyring-daemon --unlock
+        eval $(dbus-launch --sh-syntax)
+        echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
+        echo -n "test" | gnome-keyring-daemon --unlock --components=secrets
       shell: bash
 
     - name: Install cargo-llvm-cov

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -188,9 +188,11 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes gnome-keyring keyutils
+          sudo apt-get install --yes gnome-keyring keyutils dbus-x11
           rm -f $HOME/.local/share/keyrings/*
-          echo -n "test" | gnome-keyring-daemon --unlock
+          eval $(dbus-launch --sh-syntax)
+          echo "DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" >> $GITHUB_ENV
+          echo -n "test" | gnome-keyring-daemon --unlock --components=secrets
 
       - name: Setup Rust with cache
         uses: ./.github/actions/utils/setup-rust-with-cache


### PR DESCRIPTION
gnome-keyring-daemon unlocked without a persistent
D-Bus session bus lost its unlock state before CLI
keyring tests ran, causing "Cannot create an item in
a locked collection" failures.

Start an explicit dbus-launch session, export the bus
address via GITHUB_ENV so all subsequent steps share
it, and scope the daemon to the secrets component.
