### PR TITLE
feat(go): implement TCP/TLS connection in Go SDK

### DIFF
--- a/foreign/go/client/tcp/tcp_core.go
+++ b/foreign/go/client/tcp/tcp_core.go
@@ -18,10 +18,12 @@
 package tcp
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"net"
+	"os"
 	"sync"
 	"time"
 
@@ -296,7 +298,6 @@ func (c *IggyTcpClient) connect() error {
 		}
 	}
 
-	// TODO handle tls logic
 	var conn net.Conn
 	if err := retry.Do(
 		func() error {
@@ -325,8 +326,42 @@ func (c *IggyTcpClient) connect() error {
 				return nil
 			}
 
-			// TODO TLS logic
-			return errors.New("TLS connection is not implemented yet")
+			// Build TLS configuration.
+			tlsServerName := c.config.tlsDomain
+			if tlsServerName == "" {
+				// Extract hostname/IP from serverAddress when tlsDomain is not set.
+				host, _, splitErr := net.SplitHostPort(c.currentServerAddress)
+				if splitErr == nil {
+					tlsServerName = host
+				} else {
+					tlsServerName = c.currentServerAddress
+				}
+			}
+
+			tlsCfg := &tls.Config{
+				ServerName:         tlsServerName,
+				InsecureSkipVerify: !c.config.tlsValidateCertificate, //nolint:gosec
+			}
+
+			if c.config.tlsCAFile != "" {
+				caCert, err := os.ReadFile(c.config.tlsCAFile)
+				if err != nil {
+					return fmt.Errorf("failed to read TLS CA file %q: %w", c.config.tlsCAFile, err)
+				}
+				caCertPool := x509.NewCertPool()
+				if !caCertPool.AppendCertsFromPEM(caCert) {
+					return fmt.Errorf("failed to parse TLS CA certificate from %q", c.config.tlsCAFile)
+				}
+				tlsCfg.RootCAs = caCertPool
+			}
+
+			tlsConn := tls.Client(connection, tlsCfg)
+			if err := tlsConn.Handshake(); err != nil {
+				_ = tlsConn.Close()
+				return fmt.Errorf("TLS handshake failed: %w", err)
+			}
+			conn = tlsConn
+			return nil
 		},
 		retry.Attempts(uint(c.config.reconnection.maxRetries)),
 		retry.Delay(c.config.reconnection.interval),


### PR DESCRIPTION
Replace the stub 'TLS connection is not implemented yet' error with a full stdlib crypto/tls implementation:
  - ServerName derived from tlsDomain or extracted via net.SplitHostPort
  - InsecureSkipVerify controlled by tlsValidateCertificate config field
  - Optional custom CA cert pool loaded from tlsCAFile
  - tls.Client wrap + explicit Handshake with clean error propagation

  No external dependencies added (stdlib crypto/tls only), consistent with the Rust and Node.js TLS implementations.

  ## Which issue does this PR close?

  Closes #2824

  ## Rationale

  The Go SDK was the only client without a working TLS implementation. Any user trying to connect to a TLS-enabled iggy server from Go would get an immediate hard error at connection
  time.

  ## What changed?

  `tcp_core.go` had a single-line stub returning `errors.New("TLS connection is not implemented yet")`. The plain TCP path was already complete; TLS just needed to wrap the established
  connection.

  The fix wraps the `net.Conn` with `tls.Client()` after the plain TCP dial, derives `ServerName` from `tlsDomain` or falls back to `net.SplitHostPort`, respects `tlsValidateCertificate`
  for cert validation, and optionally loads a custom CA pool from `tlsCAFile`. All four existing config fields are now wired up with no new fields or dependencies added.

  ## Local Execution

  - `go build ./...` — passed
  - `golangci-lint run` — passed, 0 issues
  - BDD tests (Docker) — not run. Happy to add those tests if required.

  ## AI Usage

  1. **Tools:** Claude (claude-sonnet-4-6) via Claude Code + yoyo (local code-intelligence MCP server)
  2. **Scope:** Entire implementation. yoyo was used to read the existing codebase and cross-reference the Rust (`tcp_tls_connection_stream.rs`) and Node.js (`client.connection.ts`) TLS
  implementations. Claude generated the Go implementation based on those patterns.
  3. **Verification:** `go build ./...` and `golangci-lint run` both pass. The logic mirrors the working Rust and Node.js SDKs line-for-line in terms of intent.
  4. **Explainability:** Yes, every line is explainable. I don't know the iggy codebase deeply but I understand the Go TLS code fully.