### PR TITLE
refactor(java): replace JUnit assertions with AssertJ across all tests

### DIFF
--- a/foreign/java/README.md
+++ b/foreign/java/README.md
@@ -234,5 +234,6 @@ Before opening a pull request:
 
 1. **Format code:** `./gradlew spotlessApply`
 2. **Validate build:** `./gradlew check`
+3. **Use AssertJ for assertions:** Tests should use [AssertJ](https://assertj.github.io/doc/) (`assertThat(...)`) instead of JUnit assertions.
 
 This ensures code style compliance and that all tests and checkstyle validations pass.

--- a/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/config/IggyStreamConfigTest.java
+++ b/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/config/IggyStreamConfigTest.java
@@ -25,10 +25,8 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class IggyStreamConfigTest {
 
@@ -38,16 +36,16 @@ class IggyStreamConfigTest {
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
-        assertEquals("localhost", config.getHost());
-        assertEquals(8090, config.getPort());
-        assertEquals("iggy", config.getUsername());
-        assertEquals("iggy", config.getPassword());
-        assertEquals("analytics", config.getStreamId());
-        assertEquals("events", config.getTopicId());
-        assertEquals("test-consumer-group", config.getConsumerGroup());
-        assertEquals(100, config.getPollBatchSize());
-        assertEquals(4, config.getConnectionPoolSize());
-        assertFalse(config.isEnableTls());
+        assertThat(config.getHost()).isEqualTo("localhost");
+        assertThat(config.getPort()).isEqualTo(8090);
+        assertThat(config.getUsername()).isEqualTo("iggy");
+        assertThat(config.getPassword()).isEqualTo("iggy");
+        assertThat(config.getStreamId()).isEqualTo("analytics");
+        assertThat(config.getTopicId()).isEqualTo("events");
+        assertThat(config.getConsumerGroup()).isEqualTo("test-consumer-group");
+        assertThat(config.getPollBatchSize()).isEqualTo(100);
+        assertThat(config.getConnectionPoolSize()).isEqualTo(4);
+        assertThat(config.isEnableTls()).isFalse();
     }
 
     @Test
@@ -63,12 +61,12 @@ class IggyStreamConfigTest {
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
-        assertEquals(9090, config.getPort());
-        assertEquals("custom-user", config.getUsername());
-        assertEquals("custom-pass", config.getPassword());
-        assertEquals(500, config.getPollBatchSize());
-        assertEquals(8, config.getConnectionPoolSize());
-        assertTrue(config.isEnableTls());
+        assertThat(config.getPort()).isEqualTo(9090);
+        assertThat(config.getUsername()).isEqualTo("custom-user");
+        assertThat(config.getPassword()).isEqualTo("custom-pass");
+        assertThat(config.getPollBatchSize()).isEqualTo(500);
+        assertThat(config.getConnectionPoolSize()).isEqualTo(8);
+        assertThat(config.isEnableTls()).isTrue();
     }
 
     @Test
@@ -78,10 +76,9 @@ class IggyStreamConfigTest {
 
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
 
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new IggyStreamConfig(streamConfig));
-
-        assertTrue(exception.getMessage().contains("host"));
+        assertThatThrownBy(() -> new IggyStreamConfig(streamConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("host");
     }
 
     @Test
@@ -91,10 +88,9 @@ class IggyStreamConfigTest {
 
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
 
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new IggyStreamConfig(streamConfig));
-
-        assertTrue(exception.getMessage().contains("stream ID"));
+        assertThatThrownBy(() -> new IggyStreamConfig(streamConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("stream ID");
     }
 
     @Test
@@ -104,10 +100,9 @@ class IggyStreamConfigTest {
 
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
 
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new IggyStreamConfig(streamConfig));
-
-        assertTrue(exception.getMessage().contains("topic ID"));
+        assertThatThrownBy(() -> new IggyStreamConfig(streamConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("topic ID");
     }
 
     @Test
@@ -117,10 +112,9 @@ class IggyStreamConfigTest {
 
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
 
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> new IggyStreamConfig(streamConfig));
-
-        assertTrue(exception.getMessage().contains("consumer group"));
+        assertThatThrownBy(() -> new IggyStreamConfig(streamConfig))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("consumer group");
     }
 
     @Test
@@ -129,7 +123,7 @@ class IggyStreamConfigTest {
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
-        assertEquals("localhost:8090", config.getServerAddress());
+        assertThat(config.getServerAddress()).isEqualTo("localhost:8090");
     }
 
     @Test
@@ -138,7 +132,7 @@ class IggyStreamConfigTest {
         StreamConfig streamConfig = new StreamConfig("events_REALTIME", props);
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
-        assertEquals("events_REALTIME", config.getTableNameWithType());
+        assertThat(config.getTableNameWithType()).isEqualTo("events_REALTIME");
     }
 
     @Test
@@ -148,11 +142,12 @@ class IggyStreamConfigTest {
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
         String str = config.toString();
-        assertTrue(str.contains("localhost"));
-        assertTrue(str.contains("8090"));
-        assertTrue(str.contains("analytics"));
-        assertTrue(str.contains("events"));
-        assertTrue(str.contains("test-consumer-group"));
+        assertThat(str)
+                .contains("localhost")
+                .contains("8090")
+                .contains("analytics")
+                .contains("events")
+                .contains("test-consumer-group");
     }
 
     @Test
@@ -164,8 +159,8 @@ class IggyStreamConfigTest {
         StreamConfig streamConfig = new StreamConfig("test_table_REALTIME", props);
         IggyStreamConfig config = new IggyStreamConfig(streamConfig);
 
-        assertEquals("123", config.getStreamId());
-        assertEquals("456", config.getTopicId());
+        assertThat(config.getStreamId()).isEqualTo("123");
+        assertThat(config.getTopicId()).isEqualTo("456");
     }
 
     private Map<String, String> createValidConfig() {

--- a/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/consumer/IggyMessageBatchTest.java
+++ b/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/consumer/IggyMessageBatchTest.java
@@ -25,16 +25,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class IggyMessageBatchTest {
 
     @Test
     void testEmptyBatch() {
         IggyMessageBatch batch = new IggyMessageBatch(new ArrayList<>());
-        assertEquals(0, batch.getMessageCount());
+        assertThat(batch.getMessageCount()).isEqualTo(0);
     }
 
     @Test
@@ -46,11 +44,11 @@ class IggyMessageBatchTest {
 
         IggyMessageBatch batch = new IggyMessageBatch(messages);
 
-        assertEquals(1, batch.getMessageCount());
-        assertArrayEquals(payload, batch.getMessageAtIndex(0));
-        assertEquals(payload.length, batch.getMessageLengthAtIndex(0));
-        assertEquals(100L, batch.getNextStreamMessageOffsetAtIndex(0));
-        assertEquals(offset, batch.getNextStreamPartitionMsgOffsetAtIndex(0));
+        assertThat(batch.getMessageCount()).isEqualTo(1);
+        assertThat(batch.getMessageAtIndex(0)).isEqualTo(payload);
+        assertThat(batch.getMessageLengthAtIndex(0)).isEqualTo(payload.length);
+        assertThat(batch.getNextStreamMessageOffsetAtIndex(0)).isEqualTo(100L);
+        assertThat(batch.getNextStreamPartitionMsgOffsetAtIndex(0)).isEqualTo(offset);
     }
 
     @Test
@@ -65,14 +63,14 @@ class IggyMessageBatchTest {
 
         IggyMessageBatch batch = new IggyMessageBatch(messages);
 
-        assertEquals(10, batch.getMessageCount());
+        assertThat(batch.getMessageCount()).isEqualTo(10);
 
         for (int i = 0; i < 10; i++) {
             byte[] expectedPayload = ("message-" + i).getBytes(StandardCharsets.UTF_8);
-            assertArrayEquals(expectedPayload, batch.getMessageAtIndex(i));
-            assertEquals(expectedPayload.length, batch.getMessageLengthAtIndex(i));
-            assertEquals(i * 100L, batch.getNextStreamMessageOffsetAtIndex(i));
-            assertEquals(i, batch.getMessageOffsetAtIndex(i));
+            assertThat(batch.getMessageAtIndex(i)).isEqualTo(expectedPayload);
+            assertThat(batch.getMessageLengthAtIndex(i)).isEqualTo(expectedPayload.length);
+            assertThat(batch.getNextStreamMessageOffsetAtIndex(i)).isEqualTo(i * 100L);
+            assertThat(batch.getMessageOffsetAtIndex(i)).isEqualTo(i);
         }
     }
 
@@ -83,9 +81,9 @@ class IggyMessageBatchTest {
 
         IggyMessageBatch.IggyMessageAndOffset wrapper = new IggyMessageBatch.IggyMessageAndOffset(payload, offset);
 
-        assertArrayEquals(payload, wrapper.getMessage());
-        assertEquals(offset, wrapper.getOffset());
-        assertEquals(123L, wrapper.getOffset().getOffset());
+        assertThat(wrapper.getMessage()).isEqualTo(payload);
+        assertThat(wrapper.getOffset()).isEqualTo(offset);
+        assertThat(wrapper.getOffset().getOffset()).isEqualTo(123L);
     }
 
     @Test
@@ -97,10 +95,10 @@ class IggyMessageBatchTest {
 
         IggyMessageBatch batch = new IggyMessageBatch(messages);
 
-        assertNull(batch.getNextStreamPartitionMsgOffsetAtIndex(-1));
-        assertNull(batch.getNextStreamPartitionMsgOffsetAtIndex(10));
-        assertEquals(0, batch.getNextStreamMessageOffsetAtIndex(-1));
-        assertEquals(0, batch.getNextStreamMessageOffsetAtIndex(10));
+        assertThat(batch.getNextStreamPartitionMsgOffsetAtIndex(-1)).isNull();
+        assertThat(batch.getNextStreamPartitionMsgOffsetAtIndex(10)).isNull();
+        assertThat(batch.getNextStreamMessageOffsetAtIndex(-1)).isEqualTo(0);
+        assertThat(batch.getNextStreamMessageOffsetAtIndex(10)).isEqualTo(0);
     }
 
     @Test
@@ -116,8 +114,8 @@ class IggyMessageBatchTest {
 
         IggyMessageBatch batch = new IggyMessageBatch(messages);
 
-        assertEquals(1000, batch.getMessageCount());
-        assertEquals(1024, batch.getMessageLengthAtIndex(0));
-        assertEquals(1024, batch.getMessageLengthAtIndex(999));
+        assertThat(batch.getMessageCount()).isEqualTo(1000);
+        assertThat(batch.getMessageLengthAtIndex(0)).isEqualTo(1024);
+        assertThat(batch.getMessageLengthAtIndex(999)).isEqualTo(1024);
     }
 }

--- a/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/consumer/IggyStreamPartitionMsgOffsetTest.java
+++ b/foreign/java/external-processors/iggy-connector-pinot/src/test/java/org/apache/iggy/connector/pinot/consumer/IggyStreamPartitionMsgOffsetTest.java
@@ -21,16 +21,14 @@ package org.apache.iggy.connector.pinot.consumer;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class IggyStreamPartitionMsgOffsetTest {
 
     @Test
     void testOffsetCreation() {
         IggyStreamPartitionMsgOffset offset = new IggyStreamPartitionMsgOffset(100L);
-        assertEquals(100L, offset.getOffset());
+        assertThat(offset.getOffset()).isEqualTo(100L);
     }
 
     @Test
@@ -39,9 +37,9 @@ class IggyStreamPartitionMsgOffsetTest {
         IggyStreamPartitionMsgOffset offset2 = new IggyStreamPartitionMsgOffset(200L);
         IggyStreamPartitionMsgOffset offset3 = new IggyStreamPartitionMsgOffset(100L);
 
-        assertTrue(offset1.compareTo(offset2) < 0);
-        assertTrue(offset2.compareTo(offset1) > 0);
-        assertEquals(0, offset1.compareTo(offset3));
+        assertThat(offset1.compareTo(offset2)).isNegative();
+        assertThat(offset2.compareTo(offset1)).isPositive();
+        assertThat(offset1.compareTo(offset3)).isZero();
     }
 
     @Test
@@ -50,11 +48,11 @@ class IggyStreamPartitionMsgOffsetTest {
         IggyStreamPartitionMsgOffset offset2 = new IggyStreamPartitionMsgOffset(100L);
         IggyStreamPartitionMsgOffset offset3 = new IggyStreamPartitionMsgOffset(200L);
 
-        assertEquals(offset1, offset2);
-        assertNotEquals(offset1, offset3);
-        assertEquals(offset1, offset1);
-        assertNotEquals(offset1, null);
-        assertNotEquals(offset1, "string");
+        assertThat(offset1).isEqualTo(offset2);
+        assertThat(offset1).isNotEqualTo(offset3);
+        assertThat(offset1).isEqualTo(offset1);
+        assertThat(offset1).isNotEqualTo(null);
+        assertThat(offset1).isNotEqualTo("string");
     }
 
     @Test
@@ -63,28 +61,28 @@ class IggyStreamPartitionMsgOffsetTest {
         IggyStreamPartitionMsgOffset offset2 = new IggyStreamPartitionMsgOffset(100L);
         IggyStreamPartitionMsgOffset offset3 = new IggyStreamPartitionMsgOffset(200L);
 
-        assertEquals(offset1.hashCode(), offset2.hashCode());
-        assertNotEquals(offset1.hashCode(), offset3.hashCode());
+        assertThat(offset1.hashCode()).isEqualTo(offset2.hashCode());
+        assertThat(offset1.hashCode()).isNotEqualTo(offset3.hashCode());
     }
 
     @Test
     void testToString() {
         IggyStreamPartitionMsgOffset offset = new IggyStreamPartitionMsgOffset(12345L);
-        assertEquals("12345", offset.toString());
+        assertThat(offset.toString()).isEqualTo("12345");
     }
 
     @Test
     void testZeroOffset() {
         IggyStreamPartitionMsgOffset offset = new IggyStreamPartitionMsgOffset(0L);
-        assertEquals(0L, offset.getOffset());
-        assertEquals("0", offset.toString());
+        assertThat(offset.getOffset()).isEqualTo(0L);
+        assertThat(offset.toString()).isEqualTo("0");
     }
 
     @Test
     void testLargeOffset() {
         long largeOffset = Long.MAX_VALUE - 1;
         IggyStreamPartitionMsgOffset offset = new IggyStreamPartitionMsgOffset(largeOffset);
-        assertEquals(largeOffset, offset.getOffset());
-        assertEquals(String.valueOf(largeOffset), offset.toString());
+        assertThat(offset.getOffset()).isEqualTo(largeOffset);
+        assertThat(offset.toString()).isEqualTo(String.valueOf(largeOffset));
     }
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/async/AsyncConsumerGroupsTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/async/AsyncConsumerGroupsTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Dedicated async-specific tests for {@link ConsumerGroupsClient} via
@@ -382,16 +382,20 @@ public class AsyncConsumerGroupsTest extends BaseIntegrationTest {
     void shouldFailToDeleteNonExistentGroup() {
         var future = client.consumerGroups().deleteConsumerGroup(STREAM_ID, TOPIC_ID, ConsumerId.of(999_999L));
 
-        var exception = assertThrows(ExecutionException.class, () -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        assertThat(exception.getCause()).isInstanceOf(IggyResourceNotFoundException.class);
+        assertThatThrownBy(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(IggyResourceNotFoundException.class);
     }
 
     @Test
     void shouldFailToJoinNonExistentGroup() {
         var future = client.consumerGroups().joinConsumerGroup(STREAM_ID, TOPIC_ID, ConsumerId.of(999_999L));
 
-        var exception = assertThrows(ExecutionException.class, () -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        assertThat(exception.getCause()).isInstanceOf(IggyResourceNotFoundException.class);
+        assertThatThrownBy(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(IggyResourceNotFoundException.class);
     }
 
     @Test
@@ -404,8 +408,10 @@ public class AsyncConsumerGroupsTest extends BaseIntegrationTest {
 
         var future = client.consumerGroups().leaveConsumerGroup(STREAM_ID, TOPIC_ID, ConsumerId.of(created.id()));
 
-        var exception = assertThrows(ExecutionException.class, () -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS));
-        assertThat(exception.getCause()).isInstanceOf(IggyResourceNotFoundException.class);
+        assertThatThrownBy(() -> future.get(TIMEOUT_SECONDS, TimeUnit.SECONDS))
+                .isInstanceOf(ExecutionException.class)
+                .cause()
+                .isInstanceOf(IggyResourceNotFoundException.class);
     }
 
     // ===== CompletableFuture-specific tests =====

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/async/tcp/AsyncIggyTcpClientBuilderTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/async/tcp/AsyncIggyTcpClientBuilderTest.java
@@ -31,10 +31,8 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -68,15 +66,15 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Then: Client should be connected and functional
-        assertNotNull(client.users());
-        assertNotNull(client.messages());
-        assertNotNull(client.streams());
-        assertNotNull(client.topics());
-        assertNotNull(client.consumerGroups());
-        assertNotNull(client.system());
-        assertNotNull(client.personalAccessTokens());
-        assertNotNull(client.partitions());
-        assertNotNull(client.consumerOffsets());
+        assertThat(client.users()).isNotNull();
+        assertThat(client.messages()).isNotNull();
+        assertThat(client.streams()).isNotNull();
+        assertThat(client.topics()).isNotNull();
+        assertThat(client.consumerGroups()).isNotNull();
+        assertThat(client.system()).isNotNull();
+        assertThat(client.personalAccessTokens()).isNotNull();
+        assertThat(client.partitions()).isNotNull();
+        assertThat(client.consumerOffsets()).isNotNull();
     }
 
     @Test
@@ -93,7 +91,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Then: Should succeed
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -103,7 +101,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 AsyncIggyTcpClient.builder().host("").port(serverTcpPort());
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -113,7 +111,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 AsyncIggyTcpClient.builder().host(null).port(serverTcpPort());
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -123,7 +121,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 AsyncIggyTcpClient.builder().host(serverHost()).port(-1);
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -133,7 +131,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 AsyncIggyTcpClient.builder().host(serverHost()).port(0);
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -145,7 +143,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Then: Should work as before
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -160,15 +158,23 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Then: Should be able to access all clients
-        assertNotNull(client.users(), "Users client should not be null");
-        assertNotNull(client.messages(), "Messages client should not be null");
-        assertNotNull(client.streams(), "Streams client should not be null");
-        assertNotNull(client.topics(), "Topics client should not be null");
-        assertNotNull(client.consumerGroups(), "Consumer groups client should not be null");
-        assertNotNull(client.system(), "System client should not be null");
-        assertNotNull(client.personalAccessTokens(), "Personal access tokens client should not be null");
-        assertNotNull(client.partitions(), "Partitions client should not be null");
-        assertNotNull(client.consumerOffsets(), "Consumer offsets client should not be null");
+        assertThat(client.users()).as("Users client should not be null").isNotNull();
+        assertThat(client.messages()).as("Messages client should not be null").isNotNull();
+        assertThat(client.streams()).as("Streams client should not be null").isNotNull();
+        assertThat(client.topics()).as("Topics client should not be null").isNotNull();
+        assertThat(client.consumerGroups())
+                .as("Consumer groups client should not be null")
+                .isNotNull();
+        assertThat(client.system()).as("System client should not be null").isNotNull();
+        assertThat(client.personalAccessTokens())
+                .as("Personal access tokens client should not be null")
+                .isNotNull();
+        assertThat(client.partitions())
+                .as("Partitions client should not be null")
+                .isNotNull();
+        assertThat(client.consumerOffsets())
+                .as("Consumer offsets client should not be null")
+                .isNotNull();
     }
 
     @Test
@@ -185,8 +191,8 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         closeFuture.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
         // Then: Should complete without exception
-        assertTrue(closeFuture.isDone());
-        assertFalse(closeFuture.isCompletedExceptionally());
+        assertThat(closeFuture.isDone()).isTrue();
+        assertThat(closeFuture.isCompletedExceptionally()).isFalse();
     }
 
     @Test
@@ -197,7 +203,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .credentials(TEST_USERNAME, TEST_PASSWORD)
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.login());
+        assertThatThrownBy(() -> client.login()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -207,7 +213,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.users());
+        assertThatThrownBy(() -> client.users()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -217,7 +223,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.messages());
+        assertThatThrownBy(() -> client.messages()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -227,7 +233,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.streams());
+        assertThatThrownBy(() -> client.streams()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -237,7 +243,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.topics());
+        assertThatThrownBy(() -> client.topics()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -247,7 +253,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.consumerGroups());
+        assertThatThrownBy(() -> client.consumerGroups()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -257,7 +263,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.system());
+        assertThatThrownBy(() -> client.system()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -267,7 +273,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.personalAccessTokens());
+        assertThatThrownBy(() -> client.personalAccessTokens()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -277,7 +283,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.partitions());
+        assertThatThrownBy(() -> client.partitions()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -287,7 +293,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .build();
 
-        assertThrows(IggyNotConnectedException.class, () -> client.consumerOffsets());
+        assertThatThrownBy(() -> client.consumerOffsets()).isInstanceOf(IggyNotConnectedException.class);
     }
 
     @Test
@@ -298,7 +304,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(5, TimeUnit.SECONDS);
 
-        assertThrows(IggyMissingCredentialsException.class, () -> client.login());
+        assertThatThrownBy(() -> client.login()).isInstanceOf(IggyMissingCredentialsException.class);
     }
 
     @Test
@@ -306,7 +312,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         AsyncIggyTcpClientBuilder builder =
                 AsyncIggyTcpClient.builder().host(serverHost()).port(serverTcpPort());
 
-        assertThrows(IggyMissingCredentialsException.class, builder::buildAndLogin);
+        assertThatThrownBy(builder::buildAndLogin).isInstanceOf(IggyMissingCredentialsException.class);
     }
 
     @Test
@@ -316,7 +322,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .credentials(null, TEST_PASSWORD);
 
-        assertThrows(IggyMissingCredentialsException.class, builder::buildAndLogin);
+        assertThatThrownBy(builder::buildAndLogin).isInstanceOf(IggyMissingCredentialsException.class);
     }
 
     @Test
@@ -326,7 +332,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .port(serverTcpPort())
                 .credentials(TEST_USERNAME, null);
 
-        assertThrows(IggyMissingCredentialsException.class, builder::buildAndLogin);
+        assertThatThrownBy(builder::buildAndLogin).isInstanceOf(IggyMissingCredentialsException.class);
     }
 
     @Test
@@ -338,7 +344,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -350,7 +356,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -362,7 +368,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -374,7 +380,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -386,7 +392,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -398,7 +404,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -410,7 +416,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -422,7 +428,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -433,7 +439,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .enableTls()
                 .build();
 
-        assertNotNull(client);
+        assertThat(client).isNotNull();
     }
 
     @Test
@@ -450,15 +456,15 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .build();
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
-        assertNotNull(client.messages());
-        assertNotNull(client.streams());
-        assertNotNull(client.topics());
-        assertNotNull(client.consumerGroups());
-        assertNotNull(client.system());
-        assertNotNull(client.personalAccessTokens());
-        assertNotNull(client.partitions());
-        assertNotNull(client.consumerOffsets());
+        assertThat(client.users()).isNotNull();
+        assertThat(client.messages()).isNotNull();
+        assertThat(client.streams()).isNotNull();
+        assertThat(client.topics()).isNotNull();
+        assertThat(client.consumerGroups()).isNotNull();
+        assertThat(client.system()).isNotNull();
+        assertThat(client.personalAccessTokens()).isNotNull();
+        assertThat(client.partitions()).isNotNull();
+        assertThat(client.consumerOffsets()).isNotNull();
     }
 
     @Test
