### PR TITLE
feat(message_bus): add drain with routing metadata and backpressure

### DIFF
--- a/core/message_bus/src/lib.rs
+++ b/core/message_bus/src/lib.rs
@@ -20,7 +20,24 @@ use crate::cache::connection::{
     ConnectionCache, Coordinator, LeastLoadedStrategy, ShardedConnections,
 };
 use iggy_common::{IggyError, SenderKind, TcpSender, header::GenericHeader, message::Message};
-use std::{collections::HashMap, rc::Rc};
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::rc::Rc;
+
+/// Maximum number of messages that can be buffered in the outbox before delivery.
+/// Overflow is a logic error (pump loop not draining). Matches the assert pattern
+/// used by `VsrConsensus::push_loopback` in `core/consensus/src/impls.rs`.
+const OUTBOX_CAPACITY_MAX: usize = 128;
+
+/// Routing target for a message drained from the bus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Recipient<C, R> {
+    Client(C),
+    Replica(R),
+}
+
+/// An outbound message paired with its intended [`Recipient`].
+pub type Outbound<C, R, D> = (Recipient<C, R>, D);
 
 /// Message bus parameterized by allocation strategy and sharded state
 pub trait MessageBus {
@@ -35,7 +52,7 @@ pub trait MessageBus {
     fn add_replica(&mut self, replica: Self::Replica) -> bool;
     fn remove_replica(&mut self, replica: Self::Replica) -> bool;
 
-    // TODO: refactor consesus headers.
+    // TODO: refactor consensus headers.
     fn send_to_client(
         &self,
         client_id: Self::Client,
@@ -46,6 +63,12 @@ pub trait MessageBus {
         replica: Self::Replica,
         data: Self::Data,
     ) -> impl Future<Output = Result<(), IggyError>>;
+
+    /// Drain all buffered outbound messages into `buf`, leaving the internal queue empty.
+    ///
+    /// Each entry pairs the message with its intended [`Recipient`].
+    /// The caller is responsible for dispatching them to their targets.
+    fn drain(&self, _buf: &mut Vec<Outbound<Self::Client, Self::Replica, Self::Data>>) {}
 }
 
 // TODO: explore generics for Strategy
@@ -54,6 +77,7 @@ pub struct IggyMessageBus {
     clients: HashMap<u128, SenderKind>,
     replicas: ShardedConnections<LeastLoadedStrategy, ConnectionCache>,
     shard_id: u16,
+    outbox: RefCell<VecDeque<Outbound<u128, u8, Message<GenericHeader>>>>,
 }
 
 impl IggyMessageBus {
@@ -69,6 +93,7 @@ impl IggyMessageBus {
                 },
             },
             shard_id,
+            outbox: RefCell::new(VecDeque::with_capacity(OUTBOX_CAPACITY_MAX)),
         }
     }
 
