### PR TITLE
chore(python): bump Python SDK to 0.7.3-dev1

### DIFF
--- a/foreign/python/Cargo.toml
+++ b/foreign/python/Cargo.toml
@@ -17,7 +17,7 @@
 
 [package]
 name = "apache-iggy"
-version = "0.7.2-dev.1"
+version = "0.7.3-dev1"
 edition = "2021"
 authors = [
     "Dario Lencina Talarico <darioalessandrolencina@gmail.com>",

--- a/foreign/python/pyproject.toml
+++ b/foreign/python/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "maturin"
 [project]
 name = "apache-iggy"
 requires-python = ">=3.10"
-version = "0.7.2.dev.1"
+version = "0.7.3.dev1"
 description = "Apache Iggy is the persistent message streaming platform written in Rust, supporting QUIC, TCP and HTTP transport protocols, capable of processing millions of messages per second."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Also fix PEP 440 format: .dev.1 -> .dev1 (no dot before
counter).