@@ -470,15 +476,15 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
                 .buildAndLogin()
                 .get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
-        assertNotNull(client.messages());
-        assertNotNull(client.streams());
-        assertNotNull(client.topics());
-        assertNotNull(client.consumerGroups());
-        assertNotNull(client.system());
-        assertNotNull(client.personalAccessTokens());
-        assertNotNull(client.partitions());
-        assertNotNull(client.consumerOffsets());
+        assertThat(client.users()).isNotNull();
+        assertThat(client.messages()).isNotNull();
+        assertThat(client.streams()).isNotNull();
+        assertThat(client.topics()).isNotNull();
+        assertThat(client.consumerGroups()).isNotNull();
+        assertThat(client.system()).isNotNull();
+        assertThat(client.personalAccessTokens()).isNotNull();
+        assertThat(client.partitions()).isNotNull();
+        assertThat(client.consumerOffsets()).isNotNull();
     }
 
     @Test
@@ -491,8 +497,8 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         CompletableFuture<Void> closeFuture = client.close();
         closeFuture.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertTrue(closeFuture.isDone());
-        assertFalse(closeFuture.isCompletedExceptionally());
+        assertThat(closeFuture.isDone()).isTrue();
+        assertThat(closeFuture.isCompletedExceptionally()).isFalse();
     }
 
     @Test
