### PR TITLE
fix(test): remove racy assertion in postgres source delete_after_read test                                                                                                                  

### DIFF
--- a/core/integration/tests/connectors/postgres/postgres_source.rs
+++ b/core/integration/tests/connectors/postgres/postgres_source.rs
@@ -260,12 +260,6 @@ async fn delete_after_read_source_removes_rows_after_producing(
             .await;
     }
 
-    let initial_count = fixture.count_rows(&pool).await;
-    assert_eq!(
-        initial_count, TEST_MESSAGE_COUNT as i64,
-        "Expected {TEST_MESSAGE_COUNT} rows before processing"
-    );
-
     let stream_id: Identifier = seeds::names::STREAM.try_into().unwrap();
     let topic_id: Identifier = seeds::names::TOPIC.try_into().unwrap();
     let consumer_id: Identifier = "test_consumer".try_into().unwrap();


### PR DESCRIPTION
## Summary         
                                                                                                                                                                         
- Remove racy pre-processing assertion in `delete_after_read_source_removes_rows_after_producing`                                                                                        that checks row count immediately after insertion, while the background connector poller                                                                                                 (10ms interval) can delete rows before the assertion runs                                                                                                                                  

- Same race condition pattern as #3052                                                                                                                                                      
