### PR TITLE
fix(integration): reduce flakiness in connector integration tests

### DIFF
--- a/core/integration/src/harness/handle/connectors_runtime.rs
+++ b/core/integration/src/harness/handle/connectors_runtime.rs
@@ -190,12 +190,6 @@ impl TestBinary for ConnectorsRuntimeHandle {
         })?;
         self.child_handle = Some(child);
 
-        // Release port reservation immediately after spawn to avoid SO_REUSEPORT
-        // load-balancing conflicts during health checks.
-        if let Some(reserver) = self.port_reserver.take() {
-            reserver.release();
-        }
-
         Ok(())
     }
 
@@ -251,6 +245,16 @@ impl IggyServerDependent for ConnectorsRuntimeHandle {
     }
 
     async fn wait_ready(&mut self) -> Result<(), TestBinaryError> {
+        // Release port reservation just before health-checking. The reservation
+        // holds the port while the child process initializes, preventing another
+        // process from claiming it. By the time we reach here the child has had
+        // enough time to bind (or will bind within the first few health-check
+        // retries). This matches the server handle pattern where the reservation
+        // is held until the process has bound.
+        if let Some(reserver) = self.port_reserver.take() {
+            reserver.release();
+        }
+
         let http_address = self.http_url();
         let client = reqwest::Client::new();
 

--- a/core/integration/src/harness/handle/mcp.rs
+++ b/core/integration/src/harness/handle/mcp.rs
@@ -206,12 +206,6 @@ impl TestBinary for McpHandle {
         })?;
         self.child_handle = Some(child);
 
-        // Release port reservation immediately after spawn to avoid SO_REUSEPORT
-        // load-balancing conflicts during health checks.
-        if let Some(reserver) = self.port_reserver.take() {
-            reserver.release();
-        }
-
         Ok(())
     }
 
@@ -250,6 +244,12 @@ impl IggyServerDependent for McpHandle {
     }
 
     async fn wait_ready(&mut self) -> Result<(), TestBinaryError> {
+        // Release port reservation just before health-checking. Holds the port
+        // while the child initializes, matching the server handle pattern.
+        if let Some(reserver) = self.port_reserver.take() {
+            reserver.release();
+        }
+
         let http_address = format!(
             "http://{}:{}",
             self.server_address.ip(),

--- a/core/integration/tests/connectors/mongodb/mod.rs
+++ b/core/integration/tests/connectors/mongodb/mod.rs
@@ -20,5 +20,5 @@
 mod mongodb_sink;
 
 const TEST_MESSAGE_COUNT: usize = 3;
-const POLL_ATTEMPTS: usize = 100;
+const POLL_ATTEMPTS: usize = 400;
 const POLL_INTERVAL_MS: u64 = 50;


### PR DESCRIPTION
Two connector CI tests failed intermittently due to
timing races in test infrastructure.

1) The test harness released the reserved port immediately
after spawn, before the child process reached bind. On
busy CI runners another process grabbed the port in that
window. Fix: hold the port reservation until wait_ready()
in both ConnectorsRuntimeHandle and McpHandle, matching
the server handle pattern.

2) The MongoDB sink test polled for 5s (100 * 50ms),
which equals the server's rebalancing_check_interval.
Consumer group partition assignment could consume the
entire window, leaving zero time for message delivery.
Fix: increase polling budget to 20s (400 * 50ms). The
loop breaks early on success so passing tests are
unaffected.
