### PR TITLE
chore(ci): add uv lock check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,14 @@ repos:
         files: ^foreign/python/(Cargo\.toml|pyproject\.toml)$
         pass_filenames: false
 
+      - id: uv-lock-check
+        name: uv lock check
+        entry: ./scripts/ci/uv-lock-check.sh
+        args: ["--fix"]
+        language: system
+        files: ^(foreign|bdd|examples)/python/(pyproject\.toml|uv\.lock)$
+        pass_filenames: false
+
       - id: trailing-whitespace
         name: trailing whitespace
         entry: ./scripts/ci/trailing-whitespace.sh

--- a/bdd/python/uv.lock
+++ b/bdd/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.7.2.dev1"
+version = "0.7.3.dev1"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]

--- a/examples/python/uv.lock
+++ b/examples/python/uv.lock
@@ -4,13 +4,13 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.7.0"
+version = "0.7.3.dev1"
 source = { directory = "../../foreign/python" }
 
 [package.metadata]
 requires-dist = [
-    { name = "black", marker = "extra == 'all'", specifier = ">=23.0,<25.0" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0,<25.0" },
+    { name = "black", marker = "extra == 'all'", specifier = ">=23.0,<27.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0,<27.0" },
     { name = "isort", marker = "extra == 'all'", specifier = ">=5.12.0,<6.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0,<6.0" },
     { name = "loguru", marker = "extra == 'all'", specifier = ">=0.7.0,<1.0" },
@@ -22,6 +22,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'testing'", specifier = ">=7.0,<9.0" },
     { name = "pytest-asyncio", marker = "extra == 'all'", specifier = ">=0.21.0,<1.0" },
     { name = "pytest-asyncio", marker = "extra == 'testing'", specifier = ">=0.21.0,<1.0" },
+    { name = "pytest-cov", marker = "extra == 'all'", specifier = ">=4.0,<7.0" },
+    { name = "pytest-cov", marker = "extra == 'testing'", specifier = ">=4.0,<7.0" },
     { name = "pytest-timeout", marker = "extra == 'all'", specifier = ">=2.0,<3.0" },
     { name = "pytest-timeout", marker = "extra == 'testing'", specifier = ">=2.0,<3.0" },
     { name = "pytest-xdist", marker = "extra == 'all'", specifier = ">=3.0,<4.0" },

--- a/foreign/python/uv.lock
+++ b/foreign/python/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "apache-iggy"
-version = "0.7.2.dev1"
+version = "0.7.3.dev1"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/scripts/ci/uv-lock-check.sh
+++ b/scripts/ci/uv-lock-check.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+MODE=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --check)
+            MODE="check"
+            shift
+            ;;
+        --fix)
+            MODE="fix"
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: $0 [--check|--fix]"
+            echo ""
+            echo "Verify uv.lock files are up to date with their pyproject.toml"
+            echo ""
+            echo "Options:"
+            echo "  --check    Check if lock files are up to date"
+            echo "  --fix      Regenerate stale lock files"
+            echo "  --help     Show this help message"
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Error: Unknown option $1${NC}"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$MODE" ]; then
+    echo -e "${RED}Error: Please specify either --check or --fix${NC}"
+    echo "Use --help for usage information"
+    exit 1
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PYTHON_DIRS=(
+    "foreign/python"
+    "bdd/python"
+    "examples/python"
+)
+
+FAILED=0
+
+for dir in "${PYTHON_DIRS[@]}"; do
+    if [ ! -f "$dir/uv.lock" ]; then
+        continue
+    fi
+
+    if (cd "$dir" && uv lock --check 2>/dev/null); then
+        echo -e "${GREEN}$dir/uv.lock is up to date${NC}"
+    else
+        if [ "$MODE" = "check" ]; then
+            echo -e "${RED}$dir/uv.lock is out of date${NC}"
+            FAILED=1
+        else
+            echo -e "${YELLOW}$dir/uv.lock is out of date, regenerating...${NC}"
+            (cd "$dir" && uv lock 2>/dev/null)
+            echo -e "${GREEN}$dir/uv.lock updated${NC}"
+        fi
+    fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo -e "${RED}Some uv.lock files are out of date${NC}"
+    echo -e "${YELLOW}Run '$0 --fix' to fix this automatically${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Stale uv.lock files went unnoticed across multiple version
bumps (e.g. foreign/python stuck at 0.7.2.dev1 when the
version was already 0.7.3.dev1). Add a pre-commit hook
that runs uv lock --check on all Python directories and
auto-regenerates stale lock files.