@@ -508,31 +514,31 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         CompletableFuture<Void> secondClose = client.close();
         secondClose.get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertTrue(firstClose.isDone());
-        assertFalse(firstClose.isCompletedExceptionally());
-        assertTrue(secondClose.isDone());
-        assertFalse(secondClose.isCompletedExceptionally());
+        assertThat(firstClose.isDone()).isTrue();
+        assertThat(firstClose.isCompletedExceptionally()).isFalse();
+        assertThat(secondClose.isDone()).isTrue();
+        assertThat(secondClose.isCompletedExceptionally()).isFalse();
     }
 
     @Test
     void testHandleNullTlsCertificateString() {
         AsyncIggyTcpClientBuilder builder = AsyncIggyTcpClient.builder().tlsCertificate((String) null);
 
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
     }
 
     @Test
     void testHandleEmptyTlsCertificateString() {
         AsyncIggyTcpClientBuilder builder = AsyncIggyTcpClient.builder().tlsCertificate("");
 
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
     }
 
     @Test
     void testHandleBlankTlsCertificateString() {
         AsyncIggyTcpClientBuilder builder = AsyncIggyTcpClient.builder().tlsCertificate("   ");
 
-        assertNotNull(builder);
+        assertThat(builder).isNotNull();
     }
 
     @Test