@@ -112,25 +137,118 @@ impl MessageBus for IggyMessageBus {
     async fn send_to_client(
         &self,
         client_id: Self::Client,
-        _message: Self::Data,
+        message: Self::Data,
     ) -> Result<(), IggyError> {
         #[allow(clippy::cast_possible_truncation)] // IggyError::ClientNotFound takes u32
         let _sender = self
             .clients
             .get(&client_id)
             .ok_or(IggyError::ClientNotFound(client_id as u32))?;
+        let mut outbox = self.outbox.borrow_mut();
+        assert!(
+            outbox.len() < OUTBOX_CAPACITY_MAX,
+            "outbox overflow: {} items",
+            outbox.len()
+        );
+        outbox.push_back((Recipient::Client(client_id), message));
         Ok(())
     }
 
     async fn send_to_replica(
         &self,
         replica: Self::Replica,
-        _message: Self::Data,
+        message: Self::Data,
     ) -> Result<(), IggyError> {
         // TODO: Handle lazily creating the connection.
         let _connection = self
             .get_replica_connection(replica)
             .ok_or(IggyError::ResourceNotFound(format!("Replica {replica}")))?;
+        let mut outbox = self.outbox.borrow_mut();
+        assert!(
+            outbox.len() < OUTBOX_CAPACITY_MAX,
+            "outbox overflow: {} items",
+            outbox.len()
+        );
+        outbox.push_back((Recipient::Replica(replica), message));
         Ok(())
+    }
+
+    fn drain(&self, buf: &mut Vec<Outbound<Self::Client, Self::Replica, Self::Data>>) {
+        buf.extend(self.outbox.borrow_mut().drain(..));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_message() -> Message<GenericHeader> {
+        Message::<GenericHeader>::new(std::mem::size_of::<GenericHeader>())
+    }
+
+    #[test]
+    fn drain_empty_yields_nothing() {
+        let bus = IggyMessageBus::new(1, 0, 42);
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn double_drain_second_empty() {
+        let bus = IggyMessageBus::new(1, 0, 42);
+        bus.outbox
+            .borrow_mut()
+            .push_back((Recipient::Client(0), make_message()));
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+
+        buf.clear();
+        bus.drain(&mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drain_preserves_client_routing() {
+        let bus = IggyMessageBus::new(1, 0, 42);
+        bus.outbox
+            .borrow_mut()
+            .push_back((Recipient::Client(42), make_message()));
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0].0, Recipient::Client(42));
+    }
+
+    #[test]
+    fn drain_preserves_replica_routing() {
+        let bus = IggyMessageBus::new(1, 0, 42);
+        bus.outbox
+            .borrow_mut()
+            .push_back((Recipient::Replica(3), make_message()));
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0].0, Recipient::Replica(3));
+    }
+
+    #[test]
+    fn client_and_replica_preserves_fifo_order() {
+        let bus = IggyMessageBus::new(1, 0, 42);
+        {
+            let mut outbox = bus.outbox.borrow_mut();
+            outbox.push_back((Recipient::Client(10), make_message()));
+            outbox.push_back((Recipient::Replica(1), make_message()));
+        }
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf[0].0, Recipient::Client(10));
+        assert_eq!(buf[1].0, Recipient::Replica(1));
     }
 }

--- a/core/simulator/src/bus.rs
+++ b/core/simulator/src/bus.rs
@@ -16,7 +16,7 @@
 // under the License.
 
 use iggy_common::{IggyError, header::GenericHeader, message::Message};
-use message_bus::MessageBus;
+use message_bus::{MessageBus, Outbound, Recipient};
 use std::collections::{HashSet, VecDeque};
 use std::ops::Deref;
 use std::sync::{Arc, Mutex};
@@ -51,7 +51,7 @@ impl MemBus {
         }
     }
 
-    /// Get the next pending message from the bus
+    /// Get the next pending message from the bus.
     ///
     /// # Panics
     /// Panics if the internal mutex is poisoned.
@@ -67,11 +67,7 @@ impl MessageBus for MemBus {
     type Sender = ();
 
     fn add_client(&mut self, client: Self::Client, _sender: Self::Sender) -> bool {
-        if self.clients.lock().unwrap().contains(&client) {
-            return false;
-        }
-        self.clients.lock().unwrap().insert(client);
-        true
+        self.clients.lock().unwrap().insert(client)
     }
 
     fn remove_client(&mut self, client: Self::Client) -> bool {
@@ -79,11 +75,7 @@ impl MessageBus for MemBus {
     }
 
     fn add_replica(&mut self, replica: Self::Replica) -> bool {
-        if self.replicas.lock().unwrap().contains(&replica) {
-            return false;
-        }
-        self.replicas.lock().unwrap().insert(replica);
-        true
+        self.replicas.lock().unwrap().insert(replica)
     }
 
     fn remove_replica(&mut self, replica: Self::Replica) -> bool {
@@ -127,6 +119,25 @@ impl MessageBus for MemBus {
         });
 
         Ok(())
+    }
+
+    fn drain(&self, buf: &mut Vec<Outbound<Self::Client, Self::Replica, Self::Data>>) {
+        buf.extend(
+            self.pending_messages
+                .lock()
+                .unwrap()
+                .drain(..)
+                .map(|envelope| {
+                    let recipient = if let Some(client) = envelope.to_client {
+                        Recipient::Client(client)
+                    } else if let Some(replica) = envelope.to_replica {
+                        Recipient::Replica(replica)
+                    } else {
+                        unreachable!("envelope must have either to_client or to_replica set")
+                    };
+                    (recipient, envelope.message)
+                }),
+        );
     }
 }
 
