### PR TITLE
chore: add third-party attribution for bundled Gradle Wrapper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,33 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+===============================================================================
+APACHE IGGY (INCUBATING) SUBCOMPONENTS
+===============================================================================
+
+This product bundles third-party software. The following third-party
+components are distributed alongside the Apache Iggy (Incubating) source
+release and are licensed separately as described below.
+
+-------------------------------------------------------------------------------
+Gradle Wrapper
+-------------------------------------------------------------------------------
+
+Files:
+  bdd/java/gradlew
+  bdd/java/gradle/wrapper/gradle-wrapper.properties
+  examples/java/gradlew
+  examples/java/gradle/wrapper/gradle-wrapper.properties
+  foreign/java/gradlew
+  foreign/java/gradle/wrapper/gradle-wrapper.properties
+
+Copyright (c) 2015 the original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Upstream project: https://github.com/gradle/gradle

--- a/foreign/java/LICENSE
+++ b/foreign/java/LICENSE
@@ -199,3 +199,29 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+===============================================================================
+APACHE IGGY (INCUBATING) JAVA SDK SUBCOMPONENTS
+===============================================================================
+
+This product bundles third-party software. The following third-party
+components are distributed alongside the Java SDK sources and are
+licensed separately as described below.
+
+-------------------------------------------------------------------------------
+Gradle Wrapper
+-------------------------------------------------------------------------------
+
+Files:
+  gradlew
+  gradle/wrapper/gradle-wrapper.properties
+
+Copyright (c) 2015 the original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may
+not use this file except in compliance with the License. You may obtain
+a copy of the License at:
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Upstream project: https://github.com/gradle/gradle


### PR DESCRIPTION
Apache License requires attributing bundled third-party
components. The Gradle Wrapper files shipped in the Java
SDK and BDD/example projects were not listed.

Append a SUBCOMPONENTS section to both root and
foreign/java LICENSE files crediting the Gradle Wrapper
with its upstream Apache 2.0 license.