@@ -546,7 +552,7 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         client.login().get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 
     @Test
@@ -559,6 +565,6 @@ class AsyncIggyTcpClientBuilderTest extends BaseIntegrationTest {
         client.connect().get(5, TimeUnit.SECONDS);
         client.users().login(TEST_USERNAME, TEST_PASSWORD).get(TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
 
-        assertNotNull(client.users());
+        assertThat(client.users()).isNotNull();
     }
 }

--- a/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/IggyTcpClientBuilderTest.java
+++ b/foreign/java/java-sdk/src/test/java/org/apache/iggy/client/blocking/tcp/IggyTcpClientBuilderTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Duration;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
@@ -55,7 +55,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Client should be able to fetch system info
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -70,7 +70,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
         // When: Try to access system info (auto-login should have happened)
         // Then: Should succeed without explicit login
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -86,7 +86,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -101,7 +101,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -116,7 +116,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -131,7 +131,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -146,7 +146,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -164,7 +164,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -180,7 +180,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
 
         // Then: Should succeed
         List<ClientInfo> clients = client.system().getClients();
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 
     @Test
@@ -189,7 +189,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
         IggyTcpClientBuilder builder = IggyTcpClient.builder().host("").port(serverTcpPort());
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -198,7 +198,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
         IggyTcpClientBuilder builder = IggyTcpClient.builder().host(null).port(serverTcpPort());
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -208,7 +208,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
                 IggyTcpClient.builder().host(serverHost()).port(-1);
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -218,7 +218,7 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
                 IggyTcpClient.builder().host(serverHost()).port(0);
 
         // When/Then: Building should throw IggyInvalidArgumentException
-        assertThrows(IggyInvalidArgumentException.class, builder::build);
+        assertThatThrownBy(builder::build).isInstanceOf(IggyInvalidArgumentException.class);
     }
 
     @Test
@@ -232,6 +232,6 @@ class IggyTcpClientBuilderTest extends IntegrationTest {
         List<ClientInfo> clients = client.system().getClients();
 
         // Then: Should work
-        assertNotNull(clients);
+        assertThat(clients).isNotNull();
     }
 }


### PR DESCRIPTION
Six test files still used JUnit assertions (assertEquals,
assertThrows, assertNotNull, etc.) instead of the project
standard AssertJ fluent API. This inconsistency made tests
harder to read and diverged from the convention used by
the rest of the test suite.

Migrated all JUnit assertion calls to AssertJ equivalents
and added an AssertJ note to the Contributing section in
README.md.