@@ -177,5 +188,112 @@ impl MessageBus for SharedMemBus {
         message: Self::Data,
     ) -> Result<(), IggyError> {
         self.0.send_to_replica(replica, message).await
+    }
+
+    fn drain(&self, buf: &mut Vec<Outbound<Self::Client, Self::Replica, Self::Data>>) {
+        self.0.drain(buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iggy_common::header::GenericHeader;
+
+    fn make_message() -> Message<GenericHeader> {
+        Message::<GenericHeader>::new(std::mem::size_of::<GenericHeader>())
+    }
+
+    #[test]
+    fn drain_empty_yields_nothing() {
+        let bus = MemBus::new();
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn send_to_replica_then_drain() {
+        let mut bus = MemBus::new();
+        bus.add_replica(0);
+
+        futures::executor::block_on(bus.send_to_replica(0, make_message())).unwrap();
+        futures::executor::block_on(bus.send_to_replica(0, make_message())).unwrap();
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf[0].0, Recipient::Replica(0));
+        assert_eq!(buf[1].0, Recipient::Replica(0));
+    }
+
+    #[test]
+    fn send_to_client_then_drain() {
+        let mut bus = MemBus::new();
+        bus.add_client(42, ());
+
+        futures::executor::block_on(bus.send_to_client(42, make_message())).unwrap();
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0].0, Recipient::Client(42));
+    }
+
+    #[test]
+    fn double_drain_second_empty() {
+        let mut bus = MemBus::new();
+        bus.add_replica(0);
+
+        futures::executor::block_on(bus.send_to_replica(0, make_message())).unwrap();
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+
+        buf.clear();
+        bus.drain(&mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn send_to_unknown_replica_errors_and_drain_empty() {
+        let bus = MemBus::new();
+        let result = futures::executor::block_on(bus.send_to_replica(99, make_message()));
+        assert!(result.is_err());
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn drain_preserves_routing() {
+        let mut bus = MemBus::new();
+        bus.add_replica(1);
+        bus.add_client(42, ());
+
+        futures::executor::block_on(bus.send_to_replica(1, make_message())).unwrap();
+        futures::executor::block_on(bus.send_to_client(42, make_message())).unwrap();
+
+        let mut buf = Vec::new();
+        bus.drain(&mut buf);
+        assert_eq!(buf.len(), 2);
+        assert_eq!(buf[0].0, Recipient::Replica(1));
+        assert_eq!(buf[1].0, Recipient::Client(42));
+    }
+
+    #[test]
+    fn shared_mem_bus_drain_delegates() {
+        let bus = Arc::new(MemBus::new());
+        let mut shared = SharedMemBus(bus);
+        shared.add_replica(0);
+
+        futures::executor::block_on(shared.send_to_replica(0, make_message())).unwrap();
+
+        let mut buf = Vec::new();
+        shared.drain(&mut buf);
+        assert_eq!(buf.len(), 1);
+        assert_eq!(buf[0].0, Recipient::Replica(0));
     }
 }


### PR DESCRIPTION
MessageBus had send_to_client/send_to_replica but no batched
retrieval for delivery. Add drain(&self, buf) following the
drain_loopback_into pattern. Each entry pairs the message
with a Recipient<C,R> enum so callers can route by target.
Outbox bounded by OUTBOX_CAPACITY_MAX with assert-on-push.